### PR TITLE
Misc Fixes for level saving and selecting asset paths

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/guis/selectPath.gui
+++ b/Templates/BaseGame/game/tools/assetBrowser/guis/selectPath.gui
@@ -12,7 +12,7 @@
    hovertime = "1000";
    isContainer = "1";
    canSave = "1";
-   canSaveDynamicFields = "1";
+   canSaveDynamicFields = "0";
 
    new GuiWindowCtrl(SelectAssetPathWindow) {
       text = "Select Path";
@@ -250,7 +250,27 @@
          isContainer = "0";
          canSave = "1";
          canSaveDynamicFields = "0";
-         command="SelectAssetPath.selectPath();";
+      };
+      new GuiButtonCtrl() {
+         text = "New Folder";
+         groupNum = "-1";
+         buttonType = "PushButton";
+         useMouseEvents = "0";
+         position = "3 414";
+         extent = "85 24";
+         minExtent = "8 2";
+         horizSizing = "right";
+         vertSizing = "bottom";
+         profile = "ToolsGuiButtonProfile";
+         visible = "1";
+         active = "1";
+         command = "SelectAssetPath.newFolder();";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "0";
+         internalName = "newFolderButton";
+         canSave = "1";
+         canSaveDynamicFields = "0";
       };
    };
 };

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/folder.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/folder.cs
@@ -11,12 +11,21 @@ function AssetBrowser::doCreateNewFolder(%this)
    if(%newFolderName $= "")
       %newFolderName = "NewFolder";
       
+   if(SelectAssetPath.isAwake())
+   {
+      %currentAddressPath = SelectAssetPath-->folderTree.getItemValue(SelectAssetPath.selectedTreeItem) @ "/" @ SelectAssetPath-->folderTree.getItemText(SelectAssetPath.selectedTreeItem);
+   }
+   else
+   {
+      %currentAddressPath = AssetBrowser.dirHandler.currentAddress;
+   }
+      
    %newFolderIdx = "";
    %matched = true;
    %newFolderPath = "";
    while(%matched == true)
    {
-      %newFolderPath = AssetBrowser.dirHandler.currentAddress @ "/" @ %newFolderName @ %newFolderIdx;
+      %newFolderPath = %currentAddressPath @ "/" @ %newFolderName @ %newFolderIdx;
       if(!isDirectory(%newFolderPath))
       {
          %matched = false;
@@ -38,6 +47,10 @@ function AssetBrowser::doCreateNewFolder(%this)
    AssetBrowser.loadDirectories();
    
    %this.navigateTo(%newFolderPath);
+   
+   //On the off chance we're trying to select a path, we'll update the select path window too
+   if(SelectAssetPath.isAwake())
+      SelectAssetPath.showDialog(%newFolderPath, SelectAssetPath.callback);
 }
 
 function AssetBrowser::buildFolderPreview(%this, %assetDef, %previewData)

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/selectPath.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/selectPath.cs
@@ -19,6 +19,11 @@ function SelectAssetPath::showDialog(%this, %startingPath, %callback)
    %dataItem = SelectAssetPath-->folderTree.insertItem(0, "Data");
    %this.dirHandler.loadFolders("Data", %dataItem);
    
+   %this.dirHandler.expandTreeToAddress(%startingPath);
+   %id = %this.dirHandler.getFolderTreeItemFromAddress(%startingPath);
+   %this.dirHandler.treeCtrl.clearSelection();
+   %this.dirHandler.treeCtrl.selectItem(%id);
+   
    Canvas.pushDialog(SelectAssetPath);
 }
 
@@ -44,4 +49,10 @@ function SelectAssetPath::selectPath(%this)
    }
    
    Canvas.popDialog(SelectAssetPath);
+}
+
+function SelectAssetPath::newFolder(%this)
+{   
+   AssetBrowser_newFolderNameTxt.text = "NewFolder";
+   Canvas.pushDialog(AssetBrowser_newFolder);
 }

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.cs
@@ -364,14 +364,17 @@ function EditorSaveMissionAs( %levelAsset )
    $Server::MissionFile = %missionName;
    %Server::LevelAsset = %levelAssetDef;
    
+   //Update the scene name to comply to the new level's name
+   GetRootScene().name = %levelAssetDef.AssetName;
+   
    //Do the save
    EditorSaveMission();
    
-   //TODO: doublecheck that we rename the scene properly
-      
-   //Make sure we have a selected module so we can create our module
-   //if(AssetBrowser.selectedModule $= "")
-   //   Canvas.pushDialog(
+   //Last, we're going to load the level proper in the editor
+   updateEditorRecentLevelsList(%levelAsset);
+   
+   //If we've opened a valid level, clear the saveAs tag as it's not really applicable now
+   EditorGui.saveAs = false;
 }
 
 function EditorOpenMission(%levelAsset)
@@ -408,33 +411,7 @@ function EditorOpenMission(%levelAsset)
          %levelAssetId = %levelAsset;
       }
       
-      EditorSettings.setValue("WorldEditor/lastEditedLevel", %levelAssetId);
-      
-      //update the recent levels list
-      %recentLevels = EditorSettings.value("WorldEditor/recentLevelsList");
-      %recentCount = getTokenCount(%recentLevels, ",");
-      
-      %updatedRecentList = %levelAssetId;
-      
-      %updatedRecentCount = 1;
-      for(%i=0; %i < %recentCount; %i++)
-      {
-         %recentEntry = getToken(%recentLevels, ",", %i);
-         
-         if(%levelAssetId $= %recentEntry)
-            continue;
-         
-         %updatedRecentList = %updatedRecentList @ "," @ %recentEntry;
-         
-         %updatedRecentCount++;
-         
-         if(%updatedRecentCount == 10)
-            break;
-      }
-      
-      EditorSettings.setValue("WorldEditor/recentLevelsList", %updatedRecentList);
-      
-      updateRecentLevelsListing();
+      updateEditorRecentLevelsList(%levelAssetId);
       
       %filename = %assetDef.getlevelFile();
       
@@ -511,6 +488,37 @@ function MakeSelectionASublevel()
    }
    %a = EWorldEditor.getSelectedObject(0);
    %b = EWorldEditor.getSelectedObject(1);*/
+}
+
+function updateEditorRecentLevelsList(%levelAssetId)
+{
+   EditorSettings.setValue("WorldEditor/lastEditedLevel", %levelAssetId);
+      
+   //update the recent levels list
+   %recentLevels = EditorSettings.value("WorldEditor/recentLevelsList");
+   %recentCount = getTokenCount(%recentLevels, ",");
+   
+   %updatedRecentList = %levelAssetId;
+   
+   %updatedRecentCount = 1;
+   for(%i=0; %i < %recentCount; %i++)
+   {
+      %recentEntry = getToken(%recentLevels, ",", %i);
+      
+      if(%levelAssetId $= %recentEntry)
+         continue;
+      
+      %updatedRecentList = %updatedRecentList @ "," @ %recentEntry;
+      
+      %updatedRecentCount++;
+      
+      if(%updatedRecentCount == 10)
+         break;
+   }
+   
+   EditorSettings.setValue("WorldEditor/recentLevelsList", %updatedRecentList);
+   
+   updateRecentLevelsListing();
 }
 
 function EditorExportToCollada()


### PR DESCRIPTION
Fixes level save as logic to correctly name new level's scene object to match, and helps ensure you're editing the right scene.

Added New Folder button to Select Path window