### PR TITLE
Misc. Fixes and cleanup for lights

### DIFF
--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -2167,9 +2167,14 @@ void WorldEditor::on3DMouseUp( const Gui3DMouseEvent &event )
                // this may actually cause things to disappear from mSelected so do the loop
                // in reverse.  This will make the loop work even if items are removed as
                // we go along.
-               for( S32 i = mSelected->size() - 1; i >= 0; -- i )
-                  Con::executef( this, "onUnSelect", ( *mSelected )[ i ]->getIdString() );
-               
+               for (S32 i = mSelected->size() - 1; i >= 0; --i)
+               {
+                  //We'll explicitly inform the object of being unmarked as selected in the editor as well for outlier cases potentially not being told, such as mounted objects
+                  WorldEditor::markAsSelected((*mSelected)[i], false);
+
+                  Con::executef(this, "onUnSelect", (*mSelected)[i]->getIdString());
+               }
+
                mSelected->clear();
                mSelected->addObject( mPossibleHitObject );
                mSelected->storeCurrentCentroid();
@@ -2894,8 +2899,13 @@ void WorldEditor::clearSelection()
    // this may actually cause things to disappear from mSelected so do the loop
    // in reverse.  This will make the loop work even if items are removed as
    // we go along.
-   for( S32 i = mSelected->size() - 1; i >= 0; -- i )
-      Con::executef( this, "onUnSelect", ( *mSelected )[ i ]->getIdString() );
+   for (S32 i = mSelected->size() - 1; i >= 0; --i)
+   {
+      //We'll explicitly inform the object of being unmarked as selected in the editor as well for outlier cases potentially not being told, such as mounted objects
+      WorldEditor::markAsSelected((*mSelected)[i], false);
+
+      Con::executef(this, "onUnSelect", (*mSelected)[i]->getIdString());
+   }
 
    Con::executef(this, "onClearSelection");
    mSelected->clear();

--- a/Engine/source/lighting/advanced/advancedLightBinManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightBinManager.cpp
@@ -370,18 +370,16 @@ void AdvancedLightBinManager::render( SceneRenderState *state )
    if (sceneColorTargetRef.isNull())
       return;
 
-   GFXTextureTargetRef lightingTargetRef = GFX->allocRenderToTextureTarget();
-
-   if (lightingTargetRef.isNull())
-      return;
+      if (mLightingTargetRef.isNull())
+      mLightingTargetRef = GFX->allocRenderToTextureTarget();
 
    //Do a quick pass to update our probes if they're dirty
    //PROBEMGR->updateDirtyProbes();
 
-   lightingTargetRef->attachTexture(GFXTextureTarget::Color0, sceneColorTargetRef->getTexture());
+   mLightingTargetRef->attachTexture(GFXTextureTarget::Color0, sceneColorTargetRef->getTexture());
 
    GFX->pushActiveRenderTarget();
-   GFX->setActiveRenderTarget(lightingTargetRef);
+   GFX->setActiveRenderTarget(mLightingTargetRef);
 
    GFX->setViewport(sceneColorTargetRef->getViewport());
 

--- a/Engine/source/lighting/advanced/advancedLightBinManager.h
+++ b/Engine/source/lighting/advanced/advancedLightBinManager.h
@@ -93,6 +93,8 @@ public:
    NamedTexTargetRef mDiffuseLightingTarget;
    GFXTexHandle      mDiffuseLightingTex;
 
+   GFXTextureTargetRef mLightingTargetRef;
+
    /// The shadow filter mode to use on shadowed light materials.
    static ShadowFilterMode smShadowFilterMode;
 

--- a/Templates/BaseGame/game/core/lighting/scripts/advancedLighting_Shaders.cs
+++ b/Templates/BaseGame/game/core/lighting/scripts/advancedLighting_Shaders.cs
@@ -46,9 +46,7 @@ singleton GFXStateBlockData( AL_VectorLightState )
    mSamplerNames[0] = "deferredBuffer";
    samplerStates[1] = SamplerClampPoint;  // Shadow Map (Do not change this to linear, as all cards can not filter equally.)
    mSamplerNames[1] = "shadowMap";
-   samplerStates[2] = SamplerClampPoint;  // Shadow Map (Do not change this to linear, as all cards can not filter equally.)
-   mSamplerNames[2] = "dynamicShadowMap";
-   samplerStates[3] = SamplerWrapPoint;   // Random Direction Map
+   samplerStates[2] = SamplerWrapPoint;   // Random Direction Map
    
    cullDefined = true;
    cullMode = GFXCullNone;
@@ -69,11 +67,10 @@ singleton shaderData( AL_VectorLightShader )
    
    samplerNames[0] = "$deferredBuffer";
    samplerNames[1] = "$shadowMap";
