### PR TITLE
adress #221 crash surpress macromap

### DIFF
--- a/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
+++ b/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
@@ -45,7 +45,7 @@ namespace
       FEATUREMGR->registerFeature( MFT_TerrainParallaxMap, new NamedFeatureGLSL( "Terrain Parallax Texture" ) );   
       FEATUREMGR->registerFeature( MFT_TerrainDetailMap, new TerrainDetailMapFeatGLSL );
       FEATUREMGR->registerFeature( MFT_TerrainNormalMap, new TerrainNormalMapFeatGLSL );
-      FEATUREMGR->registerFeature( MFT_TerrainMacroMap, new TerrainMacroMapFeatGLSL );
+      FEATUREMGR->registerFeature( MFT_TerrainMacroMap, new NamedFeatureGLSL("TerrainMacroMap Deprecated")); // new TerrainMacroMapFeatGLSL);
       FEATUREMGR->registerFeature( MFT_TerrainLightMap, new TerrainLightMapFeatGLSL );
       FEATUREMGR->registerFeature( MFT_TerrainSideProject, new NamedFeatureGLSL( "Terrain Side Projection" ) );
       FEATUREMGR->registerFeature( MFT_TerrainAdditive, new TerrainAdditiveFeatGLSL );

--- a/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
+++ b/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
@@ -45,7 +45,7 @@ namespace
       FEATUREMGR->registerFeature( MFT_TerrainParallaxMap, new NamedFeatureHLSL( "Terrain Parallax Texture" ) );   
       FEATUREMGR->registerFeature( MFT_TerrainDetailMap, new TerrainDetailMapFeatHLSL );
       FEATUREMGR->registerFeature( MFT_TerrainNormalMap, new TerrainNormalMapFeatHLSL );
-      FEATUREMGR->registerFeature( MFT_TerrainMacroMap, new TerrainMacroMapFeatHLSL );
+      FEATUREMGR->registerFeature( MFT_TerrainMacroMap, new NamedFeatureHLSL("TerrainMacroMap Deprecated")); // new TerrainMacroMapFeatHLSL);
       FEATUREMGR->registerFeature( MFT_TerrainLightMap, new TerrainLightMapFeatHLSL );
       FEATUREMGR->registerFeature( MFT_TerrainSideProject, new NamedFeatureHLSL( "Terrain Side Projection" ) );
       FEATUREMGR->registerFeature( MFT_TerrainAdditive, new TerrainAdditiveFeatHLSL );  

--- a/Engine/source/terrain/terrCellMaterial.cpp
+++ b/Engine/source/terrain/terrCellMaterial.cpp
@@ -52,14 +52,14 @@ Vector<String> _initSamplerNames()
    Vector<String> samplerNames;
    samplerNames.push_back("$baseTexMap");
    samplerNames.push_back("$layerTex");   
-   samplerNames.push_back("$macrolayerTex");   
+   //samplerNames.push_back("$macrolayerTex");   
    samplerNames.push_back("$lightMapTex");
    samplerNames.push_back("$lightInfoBuffer");
-   for(int i = 0; i < 3; ++i)
+   for(int i = 0; i < sgMaxTerrainMaterialsPerPass; ++i)
    {
       samplerNames.push_back(avar("$normalMap%d",i));
       samplerNames.push_back(avar("$detailMap%d",i));
-      samplerNames.push_back(avar("$macroMap%d", i));
+      //samplerNames.push_back(avar("$macroMap%d", i));
       samplerNames.push_back(avar("$compositeMap%d", i));
    }   
 


### PR DESCRIPTION
while shifitng loop in _initSamplerNames to use sgMaxTerrainMaterialsPerPass. if folks absolutely require thier projects to contain terrain macromaps, they can unrem

FEATUREMGR->registerFeature( MFT_TerrainMacroMap, new NamedFeatureGLSL("TerrainMacroMap Deprecated")); // new TerrainMacroMapFeatGLSL);
   //samplerNames.push_back("$macrolayerTex");
and
      //samplerNames.push_back(avar("$macroMap%d", i));
as well as turn sgMaxTerrainMaterialsPerPass down to 2 entries on a given terrain subchunk before it requires another rerender of the terrain blended in with prior passes.