### PR TITLE
Fix for crash in _onZoningChanged methods when called by hidden objects.

### DIFF
--- a/Engine/source/forest/forest.cpp
+++ b/Engine/source/forest/forest.cpp
@@ -260,7 +260,9 @@ void Forest::setTransform( const MatrixF &mat )
 
 void Forest::_onZoningChanged( SceneZoneSpaceManager *zoneManager )
 {
-   if ( mData == NULL || zoneManager != getSceneManager()->getZoneManager() )
+   const SceneManager* sm = getSceneManager();
+
+   if (mData == NULL || (sm != NULL && sm->getZoneManager() != NULL && zoneManager != sm->getZoneManager()))
       return;
 
    mZoningDirty = true;

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -461,7 +461,9 @@ void TerrainBlock::_updateBounds()
 
 void TerrainBlock::_onZoningChanged( SceneZoneSpaceManager *zoneManager )
 {
-   if ( mCell == NULL || zoneManager != getSceneManager()->getZoneManager() )
+   const SceneManager* sm = getSceneManager();
+
+   if (mCell == NULL || (sm != NULL && sm->getZoneManager() != NULL && zoneManager != sm->getZoneManager()))
       return;
 
    mZoningDirty = true;


### PR DESCRIPTION
Fix for #230.

Terrain and Forest objects cause a crash in their _onZoningChanged() methods if they are hidden. Hidden objects are removed from the scene manager so the calls to getSceneManager()->getZoneManager() crash and burn. This fix just ensures getSceneManager() and getZoneManager() != NULL before we attempt to use them.

