### PR TITLE
Even more misc asset fixes

### DIFF
--- a/Engine/source/T3D/assets/CppAsset.cpp
+++ b/Engine/source/T3D/assets/CppAsset.cpp
@@ -93,6 +93,8 @@ CppAsset::CppAsset() : AssetBase()
 {
    mCodeFile = StringTable->EmptyString();
    mHeaderFile = StringTable->EmptyString();
+   mCodePath = StringTable->EmptyString();
+   mHeaderPath = StringTable->EmptyString();
 }
 
 //-----------------------------------------------------------------------------
@@ -164,7 +166,14 @@ void CppAsset::setHeaderFile(const char* pHeaderFile)
 
 void CppAsset::initializeAsset()
 {
-   mCodeFile = expandAssetFilePath(mCodeFile);
+   mCodePath = getOwned() ? expandAssetFilePath(mCodeFile) : mCodePath;
 
-   mHeaderFile = expandAssetFilePath(mHeaderFile);
+   mHeaderPath = getOwned() ? expandAssetFilePath(mHeaderFile) : mHeaderPath;
+}
+
+void CppAsset::onAssetRefresh(void)
+{
+   mCodePath = getOwned() ? expandAssetFilePath(mCodeFile) : mCodePath;
+
+   mHeaderPath = getOwned() ? expandAssetFilePath(mHeaderFile) : mHeaderPath;
 }

--- a/Engine/source/T3D/assets/CppAsset.h
+++ b/Engine/source/T3D/assets/CppAsset.h
@@ -45,7 +45,9 @@ class CppAsset : public AssetBase
    typedef AssetBase Parent;
 
    StringTableEntry        mCodeFile;
+   StringTableEntry        mCodePath;
    StringTableEntry        mHeaderFile;
+   StringTableEntry        mHeaderPath;
 
 public:
    CppAsset();
@@ -66,10 +68,13 @@ public:
 
 protected:
 	virtual void            initializeAsset(void);
-	virtual void            onAssetRefresh(void) {};
+	virtual void            onAssetRefresh(void);
 
    static bool setCppFile(void *obj, const char *index, const char *data) { static_cast<CppAsset*>(obj)->setCppFile(data); return false; }
    static const char* getCppFile(void* obj, const char* data) { return static_cast<CppAsset*>(obj)->getCppFile(); }
+
+   inline StringTableEntry getCppFilePath(void) const { return mCodePath; };
+   inline StringTableEntry getHeaderFilePath(void) const { return mHeaderPath; };
 
    static bool setHeaderFile(void *obj, const char *index, const char *data) { static_cast<CppAsset*>(obj)->setHeaderFile(data); return false; }
    static const char* getHeaderFile(void* obj, const char* data) { return static_cast<CppAsset*>(obj)->getHeaderFile(); }

--- a/Engine/source/T3D/assets/GUIAsset.cpp
+++ b/Engine/source/T3D/assets/GUIAsset.cpp
@@ -86,6 +86,9 @@ GUIAsset::GUIAsset()
 {
    mScriptFile = StringTable->EmptyString();
    mGUIFile = StringTable->EmptyString();
+
+   mScriptPath = StringTable->EmptyString();
+   mGUIPath = StringTable->EmptyString();
 }
 
 //-----------------------------------------------------------------------------
@@ -118,28 +121,28 @@ void GUIAsset::copyTo(SimObject* object)
 
 void GUIAsset::initializeAsset()
 {
-   mGUIFile = expandAssetFilePath(mGUIFile);
+   mGUIPath = expandAssetFilePath(mGUIFile);
 
-   if (Platform::isFile(mGUIFile))
-      Con::executeFile(mGUIFile, false, false);
+   if (Platform::isFile(mGUIPath))
+      Con::executeFile(mGUIPath, false, false);
 
-   mScriptFile = expandAssetFilePath(mScriptFile);
+   mScriptPath = expandAssetFilePath(mScriptFile);
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 }
 
 void GUIAsset::onAssetRefresh()
 {
-   mGUIFile = expandAssetFilePath(mGUIFile);
+   mGUIPath = expandAssetFilePath(mGUIFile);
 
-   if (Platform::isFile(mGUIFile))
-      Con::executeFile(mGUIFile, false, false);
+   if (Platform::isFile(mGUIPath))
+      Con::executeFile(mGUIPath, false, false);
 
-   mScriptFile = expandAssetFilePath(mScriptFile);
+   mScriptPath = expandAssetFilePath(mScriptFile);
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 }
 
 void GUIAsset::setGUIFile(const char* pScriptFile)
@@ -155,7 +158,7 @@ void GUIAsset::setGUIFile(const char* pScriptFile)
       return;
 
    // Update.
-   mGUIFile = getOwned() ? expandAssetFilePath(pScriptFile) : StringTable->insert(pScriptFile);
+   mGUIFile = StringTable->insert(pScriptFile);
 
    // Refresh the asset.
    refreshAsset();
@@ -174,7 +177,7 @@ void GUIAsset::setScriptFile(const char* pScriptFile)
       return;
 
    // Update.
-   mScriptFile = getOwned() ? expandAssetFilePath(pScriptFile) : StringTable->insert(pScriptFile);
+   mScriptFile = StringTable->insert(pScriptFile);
 
    // Refresh the asset.
    refreshAsset();

--- a/Engine/source/T3D/assets/GUIAsset.h
+++ b/Engine/source/T3D/assets/GUIAsset.h
@@ -49,6 +49,9 @@ class GUIAsset : public AssetBase
    StringTableEntry mScriptFile;
    StringTableEntry mGUIFile;
 
+   StringTableEntry mScriptPath;
+   StringTableEntry mGUIPath;
+
 public:
    GUIAsset();
    virtual ~GUIAsset();
@@ -64,6 +67,9 @@ public:
    inline StringTableEntry getGUIFile(void) const { return mGUIFile; };
    void                    setScriptFile(const char* pScriptFile);
    inline StringTableEntry getScriptFile(void) const { return mScriptFile; };