-   samplerNames[2] = "$dynamicShadowMap";
-   samplerNames[3] = "$gTapRotationTex";
-   samplerNames[4] = "$lightBuffer";
-   samplerNames[5] = "$colorBuffer";
-   samplerNames[6] = "$matInfoBuffer";  
+   samplerNames[2] = "$gTapRotationTex";
+   samplerNames[3] = "$lightBuffer";
+   samplerNames[4] = "$colorBuffer";
+   samplerNames[5] = "$matInfoBuffer";  
    
    pixVersion = 3.0;
 };
@@ -85,7 +82,6 @@ new CustomMaterial( AL_VectorLightMaterial )
    
    sampler["deferredBuffer"] = "#deferred";
    sampler["shadowMap"] = "$dynamiclight";
-   sampler["dynamicShadowMap"] = "$dynamicShadowMap";
    sampler["lightBuffer"] = "#specularLighting";
    sampler["colorBuffer"] = "#color";
    sampler["matInfoBuffer"] = "#matinfo";
@@ -122,8 +118,6 @@ singleton GFXStateBlockData( AL_ConvexLightState )
    mSamplerNames[0] = "deferredBuffer";
    samplerStates[1] = SamplerClampPoint;  // Shadow Map (Do not use linear, these are perspective projections)
    mSamplerNames[1] = "shadowMap";
-   samplerStates[2] = SamplerClampPoint;  // Shadow Map (Do not use linear, these are perspective projections)
-   mSamplerNames[2] = "dynamicShadowMap";
    samplerStates[3] = SamplerClampLinear; // Cookie Map   
    samplerStates[4] = SamplerWrapPoint;   // Random Direction Map
    
@@ -146,12 +140,11 @@ singleton shaderData( AL_PointLightShader )
 
    samplerNames[0] = "$deferredBuffer";
    samplerNames[1] = "$shadowMap";
-   samplerNames[2] = "$dynamicShadowMap";
-   samplerNames[3] = "$cookieMap";
-   samplerNames[4] = "$gTapRotationTex";
-   samplerNames[5] = "$lightBuffer";
-   samplerNames[6] = "$colorBuffer";
-   samplerNames[7] = "$matInfoBuffer";
+   samplerNames[2] = "$cookieMap";
+   samplerNames[3] = "$gTapRotationTex";
+   samplerNames[4] = "$lightBuffer";
+   samplerNames[5] = "$colorBuffer";
+   samplerNames[6] = "$matInfoBuffer";
    
    pixVersion = 3.0;
 };
@@ -163,7 +156,6 @@ new CustomMaterial( AL_PointLightMaterial )
    
    sampler["deferredBuffer"] = "#deferred";
    sampler["shadowMap"] = "$dynamiclight";
-   sampler["dynamicShadowMap"] = "$dynamicShadowMap";
    sampler["cookieMap"] = "$dynamiclightmask";
    sampler["lightBuffer"] = "#specularLighting";
    sampler["colorBuffer"] = "#color";
@@ -185,12 +177,11 @@ singleton shaderData( AL_SpotLightShader )
    
    samplerNames[0] = "$deferredBuffer";
    samplerNames[1] = "$shadowMap";
-   samplerNames[2] = "$dynamicShadowMap";
-   samplerNames[3] = "$cookieMap";
-   samplerNames[4] = "$gTapRotationTex";
-   samplerNames[5] = "$lightBuffer";
-   samplerNames[6] = "$colorBuffer";
-   samplerNames[7] = "$matInfoBuffer";
+   samplerNames[2] = "$cookieMap";
+   samplerNames[3] = "$gTapRotationTex";
+   samplerNames[4] = "$lightBuffer";
+   samplerNames[5] = "$colorBuffer";
+   samplerNames[6] = "$matInfoBuffer";
 
    pixVersion = 3.0;
 };
@@ -202,7 +193,6 @@ new CustomMaterial( AL_SpotLightMaterial )
    
    sampler["deferredBuffer"] = "#deferred";
    sampler["shadowMap"] = "$dynamiclight";
-   sampler["dynamicShadowMap"] = "$dynamicShadowMap";
    sampler["cookieMap"] = "$dynamiclightmask";
    sampler["lightBuffer"] = "#specularLighting";
    sampler["colorBuffer"] = "#color";

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/spotLightP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/spotLightP.glsl
@@ -106,7 +106,6 @@ void main()
 
          //distance to light in shadow map space
          float distToLight = pxlPosLightProj.z / lightRange;
-         float dynDistToLight = dynPxlPosLightProj.z / lightRange;
          float shadowed = softShadow_filter(shadowMap, ssPos.xy/ssPos.w, shadowCoord, shadowSoftness, distToLight, surfaceToLight.NdotL, lightParams.y);
       #endif      
    

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/spotLightP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/spotLightP.hlsl
@@ -112,7 +112,6 @@ float4 main(   ConvexConnectP IN ) : SV_TARGET
 
           //distance to light in shadow map space
          float distToLight = pxlPosLightProj.z / lightRange;
