### PR TITLE
Misc editor settings fixes and additions

### DIFF
--- a/Templates/BaseGame/game/core/Core.cs
+++ b/Templates/BaseGame/game/core/Core.cs
@@ -65,9 +65,6 @@ function CoreModule::onCreate(%this)
    {
       if(isFile("tools/main.cs") && !$isDedicated)
          exec("tools/main.cs");
-         
-      ModuleDatabase.scanModules( "tools", false );
-      ModuleDatabase.LoadGroup( "Tools" );
    }
    
    //This is used to build the remap keybind sets for the different actionMaps.

--- a/Templates/BaseGame/game/tools/assetBrowser/main.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/main.cs
@@ -118,6 +118,8 @@ function initializeAssetBrowser()
    Input::GetEventManager().subscribe( AssetBrowser, "DropFile" );
    Input::GetEventManager().subscribe( AssetBrowser, "EndDropFiles" );
    
+   AssetBrowserPlugin.initSettings();
+   
    if(!isObject(AssetImportSettings))
    {
       new Settings(AssetImportSettings) 
@@ -149,12 +151,6 @@ function initializeAssetBrowser()
       new ArrayObject(AssetSearchTerms);
       
    ImportAssetWindow.importingFilesArray = new ArrayObject();
-   
-   //if(!isObject(SessionImportAssetItems))
-   //   new ArrayObject(SessionImportAssetItems);
-      
-   //if(!isObject(ImportAssetItems))
-   //   new ArrayObject(ImportAssetItems);  
       
    ImportAssetWindow.importer = new AssetImporter();
       
@@ -169,6 +165,34 @@ function AssetBrowserPlugin::onWorldEditorStartup( %this )
 { 
    // Add ourselves to the toolbar.
    AssetBrowser.addToolbarButton();
+}
+
+function AssetBrowserPlugin::initSettings( %this )
+{
+   EditorSettings.beginGroup( "Assets", true );
+
+   EditorSettings.setDefaultValue( "AssetImporDefaultConfig",    "DefaultConfig" );
+   EditorSettings.setDefaultValue( "AutoImport", 1 );
+   
+   EditorSettings.beginGroup( "Browser" );
+   
+   EditorSettings.setDefaultValue( "showCoreModule", 0 );
+   EditorSettings.setDefaultValue( "showToolsModule", 0 );
+   EditorSettings.setDefaultValue( "showOnlyPopulatedModule", 0 );
+   EditorSettings.setDefaultValue( "showFolders", 1 );
+   EditorSettings.setDefaultValue( "showEmptyFolders", 1 );
+   EditorSettings.setDefaultValue( "previewTileSize", 1.0 );
+   
+   EditorSettings.endGroup();
+   EditorSettings.endGroup();
+
+   EditorSettings.beginGroup( "AssetManagement", true );
+   EditorSettings.beginGroup( "Assets" );
+
+   EditorSettings.setDefaultValue( "promptOnRename", 1 );
+   
+   EditorSettings.endGroup();
+   EditorSettings.endGroup();
 }
 
 function TSStatic::onConstructField(%this, %fieldName, %fieldLabel, %fieldTypeName, %fieldDesc, %fieldDefaultVal, %fieldDataVals, %callbackName, %ownerObj)

--- a/Templates/BaseGame/game/tools/convexEditor/main.cs
+++ b/Templates/BaseGame/game/tools/convexEditor/main.cs
@@ -93,6 +93,8 @@ function ConvexEditorPlugin::onWorldEditorStartup( %this )
    
    exec( "./convexEditorSettingsTab.ed.gui" );
    //ESettingsWindow.addTabPage( EConvexEditorSettingsPage );
+   
+   ESettingsWindow.addEditorSettingsPage("ConvexEditor", "Convex Editor");
 }
 
 function ConvexEditorPlugin::onActivated( %this )
@@ -209,6 +211,13 @@ function ConvexEditorPlugin::initSettings( %this )
    EditorSettings.beginGroup( "ConvexEditor", true );
    EditorSettings.setDefaultValue(  "MaterialName",         "Grid_512_Orange" );
    EditorSettings.endGroup();
+}
+
+function ESettingsWindow::getConvexEditorSettings(%this)
+{
+   SettingsInspector.startGroup("General");
+   SettingsInspector.addSettingsField("ConvexEditor/MaterialName", "Default Material Name", "string", "");
+   SettingsInspector.endGroup();
 }
 
 function ConvexEditorPlugin::readSettings( %this )

