### PR TITLE
proper variation on the datablock file list erasure

### DIFF
--- a/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.cs
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.cs
@@ -163,6 +163,10 @@ function endMission()
    getScene(0).delete();
    MissionCleanup.delete();
    
+  if ($Pref::Server::EnableDatablockCache)
+    resetDatablockCache();
+   DatablockFilesList.empty();
+   
    clearServerPaths();
 }
 
@@ -176,6 +180,10 @@ function resetMission()
    new SimGroup( MissionCleanup );
    $instantGroup = MissionCleanup;
 
+  if ($Pref::Server::EnableDatablockCache)
+    resetDatablockCache();
+   DatablockFilesList.empty();
+   
    clearServerPaths();
    
    // Inform the game code we're resetting.

--- a/Templates/BaseGame/game/core/clientServer/scripts/server/server.cs
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/server.cs
@@ -201,7 +201,6 @@ function onServerCreated()
    physicsInitWorld( "server" );
 
    physicsStartSimulation("server");
-   DatablockFilesList.clear();
    loadDatablockFiles( DatablockFilesList, true );
    
    callOnModules("onServerScriptExec", "Core");
@@ -287,6 +286,7 @@ function onServerDestroyed()
    
   if ($Pref::Server::EnableDatablockCache)
     resetDatablockCache();
+   DatablockFilesList.empty();
 }
 
 /// Guid list maintenance functions


### PR DESCRIPTION
clear is a nonfunctional command for arrayobjects, so a) needed to use erase, and b) needed to fill in a couple more spots