### PR TITLE
adress #116 and #179 (shaderside)

### DIFF
--- a/Templates/BaseGame/game/core/rendering/shaders/gl/scatterSkyP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/gl/scatterSkyP.glsl
@@ -60,13 +60,9 @@ void main()
    vec4 nightSkyColor = texture(nightSky, -v3Direction);
    nightSkyColor = mix(nightColor, nightSkyColor, useCubemap);
 
-   float fac = dot( normalize( pos ), sunDir );
-   fac = max( nightInterpAndExposure.y, pow( clamp( fac, 0.0, 1.0 ), 2 ) );
    OUT_col = mix( color, nightSkyColor, nightInterpAndExposure.y );
 
    OUT_col.a = 1;
-   
-   OUT_col = clamp(OUT_col, 0.0, 1.0);
-   
+      
    OUT_col = hdrEncode( OUT_col );
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/scatterSkyP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/scatterSkyP.hlsl
@@ -58,12 +58,9 @@ float4 main( Conn In ) : TORQUE_TARGET0
    float4 nightSkyColor = TORQUE_TEXCUBE(nightSky, -In.v3Direction);
    nightSkyColor = lerp( nightColor, nightSkyColor, useCubemap );
    
-   float fac = dot( normalize( In.pos ), sunDir );
-   fac = max( nightInterpAndExposure.y, pow( saturate( fac ), 2 ) );
    Out = lerp( color, nightSkyColor, nightInterpAndExposure.y );
    
    Out.a = 1;
-   Out = saturate(Out);
 
    return hdrEncode( Out );
 }


### PR DESCRIPTION
kills off code folks haven't been using for years now, as well as a clamp to force the color into a 0-1 range. (hdr relies on >1.0 values for it's blur effect to populate)