### PR TITLE
Fixes logic when opening shapeEditor with a TSStatic selected

### DIFF
--- a/Templates/BaseGame/game/tools/shapeEditor/main.cs
+++ b/Templates/BaseGame/game/tools/shapeEditor/main.cs
@@ -235,7 +235,7 @@ function ShapeEditorPlugin::onActivated(%this)
    {
       %obj = EWorldEditor.getSelectedObject(%i);
       %shapeFile = ShapeEditor.getObjectShapeFile(%obj);
-      if (%shapeFile !$= "")
+      if (%shapeFile !$= "" && isFile(%shapeFile))
       {
          if (!isObject(ShapeEditor.shape) || (ShapeEditor.shape.baseShape !$= %shapeFile))
          {
@@ -250,6 +250,10 @@ function ShapeEditorPlugin::onActivated(%this)
             ShapeEdShapeView.fitToShape();
          }
          break;
+      }
+      else if(%shapeFile !$= "")
+      {
+         %this.openShapeAssetId(%shapeFile);
       }
    }
 }

--- a/Templates/BaseGame/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
+++ b/Templates/BaseGame/game/tools/shapeEditor/scripts/shapeEditor.ed.cs
@@ -58,7 +58,7 @@ function ShapeEditor::getObjectShapeFile( %this, %obj )
    // works for the vast majority of object types)
    %path = "";
    if ( %obj.isMemberOfClass( "TSStatic" ) )
-      %path = %obj.shapeName;
+      %path = %obj.shapeAsset !$= "" ? %obj.shapeAsset : %obj.shapeName;
    else if ( %obj.isMemberOfClass( "PhysicsShape" ) )
       %path = %obj.getDataBlock().shapeName;
    else if ( %obj.isMemberOfClass( "GameBase" ) )


### PR DESCRIPTION
Fixes logic when opening shapeEditor with a TSStatic selected, it'll attempt to load up the shapeAsset if one is set on the static.