### PR TITLE
Misc. Image Asset improvements

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -353,11 +353,11 @@ ImageAsset::ImageTypes ImageAsset::getImageTypeFromName(const char* name)
    return (ImageTypes)ret;
 }
 
-DefineEngineMethod(ImageAsset, getImageFilename, const char*, (), ,
+DefineEngineMethod(ImageAsset, getImagePath, const char*, (), ,
    "Creates an instance of the given GameObject given the asset definition.\n"
    "@return The GameObject entity created from the asset.")
 {
-   return object->getImageFileName();
+   return object->getImagePath();
 }
 
 DefineEngineMethod(ImageAsset, getImageInfo, const char*, (), ,

--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -1317,7 +1317,7 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
       {
          if (!assetItem->filePath.isEmpty())
          {
-            materialAsset = addImportingAsset("MaterialAsset", "", nullptr, noSuffixName);
+            materialAsset = addImportingAsset("MaterialAsset", assetItem->filePath, nullptr, noSuffixName);
          }
       }
 
@@ -2466,6 +2466,7 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
       dSprintf(lineBuffer, 1024, "   mapTo=\"%s\";", assetName);
       file->writeLine((U8*)lineBuffer);
 
+      bool hasRoughness = false;
       for (U32 i = 0; i < assetItem->childAssetItems.size(); i++)
       {
          AssetImportObject* childItem = assetItem->childAssetItems[i];
@@ -2502,6 +2503,7 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
          else if (imageType == ImageAsset::ImageTypes::Roughness)
          {
             mapFieldName = "RoughnessMap";
+            hasRoughness = true;
          }
 
          assetFieldName = mapFieldName + "Asset";
@@ -2513,6 +2515,12 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
 
          dSprintf(lineBuffer, 1024, "   %s = \"%s:%s\";", assetFieldName.c_str(), targetModuleId.c_str(), childItem->assetName.c_str());
          file->writeLine((U8*)lineBuffer);
+      }
+
+      if (hasRoughness)
+      {
+         file->writeLine((U8*)"   invertSmoothness = true;");
+         
       }
 
       file->writeLine((U8*)"};");

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.cs
@@ -176,7 +176,7 @@ function AssetBrowser::buildImageAssetPreview(%this, %assetDef, %previewData)
    %previewData.assetPath = %assetDef.scriptFile;
    //%previewData.doubleClickCommand = "EditorOpenFileInTorsion( "@%previewData.assetPath@", 0 );";
    
-   %imageFilePath = %assetDef.getImageFilename();
+   %imageFilePath = %assetDef.getImagePath();
    if(isFile(%imageFilePath))
       %previewData.previewImage = %imageFilePath;
    else
@@ -201,7 +201,7 @@ function AssetBrowser::buildImageAssetPreview(%this, %assetDef, %previewData)
 //Renames the asset
 function AssetBrowser::renameImageAsset(%this, %assetDef, %newAssetName)
 {
-   %newFilename = renameAssetLooseFile(%assetDef.imageFile, %newAssetName);
+   %newFilename = renameAssetLooseFile(%assetDef.getImagePath(), %newAssetName);
    
    if(!%newFilename $= "")
       return;

--- a/Templates/BaseGame/game/tools/convexEditor/convexEditorGui.cs
+++ b/Templates/BaseGame/game/tools/convexEditor/convexEditorGui.cs
@@ -163,7 +163,7 @@ function ConvexEditorMaterialBtn::gotMaterialName(%this, %name)
       if(%diffuseAsset !$= "")
       {
          %diffuseAssetDef = AssetDatabase.acquireAsset(%diffuseAsset);
-         %diffusemap = %diffuseAssetDef.imageFile;
+         %diffusemap = %diffuseAssetDef.getImagePath();
       }
    }
 
@@ -228,7 +228,7 @@ function ConvexEditorDefaultMaterialBtn::gotMaterialName(%this, %name)
       if(%diffuseAsset !$= "")
       {
          %diffuseAssetDef = AssetDatabase.acquireAsset(%diffuseAsset);
-         %diffusemap = %diffuseAssetDef.imageFile;
+         %diffusemap = %diffuseAssetDef.getImagePath();
       }
    }
 


### PR DESCRIPTION
Shifts getImageFilename to getImagePath on ImageAsset
Adjusts references to utilize getImagePath to ensure things using the image asset gets the proper full path
Adjusts image import logic to import finding associated images
Adds logic so if a roughness map is imported, the generated material asset has the invertSmoothness flag on.