--- a/Templates/BaseGame/game/tools/gui/editorSettingsWindow.ed.cs
+++ b/Templates/BaseGame/game/tools/gui/editorSettingsWindow.ed.cs
@@ -288,6 +288,10 @@ function ESettingsWindow::getAxisSettings(%this)
 
 function ESettingsWindow::getGeneralSettings(%this)
 {
+   SettingsInspector.startGroup("Autosave");
+   SettingsInspector.addSettingsField("WorldEditor/AutosaveInterval", "Autosave Interval(in minutes)", "int", "");
+   SettingsInspector.endGroup();
+   
    SettingsInspector.startGroup("Paths");
    SettingsInspector.addSettingsField("WorldEditor/torsionPath", "Torsion Path", "filename", "");
    SettingsInspector.endGroup();
@@ -300,9 +304,9 @@ function ESettingsWindow::getGeneralSettings(%this)
    SettingsInspector.endGroup();
    
    SettingsInspector.startGroup("Layout");
-   SettingsInspector.addSettingsField("WorldEditor/Layout/LayoutMode", "Editor Layout Mode", "list", "This dictates which layout style the editor should use." @
+   /*SettingsInspector.addSettingsField("WorldEditor/Layout/LayoutMode", "Editor Layout Mode", "list", "This dictates which layout style the editor should use." @
                                                                                                       "WARNING - Modern layout is highlight experimental." @
-                                                                                                      "Updating this requires a restart of the program", "Classic,Modern");
+                                                                                                      "Updating this requires a restart of the program", "Classic,Modern");*/
    SettingsInspector.endGroup();
 }  
 
@@ -315,21 +319,21 @@ function ESettingsWindow::getCameraSettings(%this)
    
    //Based on currently loaded level(rootScene)
    SettingsInspector.startGroup(EditorSettings.value("WorldEditor/newLevelFile") @ " Camera");
-   SettingsInspector.addSettingsField("WorldEditor/newLevelFile", "Camera Speed Min", "float", "");
-   SettingsInspector.addSettingsField("WorldEditor/torsionPath", "Camera Speed Max", "200", "");
+   SettingsInspector.addSettingsField("Camera/cameraMinSpeed", "Camera Speed Min", "float", "");
+   SettingsInspector.addSettingsField("Camera/cameraMaxSpeed", "Camera Speed Max", "200", "");
    SettingsInspector.endGroup();
 }  
 
 function ESettingsWindow::getNavEditorSettings(%this)
 {
    SettingsInspector.startGroup("Test Spawn");
-   SettingsInspector.addSettingsField("WorldEditor/newLevelFile", "Spawn Class", "list", "", "AIPlayer");
-   SettingsInspector.addSettingsField("WorldEditor/torsionPath", "Datablock", "string", "");
+   SettingsInspector.addSettingsField("NavEditor/SpawnClass", "Spawn Class", "list", "", "AIPlayer");
+   SettingsInspector.addSettingsField("NavEditor/SpawnDatablock", "Datablock", "string", "");
    SettingsInspector.endGroup();
    
    SettingsInspector.startGroup("Colors");
-   SettingsInspector.addSettingsField("WorldEditor/newLevelFile", "Hover Spline", "colorI", "");
-   SettingsInspector.addSettingsField("WorldEditor/forceLoadDAE", "Select Spline", "colorI", "");
+   SettingsInspector.addSettingsField("NavEditor/HoverSplineColor", "Hover Spline", "colorI", "");
+   SettingsInspector.addSettingsField("NavEditor/SelectedSplineColor", "Select Spline", "colorI", "");
    SettingsInspector.endGroup();
 }
 
@@ -362,19 +366,37 @@ function ESettingsWindow::getSceneEditorSettings(%this)
    SettingsInspector.startGroup("Layout");
    SettingsInspector.addSettingsField("WorldEditor/forceSidebarToSide", "Force Sidebar Window(s) to side", "bool", "1");
    SettingsInspector.endGroup();
