### PR TITLE
Fix crash due to GuiEditCanvas::save()

### DIFF
--- a/Templates/BaseGame/game/tools/guiEditor/scripts/guiEditorCanvas.ed.cs
+++ b/Templates/BaseGame/game/tools/guiEditor/scripts/guiEditorCanvas.ed.cs
@@ -436,7 +436,13 @@ function GuiEditCanvas::save( %this, %selectedOnly, %noPrompt )
       %fileObject.delete();
      
       %fo = new FileObject();
-      %fo.openForWrite(%filename);
+      if(!%fo.openForWrite(%filename))
+      {
+        error("GuiEditCanvas::save() - Unable to save, file location not open for writing.");
+        %fo.close();
+             
+        return false;
+      }
       
       // Write out the captured TorqueScript that was before the object before the object
       for( %i = 0; %i <= %beforeLines; %i++)


### PR DESCRIPTION
Fixes #2 

Fixes crash in GuiEditCanvas::save() if file location can't be written to. Previously the method was simply opening a file object and attempting to write out data without checking the return value.