+
+   inline StringTableEntry getGUIPath(void) const { return mGUIPath; };
+   inline StringTableEntry getScriptPath(void) const { return mScriptPath; };
 
 protected:
    virtual void            initializeAsset(void);

--- a/Engine/source/T3D/assets/GameObjectAsset.cpp
+++ b/Engine/source/T3D/assets/GameObjectAsset.cpp
@@ -95,6 +95,8 @@ GameObjectAsset::GameObjectAsset()
    mGameObjectName = StringTable->EmptyString();
    mScriptFile = StringTable->EmptyString();
    mTAMLFile = StringTable->EmptyString();
+   mScriptPath = StringTable->EmptyString();
+   mTAMLPath = StringTable->EmptyString();
 }
 
 //-----------------------------------------------------------------------------
@@ -129,25 +131,23 @@ void GameObjectAsset::copyTo(SimObject* object)
 void GameObjectAsset::initializeAsset()
 {
    //Ensure we have an expanded filepath
-   if (!Platform::isFullPath(mScriptFile))
-      mScriptFile = getOwned() ? expandAssetFilePath(mScriptFile) : mScriptFile;
+   mScriptPath = getOwned() ? expandAssetFilePath(mScriptFile) : mScriptPath;
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 
-   if (!Platform::isFullPath(mTAMLFile))
-      mTAMLFile = getOwned() ? expandAssetFilePath(mTAMLFile) : mTAMLFile;
+   mTAMLPath = getOwned() ? expandAssetFilePath(mTAMLFile) : mTAMLPath;
 }
 
 void GameObjectAsset::onAssetRefresh()
 {
    //Ensure we have an expanded filepath
-   mScriptFile = expandAssetFilePath(mScriptFile);
+   mScriptPath = getOwned() ? expandAssetFilePath(mScriptFile) : mScriptPath;
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 
-   mTAMLFile = expandAssetFilePath(mTAMLFile);
+   mTAMLPath = getOwned() ? expandAssetFilePath(mTAMLFile) : mTAMLPath;
 }
 
 void GameObjectAsset::setScriptFile(const char* pScriptFile)

--- a/Engine/source/T3D/assets/GameObjectAsset.h
+++ b/Engine/source/T3D/assets/GameObjectAsset.h
@@ -50,6 +50,8 @@ class GameObjectAsset : public AssetBase
    StringTableEntry mGameObjectName;
    StringTableEntry mScriptFile;
    StringTableEntry mTAMLFile;
+   StringTableEntry mScriptPath;
+   StringTableEntry mTAMLPath;
 
 public:
    GameObjectAsset();
@@ -77,6 +79,9 @@ protected:
    static const char* getScriptFile(void* obj, const char* data) { return static_cast<GameObjectAsset*>(obj)->getScriptFile(); }
    static bool setTAMLFile(void *obj, const char *index, const char *data) { static_cast<GameObjectAsset*>(obj)->setTAMLFile(data); return false; }
    static const char* getTAMLFile(void* obj, const char* data) { return static_cast<GameObjectAsset*>(obj)->getTAMLFile(); }
+
+   inline StringTableEntry getScriptFilePath(void) const { return mScriptPath; };
+   inline StringTableEntry getTAMLFilePath(void) const { return mTAMLPath; };
 };
 
 DefineConsoleType(TypeGameObjectAssetPtr, GameObjectAsset)

--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -108,6 +108,7 @@ EndImplementEnumType;
 ImageAsset::ImageAsset() : AssetBase(), mImage(nullptr), mUseMips(true), mIsHDRImage(false), mIsValidImage(false), mImageType(Albedo)
 {
    mImageFileName = StringTable->EmptyString();
+   mImagePath = StringTable->EmptyString();
 }
 
 //-----------------------------------------------------------------------------
@@ -254,14 +255,16 @@ void ImageAsset::loadImage()
 
 void ImageAsset::initializeAsset()
 {
-   mImageFileName = expandAssetFilePath(mImageFileName);
+   mImagePath = expandAssetFilePath(mImageFileName);
 
    loadImage();
 }
 
 void ImageAsset::onAssetRefresh()
 {
-   setImageFileName(mImageFileName);
+   mImagePath = expandAssetFilePath(mImageFileName);
+
+   loadImage();
 }
 
 void ImageAsset::setImageFileName(const char* pScriptFile)

--- a/Engine/source/T3D/assets/ImageAsset.h
+++ b/Engine/source/T3D/assets/ImageAsset.h
@@ -70,6 +70,7 @@ public:
 
 protected:
    StringTableEntry mImageFileName;
+   StringTableEntry mImagePath;
 
    GFXTexHandle mImage;
 
@@ -94,6 +95,8 @@ public:
 
    void                    setImageFileName(const char* pScriptFile);
    inline StringTableEntry getImageFileName(void) const { return mImageFileName; };
+
+   inline StringTableEntry getImagePath(void) const { return mImagePath; };
 
    bool isValid() { return mIsValidImage; }
 

--- a/Engine/source/T3D/assets/LevelAsset.cpp
+++ b/Engine/source/T3D/assets/LevelAsset.cpp
@@ -92,6 +92,13 @@ LevelAsset::LevelAsset() : AssetBase(), mIsSubLevel(false)
    mForestFile = StringTable->EmptyString();
    mNavmeshFile = StringTable->EmptyString();
 
+   mLevelPath = StringTable->EmptyString();
+   mPreviewImagePath = StringTable->EmptyString();
+   mPostFXPresetPath = StringTable->EmptyString();
+   mDecalsPath = StringTable->EmptyString();
+   mForestPath = StringTable->EmptyString();
+   mNavmeshPath = StringTable->EmptyString();
+
    mGamemodeName = StringTable->EmptyString();
    mMainLevelAsset = StringTable->EmptyString();
 