+   
+   SettingsInspector.startGroup("Behavior");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/snapGround", "Snap Objects to Ground", "bool", "0");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/TerrainSnapOffsetZ", "Add Offset of Terrain Snapping on Z Axis", "bool", "0");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/OffsetZValue", "Offset Z Value", "float", "0.01");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/snapSoft", "Do Soft Snap", "bool", "0");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/snapSoftSize", "Soft Snap Size", "bool", "2");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/boundingBoxCollision", "Use Bounding Box for Collision", "bool", "0");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/objectsUseBoxCenter", "Objects Use Box Center", "bool", "1");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/dropAtScreenCenterScalar", "Drop at Sceen Center Scalar", "bool", "1");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/dropAtScreenCenterMax", "Drop at Screen Center Max Dist.", "float", "100");
+   SettingsInspector.endGroup();
+   
+   SettingsInspector.startGroup("Images");
+   SettingsInspector.addSettingsField("WorldEditor/Images/defaultHandle", "Default Handle Image", "string", "");
+   SettingsInspector.addSettingsField("WorldEditor/Images/lockedHandle", "Locked Handle Image", "string", "");
+   SettingsInspector.addSettingsField("WorldEditor/Images/selectHandle", "Selected Handle Image", "string", "");
+   SettingsInspector.endGroup();
 }
 
 function ESettingsWindow::getShapeEditorSettings(%this)
 {
    SettingsInspector.startGroup("Colors");
-   SettingsInspector.addSettingsField("WorldEditor/newLevelFile", "Sun Diffuse", "colorI", "");
-   SettingsInspector.addSettingsField("WorldEditor/newLevelFile", "Sun Ambient", "colorI", "");
-   SettingsInspector.addSettingsField("WorldEditor/newLevelFile", "Background", "colorI", "");
+   SettingsInspector.addSettingsField("ShapeEditor/SunDiffuseColor", "Sun Diffuse", "colorI", "");
+   SettingsInspector.addSettingsField("ShapeEditor/SunAmbientColor", "Sun Ambient", "colorI", "");
+   SettingsInspector.addSettingsField("ShapeEditor/BackgroundColor", "Background", "colorI", "");
    SettingsInspector.endGroup();
    
    SettingsInspector.startGroup("Grid");
-   SettingsInspector.addSettingsField("WorldEditor/newLevelFile", "Grid Size", "float", "");
-   SettingsInspector.addSettingsField("WorldEditor/newLevelFile", "Grid Dimension", "vector2", "");
+   SettingsInspector.addSettingsField("ShapeEditor/GridSize", "Grid Size", "float", "");
+   SettingsInspector.addSettingsField("ShapeEditor/GridDimension", "Grid Dimension", "vector2", "");
    SettingsInspector.endGroup();
 }
 
@@ -484,7 +506,6 @@ function ESettingsWindow::getAssetEditingSettings(%this)
    SettingsInspector.addSettingsField("Assets/Browser/showOnlyPopulatedModule", "Show Only Modules with Assets in Asset Browser", "bool", "");
    SettingsInspector.addSettingsField("Assets/Browser/showFolders", "Show Folders in Tiles view in Asset Browser", "bool", "");
    SettingsInspector.addSettingsField("Assets/Browser/showEmptyFolders", "Show Empty Folders in Tiles view in Asset Browser", "bool", "");
-   SettingsInspector.addSettingsField("Assets/Browser/previewTileSize", "Asset Preview Tile Size", "bool", "");
    SettingsInspector.addSettingsField("Assets/Browser/showLooseFiles", "Show Loose Files when viewing in Asset Browser", "bool", "");
    SettingsInspector.addSettingsField("AssetManagement/Assets/promptOnRename", "Prompt on Rename", "bool", "");
    SettingsInspector.endGroup();

--- a/Templates/BaseGame/game/tools/main.cs
+++ b/Templates/BaseGame/game/tools/main.cs
@@ -38,6 +38,10 @@ if(!$Tools::loaded)
    new Settings(EditorSettings) { file = "tools/settings.xml"; };
    EditorSettings.read();
    
+   //We may need to lean on certain EditorSettings, and specifically default values if the settings.xml
+   //isn't found
+   exec("tools/worldEditor/scripts/editorPrefs.ed.cs");
+   
    exec( "tools/gui/profiles.ed.cs" );
    exec("tools/gui/EditorLoadingGui.gui");
 }

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -256,7 +256,10 @@ function EditorGui::init(%this)
    
    // make sure to show the default world editor guis
    EditorGui.bringToFront( EWorldEditor );
-   EWorldEditor.setVisible( false );       
+   EWorldEditor.setVisible( false );  
+   
+   // Start up the settings window
+   ESettingsWindow.startup();     
    
    // Call the startup callback on the editor plugins.   
    for ( %i = 0; %i < EditorPluginSet.getCount(); %i++ )
@@ -266,9 +269,6 @@ function EditorGui::init(%this)
    }
    
    callOnModules("onWorldEditorStartup", "Tools");
-
-   // With everything loaded, start up the settings window
-   ESettingsWindow.startup();
    
    // Start up initial editor plugin.
    
@@ -1631,7 +1631,7 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
       %popup.item[ 0 ] = "Delete" TAB "" TAB "EditorMenuEditDelete();";
       %popup.item[ 1 ] = "Group" TAB "" TAB "EWorldEditor.addSimGroup( true );";
       %popup.item[ 2 ] = "-";
