### PR TITLE
Fix gamepad binds on non-windows.

### DIFF
--- a/Engine/source/platform/input/event.cpp
+++ b/Engine/source/platform/input/event.cpp
@@ -382,8 +382,7 @@ CodeMapping gVirtualMap[] =
    { "lpov2",         SI_POV,    SI_LPOV2       },
    { "rpov2",         SI_POV,    SI_RPOV2       },
 
-#if defined( TORQUE_OS_WIN )
-   //-------------------------------------- XINPUT EVENTS
+   //-------------------------------------- GAMEPAD EVENTS
    // Controller connect / disconnect:
    { "connect",       SI_BUTTON, XI_CONNECT     },
    
@@ -420,7 +419,6 @@ CodeMapping gVirtualMap[] =
    { "btn_b",         SI_BUTTON, XI_B           },
    { "btn_x",         SI_BUTTON, XI_X           },
    { "btn_y",         SI_BUTTON, XI_Y           },
-#endif
 
    //-------------------------------------- MISCELLANEOUS EVENTS
    //


### PR DESCRIPTION
Removes unneeded #ifdef that was preventing gamepad binds from being found in non-windows builds.