@@ -151,12 +158,23 @@ void LevelAsset::initializeAsset()
    Parent::initializeAsset();
 
    // Ensure the image-file is expanded.
-   mPreviewImage = expandAssetFilePath(mPreviewImage);
-   mLevelFile = expandAssetFilePath(mLevelFile);
-   mPostFXPresetFile = expandAssetFilePath(mPostFXPresetFile);
-   mDecalsFile = expandAssetFilePath(mDecalsFile);
-   mForestFile = expandAssetFilePath(mForestFile);
-   mNavmeshFile = expandAssetFilePath(mNavmeshFile);
+   mPreviewImagePath = expandAssetFilePath(mPreviewImage);
+   mLevelPath = expandAssetFilePath(mLevelFile);
+   mPostFXPresetPath = expandAssetFilePath(mPostFXPresetFile);
+   mDecalsPath = expandAssetFilePath(mDecalsFile);
+   mForestPath = expandAssetFilePath(mForestFile);
+   mNavmeshPath = expandAssetFilePath(mNavmeshFile);
+}
+
+void LevelAsset::onAssetRefresh(void)
+{
+   // Ensure the image-file is expanded.
+   mPreviewImagePath = expandAssetFilePath(mPreviewImage);
+   mLevelPath = expandAssetFilePath(mLevelFile);
+   mPostFXPresetPath = expandAssetFilePath(mPostFXPresetFile);
+   mDecalsPath = expandAssetFilePath(mDecalsFile);
+   mForestPath = expandAssetFilePath(mForestFile);
+   mNavmeshPath = expandAssetFilePath(mNavmeshFile);
 }
 
 //

--- a/Engine/source/T3D/assets/LevelAsset.h
+++ b/Engine/source/T3D/assets/LevelAsset.h
@@ -52,6 +52,13 @@ class LevelAsset : public AssetBase
    StringTableEntry        mNavmeshFile;
    StringTableEntry        mPreviewImage;
 
+   StringTableEntry        mLevelPath;
+   StringTableEntry        mPostFXPresetPath;
+   StringTableEntry        mDecalsPath;
+   StringTableEntry        mForestPath;
+   StringTableEntry        mNavmeshPath;
+   StringTableEntry        mPreviewImagePath;
+
    StringTableEntry        mEditorFile;
    StringTableEntry        mBakedSceneFile;
 
@@ -84,6 +91,13 @@ public:
    void                    setImageFile(const char* pImageFile);
    inline StringTableEntry getImageFile(void) const { return mPreviewImage; };
 
+   inline StringTableEntry getLevelPath(void) const { return mLevelPath; };
+   inline StringTableEntry getPostFXPresetPath(void) const { return mPostFXPresetPath; };
+   inline StringTableEntry getDecalsPath(void) const { return mDecalsPath; };
+   inline StringTableEntry getForestPath(void) const { return mForestPath; };
+   inline StringTableEntry getNavmeshPath(void) const { return mNavmeshPath; };
+   inline StringTableEntry getImagePath(void) const { return mPreviewImagePath; };
+
    void                    setEditorFile(const char* pEditorFile);
    inline StringTableEntry getEditorFile(void) const { return mEditorFile; };
    void                    setBakedSceneFile(const char* pBakedSceneFile);
@@ -114,7 +128,7 @@ protected:
 
 
    virtual void            initializeAsset(void);
-   virtual void            onAssetRefresh(void) {}
+   virtual void            onAssetRefresh(void);
 };
 
 DefineConsoleType(TypeLevelAssetPtr, LevelAsset)

--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -91,6 +91,7 @@ MaterialAsset::MaterialAsset()
 {
    mShaderGraphFile = "";
    mScriptFile = StringTable->EmptyString();
+   mScriptPath = StringTable->EmptyString();
    mMatDefinitionName = StringTable->EmptyString();
 }
 
@@ -121,19 +122,18 @@ void MaterialAsset::initializeAsset()
 
    compileShader();
 
