### PR TITLE
safety check

### DIFF
--- a/Engine/source/T3D/cameraSpline.h
+++ b/Engine/source/T3D/cameraSpline.h
@@ -75,8 +75,8 @@ public:
    void push_front(Knot *w) { push_back(w); mFront = w; mIsMapDirty = true; }
 
    Knot* getKnot(S32 i);
-   Knot* next(Knot *k) { return (k->next == mFront) ? k : k->next; }
-   Knot* prev(Knot *k) { return (k == mFront) ? k : k->prev; }
+   Knot* next(Knot *k) { return (k && k->next == mFront) ? k : k->next; }
+   Knot* prev(Knot *k) { return (k && k == mFront) ? k : k->prev; }
 
    F32 advanceTime(F32 t, S32 delta_ms);
    F32 advanceDist(F32 t, F32 meters);


### PR DESCRIPTION
ensures
`   Knot *p1 = getKnot((S32)mFloor(t));
   Knot *p2 = next(p1);`
can't trip bad memory