### PR TITLE
Some cleanup and adjusting of local light fields and default settings.

### DIFF
--- a/Engine/source/T3D/lightAnimData.h
+++ b/Engine/source/T3D/lightAnimData.h
@@ -47,7 +47,7 @@ struct LightAnimState
 {  
    /// Constructor.
    LightAnimState()
-      :  active( true ),
+      :  active( false ),
          animationPhase( 1.0f ),
          animationPeriod( 1.0f ),
          brightness( 1.0f ),

--- a/Engine/source/T3D/pointLight.cpp
+++ b/Engine/source/T3D/pointLight.cpp
@@ -27,6 +27,7 @@
 #include "core/stream/bitStream.h"
 #include "gfx/gfxDrawUtil.h"
 
+#include "lighting/shadowMap/lightShadowMap.h"
 
 IMPLEMENT_CO_NETOBJECT_V1( PointLight );
 
@@ -83,6 +84,13 @@ PointLight::PointLight()
    // We set the type here to ensure the extended
    // parameter validation works when setting fields.
    mLight->setType( LightInfo::Point );
+
+   //This lets us override the default shadowmap properties for point lights specifically
+   //We'll set the overdark factor to a lower value to mitigate visible aliasing from over-darkening the cubemap
+   //And then use cubemaps as the default shadowmap type
+   ShadowMapParams* p = mLight->getExtended<ShadowMapParams>();
+   p->overDarkFactor = Point4F(10, 5, 4, 1);
+   p->shadowType = ShadowType::ShadowType_CubeMap;
 }
 
 PointLight::~PointLight()
@@ -104,6 +112,11 @@ void PointLight::initPersistFields()
    // Remove the scale field... it's already 
    // defined by the light radius.
    removeField( "scale" );
+
+   //These are particular fields for PSSM, so useless for point lights
+   removeField("numSplits");
+   removeField("logWeight");
+   removeField("lastSplitTerrainOnly");
 }
 
 void PointLight::_conformLights()

--- a/Engine/source/T3D/spotLight.cpp
+++ b/Engine/source/T3D/spotLight.cpp
@@ -110,6 +110,11 @@ void SpotLight::initPersistFields()
    // Remove the scale field... it's already 
    // defined by the range and angle.
    removeField( "scale" );
+
+   //These are particular fields for PSSM, so useless for point lights
+   removeField("numSplits");
+   removeField("logWeight");
+   removeField("lastSplitTerrainOnly");
 }
 
 void SpotLight::_conformLights()

--- a/Engine/source/lighting/advanced/advancedLightBinManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightBinManager.cpp
@@ -94,7 +94,7 @@ const String AdvancedLightBinManager::smShadowTypeMacro[] =
 {
    "", // ShadowType_Spot
    "", // ShadowType_PSSM,
-   "SHADOW_PARABOLOID",                   // ShadowType_Paraboloid,
+   "", // ShadowType_Paraboloid,
    "SHADOW_DUALPARABOLOID_SINGLE_PASS",   // ShadowType_DualParaboloidSinglePass,
    "SHADOW_DUALPARABOLOID",               // ShadowType_DualParaboloid,
    "SHADOW_CUBE",                         // ShadowType_CubeMap,

--- a/Engine/source/lighting/advanced/advancedLightManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightManager.cpp
@@ -48,7 +48,6 @@ ImplementEnumType( ShadowType,
    "@ingroup AdvancedLighting" )
    { ShadowType_Spot,                     "Spot" },
    { ShadowType_PSSM,                     "PSSM" },
-   { ShadowType_Paraboloid,               "Paraboloid" },
    { ShadowType_DualParaboloidSinglePass, "DualParaboloidSinglePass" },
    { ShadowType_DualParaboloid,           "DualParaboloid" },
    { ShadowType_CubeMap,                  "CubeMap" },


### PR DESCRIPTION
Hides some light fields for local lights that are intended for PSSM's, thus useless.

Also disables the Paraboloid shadowmap type, as it is non-functional.
Disabled light animations by default so as to not waste processing time if not needed
Sets point lights' shadow types to be cubemap by default, and lowers the overdark factor to make them look cleaner and not exacerbate aliasing.