-   if (!Platform::isFullPath(mScriptFile))
-      mScriptFile = getOwned() ? expandAssetFilePath(mScriptFile) : mScriptFile;
+   mScriptPath = getOwned() ? expandAssetFilePath(mScriptFile) : mScriptPath;
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 }
 
 void MaterialAsset::onAssetRefresh()
 {
-   mScriptFile = expandAssetFilePath(mScriptFile);
+   mScriptPath = getOwned() ? expandAssetFilePath(mScriptFile) : mScriptPath;
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 
    if (mMatDefinitionName != StringTable->EmptyString())
    {

--- a/Engine/source/T3D/assets/MaterialAsset.h
+++ b/Engine/source/T3D/assets/MaterialAsset.h
@@ -57,6 +57,7 @@ class MaterialAsset : public AssetBase
 
    String                  mShaderGraphFile;
    StringTableEntry        mScriptFile;
+   StringTableEntry        mScriptPath;
    StringTableEntry        mMatDefinitionName;
 
 public:
@@ -73,6 +74,8 @@ public:
 
    void                    setScriptFile(const char* pScriptFile);
    inline StringTableEntry getScriptFile(void) const { return mScriptFile; };
+
+   inline StringTableEntry getScriptPath(void) const { return mScriptPath; };
 
    /// Declare Console Object.
    DECLARE_CONOBJECT(MaterialAsset);

--- a/Engine/source/T3D/assets/PostEffectAsset.cpp
+++ b/Engine/source/T3D/assets/PostEffectAsset.cpp
@@ -95,6 +95,10 @@ PostEffectAsset::PostEffectAsset()
    mScriptFile = StringTable->EmptyString();
    mHLSLShaderFile = StringTable->EmptyString();
    mGLSLShaderFile = StringTable->EmptyString();
+
+   mScriptPath = StringTable->EmptyString();
+   mHLSLShaderPath = StringTable->EmptyString();
+   mGLSLShaderPath = StringTable->EmptyString();
 }
 
 //-----------------------------------------------------------------------------
@@ -128,22 +132,22 @@ void PostEffectAsset::copyTo(SimObject* object)
 
 void PostEffectAsset::initializeAsset()
 {
-   mScriptFile = expandAssetFilePath(mScriptFile);
-   mHLSLShaderFile = expandAssetFilePath(mHLSLShaderFile);
-   mGLSLShaderFile = expandAssetFilePath(mGLSLShaderFile);
+   mScriptPath = expandAssetFilePath(mScriptFile);
+   mHLSLShaderPath = expandAssetFilePath(mHLSLShaderFile);
+   mGLSLShaderPath = expandAssetFilePath(mGLSLShaderFile);
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 }
 
 void PostEffectAsset::onAssetRefresh()
 {
-   mScriptFile = expandAssetFilePath(mScriptFile);
-   mHLSLShaderFile = expandAssetFilePath(mHLSLShaderFile);
-   mGLSLShaderFile = expandAssetFilePath(mGLSLShaderFile);
+   mScriptPath = expandAssetFilePath(mScriptFile);
+   mHLSLShaderPath = expandAssetFilePath(mHLSLShaderFile);
+   mGLSLShaderPath = expandAssetFilePath(mGLSLShaderFile);
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 }
 
 void PostEffectAsset::setScriptFile(const char* pScriptFile)

--- a/Engine/source/T3D/assets/PostEffectAsset.h
+++ b/Engine/source/T3D/assets/PostEffectAsset.h
@@ -49,6 +49,10 @@ class PostEffectAsset : public AssetBase
    StringTableEntry        mScriptFile;
    StringTableEntry        mHLSLShaderFile;
    StringTableEntry        mGLSLShaderFile;
+
+   StringTableEntry        mScriptPath;
+   StringTableEntry        mHLSLShaderPath;
+   StringTableEntry        mGLSLShaderPath;
    
 public:
    PostEffectAsset();
@@ -65,6 +69,10 @@ public:
    inline StringTableEntry getHLSLShaderFile(void) const { return mHLSLShaderFile; };
    void                    setGLSLShaderFile(const char* pShaderFile);
    inline StringTableEntry getGLSLShaderFile(void) const { return mGLSLShaderFile; };
+
+   inline StringTableEntry getScriptPath(void) const { return mScriptPath; };
+   inline StringTableEntry getHLSLShaderPath(void) const { return mHLSLShaderPath; };
+   inline StringTableEntry getGLSLShaderPath(void) const { return mGLSLShaderPath; };
 
    /// Declare Console Object.
    DECLARE_CONOBJECT(PostEffectAsset);

--- a/Engine/source/T3D/assets/ScriptAsset.cpp
+++ b/Engine/source/T3D/assets/ScriptAsset.cpp
@@ -92,6 +92,7 @@ ConsoleSetType(TypeScriptAssetPtr)
 ScriptAsset::ScriptAsset() : AssetBase(), mIsServerSide(true)
 {
    mScriptFile = StringTable->EmptyString();
+   mScriptPath = StringTable->EmptyString();
 }
 
 //-----------------------------------------------------------------------------
@@ -121,9 +122,9 @@ void ScriptAsset::copyTo(SimObject* object)
 
 void ScriptAsset::initializeAsset()
 {
-   mScriptFile = expandAssetFilePath(mScriptFile);
+   mScriptPath = expandAssetFilePath(mScriptFile);
 
-   if (Platform::isFile(mScriptFile))
+   if (Platform::isFile(mScriptPath))
    {
       //We're initialized properly, so we'll go ahead and kick along any dependencies we may have as well
       AssetManager::typeAssetDependsOnHash::Iterator assetDependenciesItr = mpOwningAssetManager->getDependedOnAssets()->find(mpAssetDefinition->mAssetId);
@@ -143,15 +144,15 @@ void ScriptAsset::initializeAsset()
          }
       }
 
-      Con::executeFile(mScriptFile, false, false);
+      Con::executeFile(mScriptPath, false, false);
    }
 }
 
 void ScriptAsset::onAssetRefresh()
 {
-   mScriptFile = expandAssetFilePath(mScriptFile);
+   mScriptPath = expandAssetFilePath(mScriptFile);
 
-   if (Platform::isFile(mScriptFile))
+   if (Platform::isFile(mScriptPath))
    {
       //Refresh any dependencies we may have
       for (U32 i = 0; i < mScriptAssets.size(); i++)
@@ -159,7 +160,7 @@ void ScriptAsset::onAssetRefresh()
          mScriptAssets[i]->onAssetRefresh();
       }
 
-      Con::executeFile(mScriptFile, false, false);
+      Con::executeFile(mScriptPath, false, false);
    }
 }
 
@@ -176,7 +177,7 @@ void ScriptAsset::setScriptFile(const char* pScriptFile)
       return;
 
    // Update.
-   mScriptFile = getOwned() ? expandAssetFilePath(pScriptFile) : StringTable->insert(pScriptFile);
+   mScriptFile = StringTable->insert(pScriptFile);
 
    // Refresh the asset.
    refreshAsset();
@@ -191,9 +192,9 @@ bool ScriptAsset::execScript()
 
    return false;
 
