### PR TITLE
Captures secondary window close events

### DIFF
--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -101,7 +101,8 @@ mPosition(0,0),
 mMouseLocked(false),
 mShouldLockMouse(false),
 mSuppressReset(false),
-mMenuHandle(NULL)
+mMenuHandle(NULL),
+mClosing(false)
 {
    mCursorController = new PlatformCursorControllerSDL( this );
 
@@ -583,8 +584,10 @@ void PlatformWindowSDL::_processSDLEvent(SDL_Event &evt)
 
       case SDL_WINDOWEVENT:
       {
-         switch( evt.window.event )
+         if (!mClosing)
          {
+            switch (evt.window.event)
+            {
             case SDL_WINDOWEVENT_FOCUS_GAINED:
                appEvent.trigger(getWindowId(), GainFocus);
                break;
@@ -595,15 +598,21 @@ void PlatformWindowSDL::_processSDLEvent(SDL_Event &evt)
             case SDL_WINDOWEVENT_RESIZED:
             {
                int width, height;
-               SDL_GetWindowSize( mWindowHandle, &width, &height );
-               mVideoMode.resolution.set( width, height );
+               SDL_GetWindowSize(mWindowHandle, &width, &height);
+               mVideoMode.resolution.set(width, height);
                getGFXTarget()->resetMode();
                resizeEvent.trigger(getWindowId(), width, height);
                break;
             }
+            case SDL_WINDOWEVENT_CLOSE:
+            {
+               appEvent.trigger(getWindowId(), WindowClose);
+               mClosing = true;
+            }
 
             default:
                break;
+            }
          }
       }
    }

--- a/Engine/source/windowManager/sdl/sdlWindow.h
+++ b/Engine/source/windowManager/sdl/sdlWindow.h
@@ -87,6 +87,9 @@ private:
    /// Menu associated with this window.  This is a passive property of the window and is not required to be used at all.
    void* mMenuHandle;
 
+   /// Indicates if the window is being closed. This allows us to safely ignore other events like focus being gained or losed after cleanup has begun
+   bool mClosing;
+
    /// @}
 
    void _processSDLEvent(SDL_Event &evt);


### PR DESCRIPTION
Captures secondary window close events so secondary windows can be closed via hitting the x on the window itself.