### PR TITLE
Basic Platform::openWebBrowser implementation for linux

### DIFF
--- a/Engine/source/platformX86UNIX/x86UNIXPlatform.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXPlatform.cpp
@@ -1,8 +1,26 @@
 #include "platform/platform.h"
+#include <string>
 
 bool Platform::openWebBrowser( const char* webAddress )
 {
-    return false; // TODO LINUX
+    std::string startingURL(webAddress);
+    std::string filteredURL;
+
+    unsigned short length = startingURL.length();
+    for(unsigned short i = 0; i < length; i++)
+    {
+        filteredURL = filteredURL + '\\' + startingURL.at(i);
+    }
+
+    std::string runCommand = "URL=" + filteredURL + "; xdg-open $URL > /dev/null 2> /dev/null";
+
+    short statusCode;
+    statusCode = system(runCommand.c_str());
+
+    if(statusCode == 0)
+        return true;
+
+    return false;
 }
 
 #ifdef TORQUE_DEDICATED


### PR DESCRIPTION
Basic implementation for Platform::openWebBrowser that simply shell-escapes the input URL and then runs xdg-open to handle opening the target URL in the user's preferred browser. xdg-utils is installed on *most* (but probably not all) desktop distros, so this is probably an okay start and much better than nothing. Tested this code on both 3.10.1 and 4.0 and presently works for both.