-   if (Platform::isFile(mScriptFile))
+   if (Platform::isFile(mScriptPath))
    {
-      return Con::executeFile(mScriptFile, false, false);
+      return Con::executeFile(mScriptPath, false, false);
    }
    else
    {

--- a/Engine/source/T3D/assets/ScriptAsset.h
+++ b/Engine/source/T3D/assets/ScriptAsset.h
@@ -49,6 +49,7 @@ class ScriptAsset : public AssetBase
    typedef AssetBase Parent;
 
    StringTableEntry        mScriptFile;
+   StringTableEntry        mScriptPath;
    bool                    mIsServerSide;
 
    Vector<AssetPtr<ScriptAsset>> mScriptAssets;
@@ -66,6 +67,8 @@ public:
 
    void                    setScriptFile(const char* pScriptFile);
    inline StringTableEntry getScriptFile(void) const { return mScriptFile; };
+
+   inline StringTableEntry getScriptPath(void) const { return mScriptPath; };
 
    bool execScript();
 

--- a/Engine/source/T3D/assets/ShapeAnimationAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAnimationAsset.cpp
@@ -96,6 +96,7 @@ ShapeAnimationAsset::ShapeAnimationAsset() :
    mIsEmbedded(false), mIsCyclical(true), mIsBlend(false), mBlendFrame(0), mStartFrame(0), mEndFrame(-1), mPadRotation(true), mPadTransforms(false)
 {
    mFileName = StringTable->EmptyString();
+   mFilePath = StringTable->EmptyString();
    mAnimationName = StringTable->EmptyString();
 
    mBlendAnimAssetName = StringTable->EmptyString();
@@ -146,11 +147,9 @@ void ShapeAnimationAsset::initializeAsset(void)
    if (!mIsEmbedded)
    {
       //If we're not embedded, we need to load in our initial shape and do some prepwork
+      mFilePath = expandAssetFilePath(mFileName);
 
-      char filenameBuf[1024];
-      Con::expandScriptFilename(filenameBuf, sizeof(filenameBuf), mFileName);
-
-      mSourceShape = ResourceManager::get().load(filenameBuf);
+      mSourceShape = ResourceManager::get().load(mFilePath);
 
       if (!mSourceShape->addSequence("ambient", "", mAnimationName, mStartFrame, mEndFrame, mPadRotation, mPadTransforms))
       {
@@ -185,7 +184,7 @@ void ShapeAnimationAsset::setAnimationFile(const char* pAnimationFile)
       return;
 
    // Update.
-   mFileName = getOwned() ? expandAssetFilePath(pAnimationFile) : StringTable->insert(pAnimationFile);
+   mFileName = StringTable->insert(pAnimationFile);
 
    // Refresh the asset.
    refreshAsset();

--- a/Engine/source/T3D/assets/ShapeAnimationAsset.h
+++ b/Engine/source/T3D/assets/ShapeAnimationAsset.h
@@ -51,6 +51,7 @@ class ShapeAnimationAsset : public AssetBase
 
 protected:
    StringTableEntry   mFileName;
+   StringTableEntry   mFilePath;
 
    bool            mIsEmbedded;
    bool            mIsCyclical;
@@ -80,6 +81,8 @@ public:
 
    void                    setAnimationFile(const char* pScriptFile);
    inline StringTableEntry getAnimationFile(void) const { return mFileName; };
+
+   inline StringTableEntry getAnimationPath(void) const { return mFilePath; };
 
    /// Declare Console Object.
    DECLARE_CONOBJECT(ShapeAnimationAsset);

--- a/Engine/source/T3D/assets/SoundAsset.cpp
+++ b/Engine/source/T3D/assets/SoundAsset.cpp
@@ -93,6 +93,7 @@ ConsoleSetType(TypeSoundAssetPtr)
 SoundAsset::SoundAsset()
 {
    mSoundFile = StringTable->EmptyString();
+   mSoundPath = StringTable->EmptyString();
 
    mPitchAdjust = 0;
    mVolumeAdjust = 0;
@@ -130,11 +131,12 @@ void SoundAsset::copyTo(SimObject* object)
 
 void SoundAsset::initializeAsset(void)
 {
+   mSoundPath = expandAssetFilePath(mSoundFile);
 }
 
 void SoundAsset::onAssetRefresh(void)
 {
-
+   mSoundPath = expandAssetFilePath(mSoundFile);
 }
 
 void SoundAsset::setSoundFile(const char* pSoundFile)
@@ -150,7 +152,7 @@ void SoundAsset::setSoundFile(const char* pSoundFile)
       return;
 
    // Update.
-   mSoundFile = getOwned() ? expandAssetFilePath(pSoundFile) : StringTable->insert(pSoundFile);
+   mSoundFile = StringTable->insert(pSoundFile);
 
    // Refresh the asset.
    refreshAsset();

--- a/Engine/source/T3D/assets/SoundAsset.h
+++ b/Engine/source/T3D/assets/SoundAsset.h
@@ -48,6 +48,7 @@ class SoundAsset : public AssetBase
 
 protected:
    StringTableEntry        mSoundFile;
+   StringTableEntry        mSoundPath;
    F32                     mPitchAdjust;
    F32                     mVolumeAdjust;
 
@@ -64,6 +65,8 @@ public:
 
    void                    setSoundFile(const char* pScriptFile);
    inline StringTableEntry getSoundFile(void) const { return mSoundFile; };
+
+   inline StringTableEntry getSoundPath(void) const { return mSoundPath; };
 
 protected:
    virtual void            initializeAsset(void);

--- a/Engine/source/T3D/assets/TerrainAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainAsset.cpp
@@ -124,6 +124,7 @@ ConsoleSetType(TypeTerrainAssetId)
 
 TerrainAsset::TerrainAsset()
 {
+   mTerrainFileName = StringTable->EmptyString();
    mTerrainFilePath = StringTable->EmptyString();
 }
 
@@ -141,8 +142,8 @@ void TerrainAsset::initPersistFields()
    Parent::initPersistFields();
 
    //addField("shaderGraph", TypeRealString, Offset(mShaderGraphFile, TerrainAsset), "");
-   addProtectedField("terrainFile", TypeAssetLooseFilePath, Offset(mTerrainFilePath, TerrainAsset),
-      &setTerrainFilePath, &getTerrainFilePath, "Path to the file containing the terrain data.");
+   addProtectedField("terrainFile", TypeAssetLooseFilePath, Offset(mTerrainFileName, TerrainAsset),
+      &setTerrainFileName, &getTerrainFileName, "Path to the file containing the terrain data.");
 }
 
 void TerrainAsset::setDataField(StringTableEntry slotName, const char* array, const char* value)
@@ -164,19 +165,19 @@ void TerrainAsset::initializeAsset()
    // Call parent.
    Parent::initializeAsset();
 
-   mTerrainFilePath = expandAssetFilePath(mTerrainFilePath);
+   mTerrainFilePath = expandAssetFilePath(mTerrainFileName);
 
    loadTerrain();
 }
 
 void TerrainAsset::onAssetRefresh()
 {
-   mTerrainFilePath = expandAssetFilePath(mTerrainFilePath);
+   mTerrainFilePath = expandAssetFilePath(mTerrainFileName);
 
    loadTerrain();
 }
 
-void TerrainAsset::setTerrainFilePath(const char* pScriptFile)
+void TerrainAsset::setTerrainFileName(const char* pScriptFile)
 {
    // Sanity!
    AssertFatal(pScriptFile != NULL, "Cannot use a NULL script file.");
@@ -185,7 +186,7 @@ void TerrainAsset::setTerrainFilePath(const char* pScriptFile)
    pScriptFile = StringTable->insert(pScriptFile);
 
    // Update.
-   mTerrainFilePath = pScriptFile;
+   mTerrainFileName = pScriptFile;
 
    // Refresh the asset.
    refreshAsset();
@@ -259,7 +260,7 @@ bool TerrainAsset::getAssetByFilename(StringTableEntry fileName, AssetPtr<Terrai
       newTerrainAsset->setAssetName(assetName.c_str());
       String terrainPathBind = terrFilePath.getFileName() + terrFilePath.getExtension();
 
-      newTerrainAsset->mTerrainFilePath = StringTable->insert(terrainPathBind.c_str());
+      newTerrainAsset->mTerrainFileName = StringTable->insert(terrainPathBind.c_str());
 
       newTerrainAsset->saveAsset();
 
@@ -350,7 +351,7 @@ StringTableEntry TerrainAsset::getAssetIdByFilename(StringTableEntry fileName)
       newTerrainAsset->setAssetName(assetName.c_str());
       String terrainPathBind = terrFilePath.getFileName() + "." + terrFilePath.getExtension();
 
-      newTerrainAsset->mTerrainFilePath = StringTable->insert(terrainPathBind.c_str());
+      newTerrainAsset->mTerrainFileName = StringTable->insert(terrainPathBind.c_str());
 
       newTerrainAsset->saveAsset();
 

--- a/Engine/source/T3D/assets/TerrainAsset.h
+++ b/Engine/source/T3D/assets/TerrainAsset.h
@@ -58,6 +58,7 @@ class TerrainAsset : public AssetBase
 {
    typedef AssetBase Parent;
 
+   StringTableEntry        mTerrainFileName;
    StringTableEntry        mTerrainFilePath;
    Resource<TerrainFile>   mTerrainFile;
 
@@ -75,7 +76,8 @@ public:
 
    virtual void setDataField(StringTableEntry slotName, const char* array, const char* value);
 
-   void                    setTerrainFilePath(const char* pTerrainFile);
+   void                    setTerrainFileName(const char* pTerrainFile);
+   inline StringTableEntry getTerrainFileName(void) const { return mTerrainFileName; };
    inline StringTableEntry getTerrainFilePath(void) const { return mTerrainFilePath; };
 
    inline Resource<TerrainFile> getTerrainResource(void) const { return mTerrainFile; };
@@ -93,8 +95,8 @@ protected:
    virtual void initializeAsset();
    virtual void onAssetRefresh(void);
 
-   static bool setTerrainFilePath(void *obj, const char *index, const char *data) { static_cast<TerrainAsset*>(obj)->setTerrainFilePath(data); return false; }
-   static const char* getTerrainFilePath(void* obj, const char* data) { return static_cast<TerrainAsset*>(obj)->getTerrainFilePath(); }
+   static bool setTerrainFileName(void *obj, const char *index, const char *data) { static_cast<TerrainAsset*>(obj)->setTerrainFileName(data); return false; }
+   static const char* getTerrainFileName(void* obj, const char* data) { return static_cast<TerrainAsset*>(obj)->getTerrainFileName(); }
 };
 
 DefineConsoleType(TypeTerrainAssetPtr, TerrainAsset)

--- a/Engine/source/T3D/assets/TerrainMaterialAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainMaterialAsset.cpp
@@ -90,6 +90,7 @@ ConsoleSetType(TypeTerrainMaterialAssetPtr)
 TerrainMaterialAsset::TerrainMaterialAsset()
 {
    mScriptFile = StringTable->EmptyString();
+   mScriptPath = StringTable->EmptyString();
    mMatDefinitionName = StringTable->EmptyString();
 }
 
@@ -120,18 +121,18 @@ void TerrainMaterialAsset::initializeAsset()
 
    compileShader();
 
-   mScriptFile = expandAssetFilePath(mScriptFile);
+   mScriptPath = expandAssetFilePath(mScriptFile);
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 }
 
 void TerrainMaterialAsset::onAssetRefresh()
 {
-   mScriptFile = expandAssetFilePath(mScriptFile);
+   mScriptPath = expandAssetFilePath(mScriptFile);
 
-   if (Platform::isFile(mScriptFile))
-      Con::executeFile(mScriptFile, false, false);
+   if (Platform::isFile(mScriptPath))
+      Con::executeFile(mScriptPath, false, false);
 
    if (mMatDefinitionName != StringTable->EmptyString())
    {

--- a/Engine/source/T3D/assets/TerrainMaterialAsset.h
+++ b/Engine/source/T3D/assets/TerrainMaterialAsset.h
@@ -55,6 +55,7 @@ class TerrainMaterialAsset : public AssetBase
    typedef AssetBase Parent;
 
    StringTableEntry        mScriptFile;
+   StringTableEntry        mScriptPath;
    StringTableEntry        mMatDefinitionName;
 
 public:
@@ -71,6 +72,8 @@ public:
 
    void                    setScriptFile(const char* pScriptFile);
    inline StringTableEntry getScriptFile(void) const { return mScriptFile; };
+
+   inline StringTableEntry getScriptPath(void) const { return mScriptPath; };
 
    /// Declare Console Object.
    DECLARE_CONOBJECT(TerrainMaterialAsset);

--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -338,7 +338,7 @@ void AssetImportObject::initPersistFields()
 
    addField("tamlFilePath", TypeRealString, Offset(tamlFilePath, AssetImportObject), "What is the ultimate asset taml file path for this import item");
 
-   addField("imageSuffixType", TypeRealString, Offset(imageSuffixType, AssetImportObject), "Specific to ImageAsset type. What is the image asset's suffix type. Options are: Albedo, Normal, Roughness, AO, Metalness, PBRConfig");
+   addField("imageType", TypeRealString, Offset(imageSuffixType, AssetImportObject), "Specific to ImageAsset type. What is the image asset's suffix type. Options are: Albedo, Normal, Roughness, AO, Metalness, PBRConfig");
 
    addField("shapeInfo", TYPEID< GuiTreeViewCtrl >(), Offset(shapeInfo, AssetImportObject), "Specific to ShapeAsset type. Processed information about the shape file. Contains numbers and lists of meshes, materials and animations");
 }
@@ -1820,6 +1820,10 @@ void AssetImporter::resolveAssetItemIssues(AssetImportObject* assetItem)
          //Whatever status we had prior is no longer relevent, so reset the status
          resetAssetValidationStatus(assetItem);
          importIssues = false;
+      }
+      else if (activeImportConfig.DuplicatAutoResolution == String("UseExisting"))
+      {
+
       }
    }
    else if (assetItem->statusType == String("MissingFile"))

--- a/Engine/source/T3D/assets/stateMachineAsset.cpp
+++ b/Engine/source/T3D/assets/stateMachineAsset.cpp
@@ -93,6 +93,7 @@ ConsoleSetType(TypeStateMachineAssetPtr)
 StateMachineAsset::StateMachineAsset()
 {
    mStateMachineFile = StringTable->EmptyString();
+   mStateMachinePath = StringTable->EmptyString();
 }
 
 //-----------------------------------------------------------------------------
@@ -133,7 +134,7 @@ void StateMachineAsset::setStateMachineFile(const char* pStateMachineFile)
       return;
 
    // Update.
-   mStateMachineFile = getOwned() ? expandAssetFilePath(pStateMachineFile) : StringTable->insert(pStateMachineFile);
+   mStateMachineFile = StringTable->insert(pStateMachineFile);
 
    // Refresh the asset.
    refreshAsset();
@@ -141,8 +142,14 @@ void StateMachineAsset::setStateMachineFile(const char* pStateMachineFile)
 
 void StateMachineAsset::initializeAsset()
 {
-   mStateMachineFile = expandAssetFilePath(mStateMachineFile);
+   mStateMachinePath = expandAssetFilePath(mStateMachineFile);
 }
+
+void StateMachineAsset::onAssetRefresh()
+{
+   mStateMachinePath = expandAssetFilePath(mStateMachineFile);
+}
+
 
 
 DefineEngineMethod(StateMachineAsset, notifyAssetChanged, void, (),,"")

--- a/Engine/source/T3D/assets/stateMachineAsset.h
+++ b/Engine/source/T3D/assets/stateMachineAsset.h
@@ -47,6 +47,7 @@ class StateMachineAsset : public AssetBase
    typedef AssetBase Parent;
 
    StringTableEntry mStateMachineFile;
+   StringTableEntry mStateMachinePath;
 
 public:
    StateMachineAsset();
@@ -62,9 +63,11 @@ public:
    void                    setStateMachineFile(const char* pStateMachineFile);
    inline StringTableEntry getStateMachineFile(void) const { return mStateMachineFile; };
 
+   inline StringTableEntry getStateMachinePath(void) const { return mStateMachinePath; };
+
 protected:
    virtual void            initializeAsset(void);
-   virtual void            onAssetRefresh(void) {}
+   virtual void            onAssetRefresh(void);
 
    static bool setStateMachineFile(void *obj, const char *index, const char *data) { static_cast<StateMachineAsset*>(obj)->setStateMachineFile(data); return false; }
    static const char* getStateMachineFile(void* obj, const char* data) { return static_cast<StateMachineAsset*>(obj)->getStateMachineFile(); }

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.cs
@@ -63,7 +63,7 @@ function AssetBrowser::onWake(%this)
    
    AssetBrowser-->previewSlider.setValue(EditorSettings.value("Assets/Browser/previewTileSize", "1.0"));
    
-   AssetBrowser.toggleAssetTypeFilter(0); 
+   AssetBrowser-->filterAssetsButton.setEnabled(true); 
 }
 
 function contentTreeTabBook::onTabSelected(%this, %tabText, %tabIndex)
@@ -279,7 +279,11 @@ function AssetBrowser::showDialog( %this, %AssetTypeFilter, %selectCallback, %ta
    //visibility filter
    if(%AssetTypeFilter !$= "")
    {
-      AssetBrowser.toggleAssetTypeFilter(0);  
+      AssetBrowser-->filterAssetsButton.setEnabled(false);
+   }
+   else
+   {
+      AssetBrowser-->filterAssetsButton.setEnabled(true);  
    }
    
    if(%selectCallback $= "")
@@ -503,7 +507,7 @@ function AssetBrowser::buildAssetPreview( %this, %asset, %moduleName )
    //%previewButton-->AssetPreviewButton.internalName = %this.previewData.assetName@"Border";
    //%previewButton-->Button.extent = %previewSize.x + %previewBounds SPC %previewSize.y + 24;
    %previewButton.tooltip = %this.previewData.tooltip;
-   %previewButton.Command = "AssetBrowser.updateSelection( $ThisControl.getParent().assetName, $ThisControl.getParent().moduleName );";
+   %previewButton.Command = "AssetBrowser.updateSelection( $ThisControl.assetName, $ThisControl.moduleName );";
    %previewButton.altCommand = %doubleClickCommand;
    //%previewButton-->AssetPreviewButton.icon = %this.previewData.previewImage;
    
@@ -1463,11 +1467,24 @@ function AssetBrowser::doRebuildAssetArray(%this)
          }
          else
          {
-            //got it.	
-            %assetArray.add( %moduleName, %assetId );
-            
-            if(%assetType !$= "Folder")
-               %finalAssetCount++;
+            if(AssetBrowser.assetTypeFilter !$= "")
+            {
+               if(AssetBrowser.assetTypeFilter $= %assetType)
+               {
+                  %assetArray.add( %moduleName, %assetId );
+                  
+                  if(%assetType !$= "Folder")
+                     %finalAssetCount++;
+               }
+            }
+            else
+            {
+               //got it.	
+               %assetArray.add( %moduleName, %assetId );
+               
+               if(%assetType !$= "Folder")
+                  %finalAssetCount++;
+            }
          }
       }
    }

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.cs
@@ -11,7 +11,7 @@ function AssetBrowser::prepareImportImageAsset(%this, %assetItem)
       }
       else
       {
-         %suffixPos = strpos(strlwr(%assetItem.AssetName), strlwr(%assetItem.imageSuffixType), 0);
+         %suffixPos = strpos(strlwr(%assetItem.AssetName), strlwr(%assetItem.ImageType), 0);
          %noSuffixName = getSubStr(%assetItem.AssetName, 0, %suffixPos);
       }
    