-      %popup.item[ 1 ] = "Make select a Sub-Level" TAB "" TAB "MakeSelectionASublevel();";
+      %popup.item[ 3 ] = "Make select a Sub-Level" TAB "" TAB "MakeSelectionASublevel();";
    }
    else
    {
@@ -1925,6 +1925,10 @@ function Editor::open(%this)
    
    if(EditorSettings.value("WorldEditor/Layout/LayoutMode", "Classic") $= "Modern")
       togglePanelLayout();
+      
+   %autosaveInterval = EditorSettings.value("WorldEditor/AutosaveInterval", "5");
+   %autosaveInterval = %autosaveInterval * 60000; //convert to milliseconds from minutes
+   EditorGui.autosaveSchedule = schedule( %autosaveInterval, 0, "EditorAutoSaveMission" );
 }
 
 function Editor::close(%this, %gui)

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editorPrefs.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editorPrefs.ed.cs
@@ -32,7 +32,8 @@ EditorSettings.setDefaultValue(  "forceLoadDAE",            "0"               );
 EditorSettings.setDefaultValue(  "displayType",             $EditTsCtrl::DisplayTypePerspective );
 EditorSettings.setDefaultValue(  "orthoFOV",                "50" );
 EditorSettings.setDefaultValue(  "orthoShowGrid",           "1" );
-EditorSettings.setDefaultValue(  "currentEditor",           "WorldEditorInspectorPlugin" );
+EditorSettings.setDefaultValue(  "AutosaveInterval",        "5" );
+EditorSettings.setDefaultValue(  "forceSidebarToSide",        "1" );
 
 if( isFile( "C:/Program Files/Torsion/Torsion.exe" ) )
    EditorSettings.setDefaultValue(  "torsionPath",          "C:/Program Files/Torsion/Torsion.exe" );
@@ -172,6 +173,36 @@ EditorSettings.endGroup();
 EditorSettings.beginGroup( "TerrainPainter", true );
 EditorSettings.endGroup();
 
+//-------------------------------------
+
+//-------------------------------------
+EditorSettings.beginGroup( "Theme", true );
+EditorSettings.setDefaultValue(  "headerColor",             "50 49 48 255");
+EditorSettings.setDefaultValue(  "windowBackgroundColor",   "32 31 30 255");
+
+EditorSettings.setDefaultValue(  "tabsColor",               "37 36 35 255" );
+EditorSettings.setDefaultValue(  "tabsHLColor",             "50 49 48 255" );
+EditorSettings.setDefaultValue(  "tabsSELColor",            "59 58 57 255" );
+
+EditorSettings.setDefaultValue(  "dividerDarkColor",        "17 16 15 255");
+EditorSettings.setDefaultValue(  "dividerMidColor",         "50 49 48 255");
+EditorSettings.setDefaultValue(  "dividerLightColor",       "96 94 92 255");
+
+EditorSettings.setDefaultValue(  "headerTextColor",         "236 234 232 255");
+
+EditorSettings.setDefaultValue(  "fieldTextColor",          "178 175 172 255");
+EditorSettings.setDefaultValue(  "fieldTextHLColor",        "234 232 230 255");
+EditorSettings.setDefaultValue(  "fieldTextSELColor",       "255 255 255 255");
+EditorSettings.setDefaultValue(  "fieldTextNAColor",        "120 120 120 255");
+
+EditorSettings.setDefaultValue(  "fieldBGColor",            "59 58 57 255");
+EditorSettings.setDefaultValue(  "fieldBGHLColor",          "72 70 68 255");
+EditorSettings.setDefaultValue(  "fieldBGSELColor",         "100 98 96 255");
+
+EditorSettings.setDefaultValue(  "tooltipBGColor",          "43 43 43 255");
+EditorSettings.setDefaultValue(  "tooltipTextColor",        "255 255 255 255");
+EditorSettings.setDefaultValue(  "tooltipDivColor",         "72 70 68 255");
+EditorSettings.endGroup();
 //-------------------------------------
 
 //TODO: this doesn't belong here


### PR DESCRIPTION
Added autosave logic to the world editor. Via a schedule, it will autosave to tool/autosave to create a backup of the current dirty scene
Fixed RMB menu on multi select objects in the Scene Tree so it will properly display the full list of actions
Fixed up several spots of editor settings fields being incorrect copy-pastes
Integrated AssetBrowser tool into the standard initSettings hook-through for proper default settings integration
Added Editor Theme settings to the default value init'ing of the World Editor
Shifted exec of editor settings default values as part of the initial editor load to ensure that if the settings.xml is deleted, theme info reverts back to the default
Integrated Convex Editor's settings into new EditorSettings window system
Added several missing World Editor settings to Editor Settings Window