### PR TITLE
shipPrep() method .

### DIFF
--- a/Templates/BaseGame/game/core/utility/scripts/helperFunctions.cs
+++ b/Templates/BaseGame/game/core/utility/scripts/helperFunctions.cs
@@ -641,3 +641,34 @@ function populateAllFonts(%font)
    populateFontCacheRange(%font,32,0,65535);
    populateFontCacheRange(%font,36,0,65535);
 }
+
+function compileFiles(%pattern)
+{  
+   %path = filePath(%pattern);
+
+   %saveDSO    = $Scripts::OverrideDSOPath;
+   %saveIgnore = $Scripts::ignoreDSOs;
+   
+   $Scripts::OverrideDSOPath  = %path;
+   $Scripts::ignoreDSOs       = false;
+   %mainCsFile = makeFullPath("main.cs");
+
+   for (%file = findFirstFileMultiExpr(%pattern); %file !$= ""; %file = findNextFileMultiExpr(%pattern))
+   {
+      // we don't want to try and compile the primary main.cs
+      if(%mainCsFile !$= %file)      
+         compile(%file, true);
+   }
+
+   $Scripts::OverrideDSOPath  = %saveDSO;
+   $Scripts::ignoreDSOs       = %saveIgnore;
+   
+}
+
+function shipPrep()
+{
+   compileFiles("*.cs");
+   compileFiles("*.gui");
+   compileFiles("*.mis");
+   compileFiles("*.ts");  
+}


### PR DESCRIPTION
includes the old compileFiles method from the GG full game template.
todos:
conversion method from xml tmls to binary tamls
removal of listed source files once compiled
search and destroy for dae, fbx et al if a matching .cached.dts or .dts is found
???
shiny 'do it' button on the asset manager/project manager