### PR TITLE
More misc. fixes

### DIFF
--- a/Engine/source/T3D/assets/LevelAsset.cpp
+++ b/Engine/source/T3D/assets/LevelAsset.cpp
@@ -329,3 +329,10 @@ void LevelAsset::setNavmeshFile(const char* pNavmeshFile)
    // Refresh the asset.
    refreshAsset();
 }
+
+DefineEngineMethod(LevelAsset, getLevelFile, const char*, (),,
+   "Creates a new script asset using the targetFilePath.\n"
+   "@return The bool result of calling exec")
+{
+   return object->getLevelPath();
+}

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -595,3 +595,10 @@ void GuiInspectorTypeShapeAssetId::consoleInit()
 
    ConsoleBaseType::getType(TypeShapeAssetId)->setInspectorFieldType("GuiInspectorTypeShapeAssetId");
 }
+
+DefineEngineMethod(ShapeAsset, getShapeFile, const char*, (), ,
+   "Creates a new script asset using the targetFilePath.\n"
+   "@return The bool result of calling exec")
+{
+   return object->getShapeFilePath();
+}

--- a/Engine/source/T3D/assets/TerrainAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainAsset.cpp
@@ -200,6 +200,8 @@ bool TerrainAsset::loadTerrain()
    mTerrMaterialAssets.clear();
    mTerrMaterialAssetIds.clear();
 
+   StringTableEntry terrainMatAssetType = StringTable->insert("TerrainMaterialAsset");
+
    //First, load any material, animation, etc assets we may be referencing in our asset
    // Find any asset dependencies.
    AssetManager::typeAssetDependsOnHash::Iterator assetDependenciesItr = mpOwningAssetManager->getDependedOnAssets()->find(mpAssetDefinition->mAssetId);
@@ -212,12 +214,13 @@ bool TerrainAsset::loadTerrain()
       {
          StringTableEntry assetType = mpOwningAssetManager->getAssetType(assetDependenciesItr->value);
 
-         if (assetType == StringTable->insert("TerrainMaterialAsset"))
+         if (assetType == terrainMatAssetType)
          {
-            mTerrMaterialAssetIds.push_front(assetDependenciesItr->value);
+            StringTableEntry assetId = StringTable->insert(assetDependenciesItr->value);
+            mTerrMaterialAssetIds.push_front(assetId);
 
             //Force the asset to become initialized if it hasn't been already
-            AssetPtr<TerrainMaterialAsset> matAsset = assetDependenciesItr->value;
+            AssetPtr<TerrainMaterialAsset> matAsset = assetId;
 
             mTerrMaterialAssets.push_front(matAsset);
          }

--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -101,6 +101,19 @@ AssetImportConfig::~AssetImportConfig()
 
 }
 