@@ -280,7 +280,7 @@ function parseImageSuffixes(%assetItem)
       %suffixToken = getToken(getAssetImportConfigValue("Images/DiffuseTypeSuffixes", ""), ",;", %sfx);
       if(strIsMatchExpr("*"@%suffixToken, %assetItem.AssetName))
       {
-         %assetItem.imageSuffixType = %suffixToken;
+         %assetItem.ImageType = %suffixToken;
          return "diffuse";
       }
    }
@@ -292,7 +292,7 @@ function parseImageSuffixes(%assetItem)
       %suffixToken = getToken(getAssetImportConfigValue("Images/NormalTypeSuffixes", ""), ",;", %sfx);
       if(strIsMatchExpr("*"@%suffixToken, %assetItem.AssetName))
       {
-         %assetItem.imageSuffixType = %suffixToken;
+         %assetItem.ImageType = %suffixToken;
          return "normal";
       }
    }
@@ -304,7 +304,7 @@ function parseImageSuffixes(%assetItem)
       %suffixToken = getToken(getAssetImportConfigValue("Images/RoughnessTypeSuffixes", ""), ",;", %sfx);
       if(strIsMatchExpr("*"@%suffixToken, %assetItem.AssetName))
       {
-         %assetItem.imageSuffixType = %suffixToken;
+         %assetItem.ImageType = %suffixToken;
          return "roughness";
       }
    }