-         float dynDistToLight = dynPxlPosLightProj.z / lightRange;
          float shadowed = softShadow_filter(TORQUE_SAMPLER2D_MAKEARG(shadowMap), ssPos.xy, shadowCoord, shadowSoftness, distToLight, surfaceToLight.NdotL, lightParams.y);
       #endif      
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/visibility/miscViz.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/visibility/miscViz.cs
@@ -87,12 +87,12 @@ singleton shaderData( Viz_SurfaceProperties )
    OGLVertexShaderFile = $Core::CommonShaderPath @ "/postFX/gl/postFxV.glsl";
    OGLPixelShaderFile  = "./shaders/Viz_SurfacePropertiesP.glsl";
    
-   samplerNames[0] = "deferredTex";
-   samplerNames[1] = "colorBufferTex";
-   samplerNames[2] = "matinfoTex";
-   samplerNames[3] = "ssaoMaskTex";
-   samplerNames[4] = "$backBuffer";
-   samplerNames[5] = "glowBuffer";
+   samplerNames[0] = "$deferredBuffer";
+   samplerNames[1] = "$colorBuffer";
+   samplerNames[2] = "$matInfoBuffer";
+   samplerNames[3] = "$ssaoMaskTex";
+   samplerNames[4] = "$backbufferTex";
+   samplerNames[5] = "$glowBuffer";
 
    pixVersion = 2.0;
 };

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/visibility/shaders/Viz_SurfacePropertiesP.glsl
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/visibility/shaders/Viz_SurfacePropertiesP.glsl
@@ -1,0 +1,83 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2012 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+#include "../../../../core/rendering/shaders/postFX/gl/postFx.glsl"
+#include "../../../../core/rendering/shaders/gl/hlslCompat.glsl"
+#include "../../../../core/rendering/shaders/gl/lighting.glsl"
+#include "shadergen:/autogenConditioners.h"
+
+#line 27
+
+uniform sampler2D deferredBuffer;
+uniform sampler2D colorBuffer;
+uniform sampler2D matInfoBuffer;
+uniform sampler2D ssaoMaskTex;
+uniform sampler2D backbufferTex;
+uniform sampler2D glowBuffer;
+
+uniform float mode;
+uniform vec3 eyePosWorld;
+uniform mat4 cameraToWorld;
+
+out vec4 OUT_col;
+
+void main()
+{     
+    //unpack normal and linear depth 
+    vec4 normDepth = deferredUncondition(deferredBuffer, IN_uv0);
+
+    //create surface
+    Surface surface = createSurface(normDepth, colorBuffer, matInfoBuffer, IN_uv0.xy, eyePosWorld, IN_wsEyeRay, cameraToWorld);
+
+    OUT_col = vec4(0,0,0,1);   
+
+    if(mode == 0)
+        OUT_col.rgb = surface.baseColor.rgb;
+    else if(mode == 1)
+        OUT_col = vec4(surface.N.rgb,1);
+    else if(mode == 2)
+        OUT_col = vec4(surface.ao, surface.ao, surface.ao, 1);
+    else if(mode == 3)
+        OUT_col = vec4(surface.roughness, surface.roughness, surface.roughness, 1);
+    else if(mode == 4)
+        OUT_col = vec4(surface.metalness, surface.metalness, surface.metalness,1);
+    else if(mode == 5)
+        OUT_col = vec4(surface.depth, surface.depth, surface.depth,1);
+    else if(mode == 6) //Diffuse Color
+        OUT_col = vec4(surface.albedo.rgb,1);
+    else if(mode == 7) //Specular Color
+        OUT_col = vec4(surface.baseColor.rgb * surface.ao,1);
+    else if(mode == 8) //Mat Flags
+        OUT_col = vec4(surface.matFlag, surface.matFlag, surface.matFlag,1);
+    else if(mode == 9)
+        OUT_col = vec4(surface.P.xyz,1);
+    else if(mode == 10)
+        OUT_col = vec4(surface.R.xyz,1);
+    else if(mode == 11)
+        OUT_col = vec4(surface.F.rgb,1);
+    else if(mode == 12)
+        OUT_col = vec4(texture( ssaoMaskTex, IN_uv0 ).rgb, 1.0);
+    else if(mode == 13)
+        OUT_col = vec4(texture( backbufferTex, IN_uv0 ).rgb, 1.0);
+    else if(mode == 14)
+        OUT_col = vec4(texture( glowBuffer, IN_uv0 ).rgb, 1.0);
+}


### PR DESCRIPTION
Fixes de-selection logic in editor that caused special cases to permanently be selected such as mounted Lights
Shifted every-frame RT allocation to be stored in advancedLightBinManager
Remove deprecated references to dynamicShadowMap in light materials
Updated spotLight shaders to remove deprecated dynamic shadowmap reference which was causing a crash when spotlights had shadows turned on
Added GLSL version of Viz_SurfaceProperties so it works on both APIs