+bool AssetImportConfig::onAdd()
+{
+   if (!Parent::onAdd())
+      return false;
+
+   return true;
+}
+
+void AssetImportConfig::onRemove()
+{
+   Parent::onRemove();
+}
+
 /// Engine.
 void AssetImportConfig::initPersistFields()
 {
@@ -371,13 +384,26 @@ AssetImporter::AssetImporter() :
    importIssues(false),
    isReimport(false),
    assetHeirarchyChanged(false),
-   importLogBuffer("")
+   importLogBuffer(""),
+   activeImportConfig(nullptr)
 {
 }
 
 AssetImporter::~AssetImporter()
 {
+}
 
+bool AssetImporter::onAdd()
+{
+   if (!Parent::onAdd())
+      return false;
+
+   return true;
+}
+
+void AssetImporter::onRemove()
+{
+   Parent::onRemove();
 }
 
 void AssetImporter::initPersistFields()
@@ -579,27 +605,27 @@ String AssetImporter::parseImageSuffixes(String assetName, String* suffixType)
       switch (suffixTypeIdx)
       {
          case 0:
-            suffixList = activeImportConfig.DiffuseTypeSuffixes;
+            suffixList = activeImportConfig->DiffuseTypeSuffixes;
             suffixType->insert(0, "Albedo", 10);
             break;
          case 1:
-            suffixList = activeImportConfig.NormalTypeSuffixes;
+            suffixList = activeImportConfig->NormalTypeSuffixes;
             suffixType->insert(0, "Normal", 10);
             break;
          case 2:
-            suffixList = activeImportConfig.RoughnessTypeSuffixes;
+            suffixList = activeImportConfig->RoughnessTypeSuffixes;
             suffixType->insert(0, "Roughness", 10);
             break;
          case 3:
-            suffixList = activeImportConfig.AOTypeSuffixes;
+            suffixList = activeImportConfig->AOTypeSuffixes;
             suffixType->insert(0, "AO", 10);
             break;
          case 4:
-            suffixList = activeImportConfig.MetalnessTypeSuffixes;
+            suffixList = activeImportConfig->MetalnessTypeSuffixes;
             suffixType->insert(0, "Metalness", 10);
             break;
          case 5:
-            suffixList = activeImportConfig.PBRTypeSuffixes;
+            suffixList = activeImportConfig->PBRTypeSuffixes;
             suffixType->insert(0, "PBRConfig", 10);
             break;
          default:
@@ -1262,7 +1288,7 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
    dSprintf(importLogBuffer, sizeof(importLogBuffer), "Preparing Image for Import: %s", assetItem->assetName.c_str());
    activityLog.push_back(importLogBuffer);
 
-   if ((activeImportConfig.GenerateMaterialOnImport && assetItem->parentAssetItem == nullptr)/* || assetItem->parentAssetItem != nullptr*/)
+   if ((activeImportConfig->GenerateMaterialOnImport && assetItem->parentAssetItem == nullptr)/* || assetItem->parentAssetItem != nullptr*/)
    {
       //find our suffix match, if any
       String noSuffixName = assetItem->assetName;
@@ -1322,9 +1348,9 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
       //if we need to append the diffuse suffix and indeed didn't find a suffix on the name, do that here
       if (suffixType.isEmpty())
       {
-         if (activeImportConfig.UseDiffuseSuffixOnOriginImage)
+         if (activeImportConfig->UseDiffuseSuffixOnOriginImage)
          {
-            String diffuseToken = StringUnit::getUnit(activeImportConfig.DiffuseTypeSuffixes, 0, ",;");
+            String diffuseToken = StringUnit::getUnit(activeImportConfig->DiffuseTypeSuffixes, 0, ",;");
             assetItem->assetName = assetItem->assetName + diffuseToken;
             assetItem->cleanAssetName = assetItem->assetName;
          }
@@ -1359,12 +1385,12 @@ void AssetImporter::processMaterialAsset(AssetImportObject* assetItem)
 
    assetItem->generatedAsset = true;
 
-   if (activeImportConfig.IgnoreMaterials.isNotEmpty())
+   if (activeImportConfig->IgnoreMaterials.isNotEmpty())
    {
-      U32 ignoredMatNameCount = StringUnit::getUnitCount(activeImportConfig.IgnoreMaterials, ".;");
+      U32 ignoredMatNameCount = StringUnit::getUnitCount(activeImportConfig->IgnoreMaterials, ".;");
       for (U32 i = 0; i < ignoredMatNameCount; i++)
       {
-         String ignoredName = StringUnit::getUnit(activeImportConfig.IgnoreMaterials, i, ".;");
+         String ignoredName = StringUnit::getUnit(activeImportConfig->IgnoreMaterials, i, ".;");
          if (FindMatch::isMatch(ignoredName.c_str(), assetName, false))
          {
             assetItem->skip = true;
@@ -1376,7 +1402,7 @@ void AssetImporter::processMaterialAsset(AssetImportObject* assetItem)
       }
    }
 
-   if (activeImportConfig.PopulateMaterialMaps)
+   if (activeImportConfig->PopulateMaterialMaps)
    {
       //If we're trying to populate the rest of our material maps, we need to go looking
       dSprintf(importLogBuffer, sizeof(importLogBuffer), "Attempting to Auto-Populate Material Maps");
@@ -1424,22 +1450,22 @@ void AssetImporter::processMaterialAsset(AssetImportObject* assetItem)
             switch (t)
             {
             case ImageAsset::Albedo:
-               suffixList = activeImportConfig.DiffuseTypeSuffixes;
+               suffixList = activeImportConfig->DiffuseTypeSuffixes;
                break;
             case ImageAsset::Normal:
-               suffixList = activeImportConfig.NormalTypeSuffixes;
+               suffixList = activeImportConfig->NormalTypeSuffixes;
                break;
             case ImageAsset::PBRConfig:
-               suffixList = activeImportConfig.PBRTypeSuffixes;
+               suffixList = activeImportConfig->PBRTypeSuffixes;
                break;
             case ImageAsset::Metalness:
-               suffixList = activeImportConfig.MetalnessTypeSuffixes;
+               suffixList = activeImportConfig->MetalnessTypeSuffixes;
                break;
             case ImageAsset::AO:
-               suffixList = activeImportConfig.AOTypeSuffixes;
+               suffixList = activeImportConfig->AOTypeSuffixes;
                break;
             case ImageAsset::Roughness:
-               suffixList = activeImportConfig.RoughnessTypeSuffixes;
+               suffixList = activeImportConfig->RoughnessTypeSuffixes;
                break;
             //TODO: Glow map lookup too
             }
@@ -1575,12 +1601,12 @@ void AssetImporter::processShapeAsset(AssetImportObject* assetItem)
    dSprintf(importLogBuffer, sizeof(importLogBuffer), "   Shape Info: Mesh Count: %i | Material Count: %i | Anim Count: %i", meshCount, animCount, materialCount);
    activityLog.push_back(importLogBuffer);
 
-   if (activeImportConfig.ImportMesh && meshCount > 0)
+   if (activeImportConfig->ImportMesh && meshCount > 0)
    {
 
    }
 
-   if (activeImportConfig.ImportAnimations && animCount > 0)
+   if (activeImportConfig->ImportAnimations && animCount > 0)
    {
       //If we have animations but no meshes, then this is a pure animation file so we can swap the asset type here
       if (meshCount == 0)
@@ -1589,7 +1615,7 @@ void AssetImporter::processShapeAsset(AssetImportObject* assetItem)
       }
    }
 
-   if (activeImportConfig.ImportMaterials && materialCount > 0)
+   if (activeImportConfig->ImportMaterials && materialCount > 0)
    {
       S32 materialId = assetItem->shapeInfo->getChildItem(matItem);
       processShapeMaterialInfo(assetItem, materialId);
@@ -1617,12 +1643,12 @@ void AssetImporter::processShapeMaterialInfo(AssetImportObject* assetItem, S32 m
    }
 
    //Do a check so we don't import materials that are on our ignore list
-   if (activeImportConfig.IgnoreMaterials.isNotEmpty())
+   if (activeImportConfig->IgnoreMaterials.isNotEmpty())
    {
-      U32 ignoredMatNamesCount = StringUnit::getUnitCount(activeImportConfig.IgnoreMaterials, ",;");
+      U32 ignoredMatNamesCount = StringUnit::getUnitCount(activeImportConfig->IgnoreMaterials, ",;");
       for (U32 i = 0; i < ignoredMatNamesCount; i++)
       {
-         const char* ignoreMatName = StringUnit::getUnit(activeImportConfig.IgnoreMaterials, i, ",;");
+         const char* ignoreMatName = StringUnit::getUnit(activeImportConfig->IgnoreMaterials, i, ",;");
          if (FindMatch::isMatch(ignoreMatName, matName.c_str(), false))
          {
             //If we have a match to one of our ignore names, just bail out here and skip the material wholesale
@@ -1774,7 +1800,7 @@ void AssetImporter::validateAsset(AssetImportObject* assetItem)
 
    if (assetItem->status == String("Warning"))
    {
-      if (activeImportConfig.WarningsAsErrors)
+      if (activeImportConfig->WarningsAsErrors)
       {
          assetItem->status = "Error";
 
@@ -1909,7 +1935,7 @@ void AssetImporter::resolveAssetItemIssues(AssetImportObject* assetItem)
       String humanReadableReason = assetItem->statusType == String("DuplicateImportAsset") ? "Importing asset was duplicate of another importing asset" : "Importing asset was duplicate of an existing asset";
 
       //get the config value for duplicateAutoResolution
-      if (activeImportConfig.DuplicatAutoResolution == String("AutoPrune"))
+      if (activeImportConfig->DuplicatAutoResolution == String("AutoPrune"))
       {
          //delete the item
          deleteImportingAsset(assetItem);
@@ -1920,7 +1946,7 @@ void AssetImporter::resolveAssetItemIssues(AssetImportObject* assetItem)
 
          importIssues = false;
       }
-      else if (activeImportConfig.DuplicatAutoResolution == String("AutoRename"))
+      else if (activeImportConfig->DuplicatAutoResolution == String("AutoRename"))
       {
          //Set trailing number
          String renamedAssetName = assetItem->assetName;
@@ -1939,7 +1965,7 @@ void AssetImporter::resolveAssetItemIssues(AssetImportObject* assetItem)
          resetAssetValidationStatus(assetItem);
          importIssues = false;
       }
-      else if (activeImportConfig.DuplicatAutoResolution == String("UseExisting"))
+      else if (activeImportConfig->DuplicatAutoResolution == String("UseExisting"))
       {
 
       }
@@ -1991,7 +2017,11 @@ StringTableEntry AssetImporter::autoImportFile(Torque::Path filePath)
    targetPath = filePath.getPath();
 
    //use a default import config
-   activeImportConfig = AssetImportConfig();
+   if (activeImportConfig == nullptr)
+   {
+      activeImportConfig = new AssetImportConfig();
+      activeImportConfig->registerObject();
+   }
 
    bool foundConfig = false;
    Settings* editorSettings;
@@ -2005,7 +2035,7 @@ StringTableEntry AssetImporter::autoImportFile(Torque::Path filePath)
       if (Sim::findObject("AssetImportSettings", importConfigs))
       {
          //Now load the editor setting-deigned config!
-         activeImportConfig.loadImportConfig(importConfigs, defaultImportConfig.c_str());
+         activeImportConfig->loadImportConfig(importConfigs, defaultImportConfig.c_str());
       }
    }
 
@@ -2328,7 +2358,7 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
    }
 
    //build the PBRConfig file if we're flagged to and have valid image maps
-   if (activeImportConfig.CreatePBRConfig)
+   if (activeImportConfig->CreatePBRConfig)
    {
       AssetImportObject* pbrConfigMap = nullptr;
       AssetImportObject* roughnessMap = nullptr;
@@ -2635,38 +2665,38 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
       //now we write the import config logic into the constructor itself to ensure we load like we wanted it to
       String neverImportMats;
 
-      if (activeImportConfig.IgnoreMaterials.isNotEmpty())
+      if (activeImportConfig->IgnoreMaterials.isNotEmpty())
       {
-         U32 ignoredMatNamesCount = StringUnit::getUnitCount(activeImportConfig.IgnoreMaterials, ",;");
+         U32 ignoredMatNamesCount = StringUnit::getUnitCount(activeImportConfig->IgnoreMaterials, ",;");
          for (U32 i = 0; i < ignoredMatNamesCount; i++)
          {
             if (i == 0)
-               neverImportMats = StringUnit::getUnit(activeImportConfig.IgnoreMaterials, i, ",;");
+               neverImportMats = StringUnit::getUnit(activeImportConfig->IgnoreMaterials, i, ",;");
             else
-               neverImportMats += String("\t") + StringUnit::getUnit(activeImportConfig.IgnoreMaterials, i, ",;");
+               neverImportMats += String("\t") + StringUnit::getUnit(activeImportConfig->IgnoreMaterials, i, ",;");
          }
       }
 
-      if (activeImportConfig.DoUpAxisOverride)
+      if (activeImportConfig->DoUpAxisOverride)
       {
          S32 upAxis = domUpAxisType::UPAXISTYPE_Z_UP;
-         if (activeImportConfig.UpAxisOverride.compare("X_AXIS") == 0)
+         if (activeImportConfig->UpAxisOverride.compare("X_AXIS") == 0)
          {
             upAxis = domUpAxisType::UPAXISTYPE_X_UP;
          }
-         else if (activeImportConfig.UpAxisOverride.compare("Y_AXIS") == 0)
+         else if (activeImportConfig->UpAxisOverride.compare("Y_AXIS") == 0)
          {
             upAxis = domUpAxisType::UPAXISTYPE_Y_UP;
          }
-         else if (activeImportConfig.UpAxisOverride.compare("Z_AXIS") == 0)
+         else if (activeImportConfig->UpAxisOverride.compare("Z_AXIS") == 0)
          {
             upAxis = domUpAxisType::UPAXISTYPE_Z_UP;
          }
          constructor->mOptions.upAxis = (domUpAxisType)upAxis;
       }
 
-      if (activeImportConfig.DoScaleOverride)
-         constructor->mOptions.unit = activeImportConfig.ScaleOverride;
+      if (activeImportConfig->DoScaleOverride)
+         constructor->mOptions.unit = activeImportConfig->ScaleOverride;
       else
          constructor->mOptions.unit = -1;
 
@@ -2678,45 +2708,45 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
       };
 
       S32 lodType = ColladaUtils::ImportOptions::eLodType::TrailingNumber;
-      if (activeImportConfig.LODType.compare("TrailingNumber") == 0)
+      if (activeImportConfig->LODType.compare("TrailingNumber") == 0)
          lodType = ColladaUtils::ImportOptions::eLodType::TrailingNumber;
-      else if (activeImportConfig.LODType.compare("SingleSize") == 0)
+      else if (activeImportConfig->LODType.compare("SingleSize") == 0)
          lodType = ColladaUtils::ImportOptions::eLodType::SingleSize;
-      else if (activeImportConfig.LODType.compare("DetectDTS") == 0)
+      else if (activeImportConfig->LODType.compare("DetectDTS") == 0)
          lodType = ColladaUtils::ImportOptions::eLodType::DetectDTS;
       constructor->mOptions.lodType = (ColladaUtils::ImportOptions::eLodType)lodType;
 
-      constructor->mOptions.singleDetailSize = activeImportConfig.convertLeftHanded;
-      constructor->mOptions.alwaysImport = activeImportConfig.ImportedNodes;
-      constructor->mOptions.neverImport = activeImportConfig.IgnoreNodes;
-      constructor->mOptions.alwaysImportMesh = activeImportConfig.ImportMeshes;
-      constructor->mOptions.neverImportMesh = activeImportConfig.IgnoreMeshes;
-      constructor->mOptions.ignoreNodeScale = activeImportConfig.IgnoreNodeScale;
-      constructor->mOptions.adjustCenter = activeImportConfig.AdjustCenter;
-      constructor->mOptions.adjustFloor = activeImportConfig.AdjustFloor;
+      constructor->mOptions.singleDetailSize = activeImportConfig->convertLeftHanded;
+      constructor->mOptions.alwaysImport = activeImportConfig->ImportedNodes;
+      constructor->mOptions.neverImport = activeImportConfig->IgnoreNodes;
+      constructor->mOptions.alwaysImportMesh = activeImportConfig->ImportMeshes;
+      constructor->mOptions.neverImportMesh = activeImportConfig->IgnoreMeshes;
+      constructor->mOptions.ignoreNodeScale = activeImportConfig->IgnoreNodeScale;
+      constructor->mOptions.adjustCenter = activeImportConfig->AdjustCenter;
+      constructor->mOptions.adjustFloor = activeImportConfig->AdjustFloor;
 
-      constructor->mOptions.convertLeftHanded = activeImportConfig.convertLeftHanded;
-      constructor->mOptions.calcTangentSpace = activeImportConfig.calcTangentSpace;
-      constructor->mOptions.genUVCoords = activeImportConfig.genUVCoords;
-      constructor->mOptions.flipUVCoords = activeImportConfig.flipUVCoords;
-      constructor->mOptions.findInstances = activeImportConfig.findInstances;
-      constructor->mOptions.limitBoneWeights = activeImportConfig.limitBoneWeights;
-      constructor->mOptions.joinIdenticalVerts = activeImportConfig.JoinIdenticalVerts;
-      constructor->mOptions.reverseWindingOrder = activeImportConfig.reverseWindingOrder;
-      constructor->mOptions.invertNormals = activeImportConfig.invertNormals;
-      constructor->mOptions.removeRedundantMats = activeImportConfig.removeRedundantMats;
+      constructor->mOptions.convertLeftHanded = activeImportConfig->convertLeftHanded;
+      constructor->mOptions.calcTangentSpace = activeImportConfig->calcTangentSpace;
+      constructor->mOptions.genUVCoords = activeImportConfig->genUVCoords;
+      constructor->mOptions.flipUVCoords = activeImportConfig->flipUVCoords;
+      constructor->mOptions.findInstances = activeImportConfig->findInstances;
+      constructor->mOptions.limitBoneWeights = activeImportConfig->limitBoneWeights;
+      constructor->mOptions.joinIdenticalVerts = activeImportConfig->JoinIdenticalVerts;
+      constructor->mOptions.reverseWindingOrder = activeImportConfig->reverseWindingOrder;
+      constructor->mOptions.invertNormals = activeImportConfig->invertNormals;
+      constructor->mOptions.removeRedundantMats = activeImportConfig->removeRedundantMats;
 
       S32 animTimingType;
-      if (activeImportConfig.animTiming.compare("FrameCount") == 0)
+      if (activeImportConfig->animTiming.compare("FrameCount") == 0)
          animTimingType = ColladaUtils::ImportOptions::eAnimTimingType::FrameCount;
-      else if (activeImportConfig.animTiming.compare("Seconds") == 0)
+      else if (activeImportConfig->animTiming.compare("Seconds") == 0)
          animTimingType = ColladaUtils::ImportOptions::eAnimTimingType::Seconds;
-      else// (activeImportConfig.animTiming.compare("Milliseconds") == 0)
+      else// (activeImportConfig->animTiming.compare("Milliseconds") == 0)
          animTimingType = ColladaUtils::ImportOptions::eAnimTimingType::Milliseconds;
 
       constructor->mOptions.animTiming = (ColladaUtils::ImportOptions::eAnimTimingType)animTimingType;
 
-      constructor->mOptions.animFPS = activeImportConfig.animFPS;
+      constructor->mOptions.animFPS = activeImportConfig->animFPS;
 
       constructor->mOptions.neverImportMat = neverImportMats;
 

--- a/Engine/source/T3D/assets/assetImporter.h
+++ b/Engine/source/T3D/assets/assetImporter.h
@@ -15,6 +15,8 @@
 /// </summary>
 class AssetImportConfig : public SimObject
 {
+   typedef SimObject Parent;
+
    //General Settings
 public:
    /// <summary>
@@ -371,6 +373,9 @@ public:
    AssetImportConfig();
    virtual ~AssetImportConfig();
 
+   virtual bool onAdd();
+   virtual void onRemove();
+
    /// Engine.
    static void initPersistFields();
 
@@ -491,8 +496,8 @@ public:
    AssetImportObject();
    virtual ~AssetImportObject();
 
-   bool onAdd();
-   void onRemove();
+   virtual bool onAdd();
+   virtual void onRemove();
 
    /// Engine.
    static void initPersistFields();
@@ -521,7 +526,7 @@ class AssetImporter : public SimObject
    /// <summary>
    /// The import configuration that is currently being utilized
    /// </summary>
-   AssetImportConfig activeImportConfig;
+   AssetImportConfig* activeImportConfig;
 
    /// <summary>
    /// A log of all the actions that have been performed by the importer
@@ -576,6 +581,9 @@ class AssetImporter : public SimObject
 public:
    AssetImporter();
    virtual ~AssetImporter();
+
+   virtual bool onAdd();
+   virtual void onRemove();
 
    /// Engine.
    static void initPersistFields();
@@ -803,11 +811,11 @@ public:
    /// Gets the currently active import configuration
    /// <para>@return Current AssetImportConfig the importer is using</para>
    /// </summary>
-   AssetImportConfig* getImportConfig() { return &activeImportConfig; }
+   AssetImportConfig* getImportConfig() { return activeImportConfig; }
 
    void setImportConfig(AssetImportConfig* importConfig) {
       if(importConfig != nullptr)
-         activeImportConfig = *importConfig;
+         activeImportConfig = importConfig;
    }
 
    //

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -1703,6 +1703,9 @@ void TSStatic::onInspect(GuiInspector* inspector)
 
    //Put the GameObject group before everything that'd be gameobject-effecting, for orginazational purposes
    GuiInspectorGroup* materialGroup = inspector->findExistentGroup(StringTable->insert("Materials"));
+   if (!materialGroup)
+      return;
+
    GuiControl* stack = dynamic_cast<GuiControl*>(materialGroup->findObjectByInternalName(StringTable->insert("Stack")));
 
    //Do this on both the server and client

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -464,6 +464,8 @@ bool TerrainBlock::saveAsset()
       mTerrainAsset->clearAssetDependencyFields("terrainMaterailAsset");
 
       AssetQuery* pAssetQuery = new AssetQuery();
+      pAssetQuery->registerObject();
+
       AssetDatabase.findAssetType(pAssetQuery, "TerrainMaterialAsset");
 
       TerrainBlock* clientTerr = static_cast<TerrainBlock*>(getClientObject());

--- a/Templates/BaseGame/game/data/ui/guis/chooseLevelDlg.cs
+++ b/Templates/BaseGame/game/data/ui/guis/chooseLevelDlg.cs
@@ -54,9 +54,9 @@ function ChooseLevelDlg::onWake( %this )
       
       %levelAsset = AssetDatabase.acquireAsset(%assetId);
       
-      %file = %levelAsset.LevelFile;
+      %file = %levelAsset.getLevelFile();
       
-      if ( !isFile(%file @ ".mis") && !isFile(%file) )
+      if ( !isFile(%file @ ".mis") && !isFile(%file @ ".mis.dso") &&!isFile(%file) )
          continue;
          
       // Skip our new level/mission if we arent choosing a level
@@ -184,7 +184,7 @@ function ChooseLevelDlg::addMissionFile( %this, %file )
 
 function ChooseLevelDlg::addLevelAsset( %this, %levelAsset )
 {
-   %file = %levelAsset.LevelFile;
+   %file = %levelAsset.getLevelFile();
    
    /*%levelName = fileBase(%file);
    %levelDesc = "A Torque level";

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.cs
@@ -1524,90 +1524,94 @@ function AssetBrowser::doRebuildAssetArray(%this)
    }
 
    //Add Non-Asset Scripted Objects. Datablock, etc based
-   %category = getWord( %breadcrumbPath, 1 );                  
-   %dataGroup = "DataBlockGroup";
-   
-   for ( %i = 0; %i < %dataGroup.getCount(); %i++ )
+   if(AssetBrowser.assetTypeFilter $= "")
    {
-      %obj = %dataGroup.getObject(%i);
-      // echo ("Obj: " @ %obj.getName() @ " - " @ %obj.category );
+      %category = getWord( %breadcrumbPath, 1 );                  
+      %dataGroup = "DataBlockGroup";
       
-      //if ( %obj.category $= "" && %obj.category == 0 )
-      //   continue;
-      
-      %dbFilename = %obj.getFileName();
-      %dbFilePath = filePath(%dbFilename);
-      
-      %searchActive = AssetSearchTerms.count() != 0;
-      if(%searchActive)
+      for ( %i = 0; %i < %dataGroup.getCount(); %i++ )
       {
-         if(startsWith(%dbFilePath, %breadcrumbPath))
+         %obj = %dataGroup.getObject(%i);
+         // echo ("Obj: " @ %obj.getName() @ " - " @ %obj.category );
+         
+         //if ( %obj.category $= "" && %obj.category == 0 )
+         //   continue;
+         
+         %dbFilename = %obj.getFileName();
+         %dbFilePath = filePath(%dbFilename);
+         
+         %searchActive = AssetSearchTerms.count() != 0;
+         if(%searchActive)
+         {
+            if(startsWith(%dbFilePath, %breadcrumbPath))
+            {
+               %dbName = %obj.getName();
+               if(matchesSearch(%dbName, "Datablock"))
+               {
+                  %assetArray.add( %dbFilename, "Datablock" TAB %dbName );
+               }  
+            }
+         }
+         else if(%dbFilePath $= %breadcrumbPath)
          {
             %dbName = %obj.getName();
-            if(matchesSearch(%dbName, "Datablock"))
+            %assetArray.add( %dbFilename, "Datablock" TAB %dbName );
+            
+            /*%catItem = AssetBrowser-->filterTree.findItemByName(%obj.category);
+            
+            if(%catItem == 0)
+               AssetBrowser-->filterTree.insertItem(%scriptedItem, %obj.category, "scripted");*/
+            /*%ctrl = %this.findIconCtrl( %obj.category );
+            if ( %ctrl == -1 )
             {
-               %assetArray.add( %dbFilename, "Datablock" TAB %dbName );
-            }  
+               %this.addFolderIcon( %obj.category );
+            }*/
          }
       }
-      else if(%dbFilePath $= %breadcrumbPath)
+      
+      
+      %this.getLooseFilesInDir();
+      
+      %looseFiles = ABLooseFileArray.count();
+      for( %i=0; %i < %looseFiles; %i++)
       {
-         %dbName = %obj.getName();
-         %assetArray.add( %dbFilename, "Datablock" TAB %dbName );
+         %looseFileFullPath = ABLooseFileArray.getKey(%i);
+         %looseFilePath = filePath(%looseFileFullPath);
+         %looseFileName = fileName(%looseFileFullPath);
          
-         /*%catItem = AssetBrowser-->filterTree.findItemByName(%obj.category);
-         
-         if(%catItem == 0)
-            AssetBrowser-->filterTree.insertItem(%scriptedItem, %obj.category, "scripted");*/
-         /*%ctrl = %this.findIconCtrl( %obj.category );
-         if ( %ctrl == -1 )
-         {
-            %this.addFolderIcon( %obj.category );
-         }*/
+         %assetArray.add( %looseFilePath, "LooseFile" TAB %looseFileName );
       }
-   }
-   
-   %this.getLooseFilesInDir();
-   
-   %looseFiles = ABLooseFileArray.count();
-   for( %i=0; %i < %looseFiles; %i++)
-   {
-      %looseFileFullPath = ABLooseFileArray.getKey(%i);
-      %looseFilePath = filePath(%looseFileFullPath);
-      %looseFileName = fileName(%looseFileFullPath);
+         
+      //Prefabs
+      %expr = "*.prefab";
+      %fullPrefabPath = findFirstFile( %breadcrumbPath @ "/" @ %expr );
       
-      %assetArray.add( %looseFilePath, "LooseFile" TAB %looseFileName );
-   }
-      
-	//Prefabs
-	%expr = "*.prefab";
-   %fullPrefabPath = findFirstFile( %breadcrumbPath @ "/" @ %expr );
-   
-   while ( %fullPrefabPath !$= "" )
-   {         
-      %prefabPath = filePath(%fullPrefabPath);
-      %prefabName = fileName(%fullPrefabPath);
-      
-      %searchActive = AssetSearchTerms.count() != 0;
-      if(%searchActive)
-      {
-         if(startsWith(%prefabPath, %breadcrumbPath))
+      while ( %fullPrefabPath !$= "" )
+      {         
+         %prefabPath = filePath(%fullPrefabPath);
+         %prefabName = fileName(%fullPrefabPath);
+         
+         %searchActive = AssetSearchTerms.count() != 0;
+         if(%searchActive)
          {
-            if(matchesSearch(%prefabName, "Prefab"))
+            if(startsWith(%prefabPath, %breadcrumbPath))
             {
-               %assetArray.add( %prefabPath, "Prefab" TAB %prefabName );
-            }  
+               if(matchesSearch(%prefabName, "Prefab"))
+               {
+                  %assetArray.add( %prefabPath, "Prefab" TAB %prefabName );
+               }  
+            }
          }
-      }
-      else if(%prefabPath $= %breadcrumbPath)
-      {
-         %assetArray.add( %prefabPath, "Prefab" TAB %prefabName );
-      }
+         else if(%prefabPath $= %breadcrumbPath)
+         {
+            %assetArray.add( %prefabPath, "Prefab" TAB %prefabName );
+         }
 
-      %fullPrefabPath = findNextFile( %breadcrumbPath @ "/" @ %expr );
+         %fullPrefabPath = findNextFile( %breadcrumbPath @ "/" @ %expr );
+      }
    }
 	
-	for(%i=0; %i < %assetArray.count(); %i++)
+   for(%i=0; %i < %assetArray.count(); %i++)
 		AssetBrowser.buildAssetPreview( %assetArray.getValue(%i), %assetArray.getKey(%i) );  
 		
    AssetBrowser_FooterText.text = %finalAssetCount @ " Assets";

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/level.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/level.cs
@@ -134,7 +134,7 @@ function AssetBrowser::moveLevelAsset(%this, %assetDef, %destination)
 function AssetBrowser::buildLevelAssetPreview(%this, %assetDef, %previewData)
 {
    %previewData.assetName = %assetDef.assetName;
-   %previewData.assetPath = %assetDef.levelFile;
+   %previewData.assetPath = %assetDef.getlevelFile();
    %previewData.doubleClickCommand = "schedule( 1, 0, \"EditorOpenMission\", "@%assetDef@");";
    
    %levelPreviewImage = %assetDesc.PreviewImage;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/newAsset.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/newAsset.cs
@@ -153,6 +153,12 @@ function newAssetUpdatePath(%newPath)
 //We do a quick validation that mandatory fields are filled in before passing along to the asset-type specific function
 function CreateNewAsset()
 {
+   //To enusre that any in-progress-of-being-edited field applies it's changes
+   %lastEditField = AssetBrowser_newAsset.getFirstResponder(); 
+   
+   if(%lastEditField.isMethod("forceValidateText"))
+      %lastEditField.forceValidateText();
+   
    %assetName = AssetBrowser.newAssetSettings.assetName;
    
    if(%assetName $= "")

--- a/Templates/BaseGame/game/tools/shapeEditor/main.cs
+++ b/Templates/BaseGame/game/tools/shapeEditor/main.cs
@@ -148,14 +148,14 @@ function ShapeEditorPlugin::onWorldEditorStartup(%this)
 function ShapeEditorPlugin::openShapeAsset(%this, %assetDef)
 {
    %this.selectedAssetDef = %assetDef;
-   %this.open(%this.selectedAssetDef.fileName);
+   %this.open(%this.selectedAssetDef.getShapeFile());
 }
 
 function ShapeEditorPlugin::openShapeAssetId(%this, %assetId)
 {
    %this.selectedAssetDef = AssetDatabase.acquireAsset(%assetId);
    //%this.selectedAssetDef = %assetDef;
-   %this.open(%this.selectedAssetDef.fileName);
+   %this.open(%this.selectedAssetDef.getShapeFile());
 }
 
 function ShapeEditorPlugin::open(%this, %filename)

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.cs
@@ -350,8 +350,6 @@ function TerrainMaterialDlg::newMat( %this )
    %module = AssetBrowser.dirHandler.getModuleFromAddress(%path);
    AssetBrowser.selectedModule = %module.moduleID;
    
-   AssetBrowser.dirHandler.currentAddress = "data/" @ %module.moduleID;
-   
    AssetBrowser.setupCreateNewAsset("TerrainMaterialAsset", AssetBrowser.selectedModule);
 }
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.cs
@@ -355,7 +355,7 @@ function EditorSaveMissionAs( %levelAsset )
       return;
    }
                
-   %missionName = %levelAssetDef.LevelFile;
+   %missionName = %levelAssetDef.getLevelFile();
                
    if( fileExt( %missionName ) !$= ".mis" )
       %missionName = %missionName @ ".mis";
@@ -427,7 +427,7 @@ function EditorOpenMission(%levelAsset)
       
       updateRecentLevelsListing();
       
-      %filename = %assetDef.levelFile;
+      %filename = %assetDef.getlevelFile();
       
       if(%filename $= "")
       {
@@ -473,7 +473,7 @@ function EditorOpenMission(%levelAsset)
 function EditorOpenSceneAppend(%levelAsset)
 {
    //Load the asset's level file
-   exec(%levelAsset.levelFile);
+   exec(%levelAsset.getlevelFile());
    
    //We'll assume the scene name and assetname are the same for now
    %sceneName = %levelAsset.AssetName;


### PR DESCRIPTION
Adds functions to get the full path for level and shape asset files
Updated choose level UI to use getLevelPath function so it works again
Added a check for mis.dso for choose level UI as well in case it was compiled
Updated open asset in shape editor logic to use getShapeFile so it works again
Fixed on-exit crash after drag-n-drop importing of assets into the AB by properly using the import config object as a pointered object
Added sanity check when inspecting a TSStatic, if there isn't a materials inspector group for whatever reason to prevent a crash
Added filter logic so if in select mode for a specific asset type, it won't show datablocks, prefabs or other loosefiles
Removed unneeded setting of AB's current address path when creating a new terrain material asset
Added logic for forcing field validation in the create a new asset window. This fixes a problem where if you'd typed in a field but didn't hit enter and then immediately hit the done button, the typed string wasn't used.