@@ -316,7 +316,7 @@ function parseImageSuffixes(%assetItem)
       %suffixToken = getToken(getAssetImportConfigValue("Images/AOTypeSuffixes", ""), ",;", %sfx);
       if(strIsMatchExpr("*"@%suffixToken, %assetItem.AssetName))
       {
-         %assetItem.imageSuffixType = %suffixToken;
+         %assetItem.ImageType = %suffixToken;
          return "AO";
       }
    }
@@ -328,7 +328,7 @@ function parseImageSuffixes(%assetItem)
       %suffixToken = getToken(getAssetImportConfigValue("Images/MetalnessTypeSuffixes", ""), ",;", %sfx);
       if(strIsMatchExpr("*"@%suffixToken, %assetItem.AssetName))
       {
-         %assetItem.imageSuffixType = %suffixToken;
+         %assetItem.ImageType = %suffixToken;
          return "metalness";
       }
    }
@@ -340,7 +340,7 @@ function parseImageSuffixes(%assetItem)
       %suffixToken = getToken(getAssetImportConfigValue("Images/CompositeTypeSuffixes", ""), ",;", %sfx);
       if(strIsMatchExpr("*"@%suffixToken, %assetItem.AssetName))
       {
-         %assetItem.imageSuffixType = %suffixToken;
+         %assetItem.ImageType = %suffixToken;
          return "composite";
       }
    }

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.cs
@@ -555,6 +555,7 @@ function TerrainMaterialDlg::saveDirtyMaterial( %this, %mat )
    }
    
    %mat.diffuseMap = %newDiffuse;    
