### PR TITLE
export rounds LODs to the nearest power of 2

### DIFF
--- a/Engine/source/T3D/convexShape.cpp
+++ b/Engine/source/T3D/convexShape.cpp
@@ -889,7 +889,8 @@ bool ConvexShape::buildExportPolyList(ColladaUtils::ExportData* exportData, cons
       ColladaUtils::ExportData::detailLevel* curDetail = &meshData->meshDetailLevels.last();
 
       //Make sure we denote the size this detail level has
-      curDetail->size = 512;
+      curDetail->size = getNextPow2(getObjBox().len());
+
    }
 
    return true;

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -1363,7 +1363,7 @@ bool TSStatic::buildExportPolyList(ColladaUtils::ExportData* exportData, const B
          ColladaUtils::ExportData::detailLevel* curDetail = &meshData->meshDetailLevels.last();
 
          //Make sure we denote the size this detail level has
-         curDetail->size = detail.size;
+         curDetail->size = getNextPow2(detail.size);
       }
    }
 


### PR DESCRIPTION
prevent submeshes from flickering in and out due to lod mismatches when exporting groups to a singular model file