### PR TITLE
D3D-only compile fix

### DIFF
--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -459,7 +459,13 @@ endif()
 
 if(TORQUE_SDL)
     addPathRec("${srcDir}/windowManager/sdl")
+
+    if(NOT TORQUE_OPENGL)
+        set(BLACKLIST "sdlPlatformGL.cpp")
+    endif()
+
     addPathRec("${srcDir}/platformSDL")
+    set(BLACKLIST "")
 
     if(TORQUE_OPENGL)
       addPathRec("${srcDir}/gfx/gl/sdl")


### PR DESCRIPTION
A correction to the cmake file so if OGL is disabled, it doesn't include the sdl platform GL file, allowing the project to compile.