+   %mat.diffuseMapAsset = "";    
    %mat.normalMap = %newNormal;   
    %mat.pbrConfigMap = %newPBRConfig; 
    %mat.detailMap = %newDetail;    
@@ -575,7 +576,11 @@ function TerrainMaterialDlg::saveDirtyMaterial( %this, %mat )
    
    %fileName = %mat.getFileName();
    if( %fileName $= "" )
-      %fileName = "data/terrains/materials.cs";
+   {
+      error("TerrainMaterialDlg::saveDirtyMaterial() - terrain material doesn't have a fileName set to save to.");
+      return;
+      //%fileName = "data/terrains/materials.cs";
+   }
       
    ETerrainMaterialPersistMan.setDirty( %mat, %fileName ); 
 }


### PR DESCRIPTION
Updates the rest of the asset types to utilize separate expanded path variables to avoid breaking assetDef saving
Fixes select mode for the Asset Browser to properly filter to the selecting type
Fixes the imageType in the asset import window inspector to properly set to the importing image asset's discovered type if valid
Fixes AssetBrowser asset selection return so it returns back a valid assetId
Fixes TerrainMaterial save crash by ensuring we fill in the diffuseMapAsset
Removes saving of TerrainMaterial being saved to a generic script file if one isn't found for an existing TerrainMaterialAssets