### PR TITLE
Misc fixes for Asset Browser navigation, scene asset utilization and editor settings

### DIFF
--- a/Engine/source/T3D/Scene.cpp
+++ b/Engine/source/T3D/Scene.cpp
@@ -260,7 +260,14 @@ bool Scene::saveScene(StringTableEntry fileName)
 
    for (U32 i = 0; i < utilizedAssetsList.size(); i++)
    {
-      levelAssetDef->addAssetDependencyField("staticObjectAssetDependency", utilizedAssetsList[i]);
+      char depSlotName[50];
+      dSprintf(depSlotName, sizeof(depSlotName), "%s%d", "staticObjectAssetDependency", i);
+
+      char depValue[255];
+      dSprintf(depValue, sizeof(depValue), "@Asset=%s", utilizedAssetsList[i]);
+
+      levelAssetDef->setDataField(StringTable->insert(depSlotName), NULL, StringTable->insert(depValue));
+
    }
 
    saveSuccess = levelAssetDef->saveAsset();
@@ -280,8 +287,6 @@ void Scene::getUtilizedAssetsFromSceneObject(SimObject* object, Vector<StringTab
       for (U32 c = 0; c < group->size(); c++)
       {
          SceneObject* childObj = dynamic_cast<SceneObject*>(group->getObject(c));
-         if (childObj)
-            childObj->getUtilizedAssets(usedAssetsList);
 
          //Recurse down
          getUtilizedAssetsFromSceneObject(childObj, usedAssetsList);

--- a/Engine/source/T3D/Scene.cpp
+++ b/Engine/source/T3D/Scene.cpp
@@ -253,9 +253,9 @@ bool Scene::saveScene(StringTableEntry fileName)
 
    //Next, lets build out our 
    Vector<StringTableEntry> utilizedAssetsList;
-   for (U32 i = 0; i < mPermanentObjects.size(); i++)
+   for (U32 i = 0; i < size(); i++)
    {
-      mPermanentObjects[i]->getUtilizedAssets(&utilizedAssetsList);
+      getUtilizedAssetsFromSceneObject(getObject(i), &utilizedAssetsList);
    }
 
    for (U32 i = 0; i < utilizedAssetsList.size(); i++)
@@ -266,6 +266,27 @@ bool Scene::saveScene(StringTableEntry fileName)
    saveSuccess = levelAssetDef->saveAsset();
 
    return saveSuccess;
+}
+
+void Scene::getUtilizedAssetsFromSceneObject(SimObject* object, Vector<StringTableEntry>* usedAssetsList)
+{
+   SceneObject* obj = dynamic_cast<SceneObject*>(object);
+   if(obj)
+      obj->getUtilizedAssets(usedAssetsList);
+
+   SimGroup* group = dynamic_cast<SimGroup*>(object);
+   if (group)
+   {
+      for (U32 c = 0; c < group->size(); c++)
+      {
+         SceneObject* childObj = dynamic_cast<SceneObject*>(group->getObject(c));
+         if (childObj)
+            childObj->getUtilizedAssets(usedAssetsList);
+
+         //Recurse down
+         getUtilizedAssetsFromSceneObject(childObj, usedAssetsList);
+      }
+   }
 }
 
 //

--- a/Engine/source/T3D/Scene.h
+++ b/Engine/source/T3D/Scene.h
@@ -77,6 +77,8 @@ public:
    //
    Vector<SceneObject*> getObjectsByClass(String className, bool checkSubscenes);
 
+   void getUtilizedAssetsFromSceneObject(SimObject* object, Vector<StringTableEntry>* usedAssetsList);
+
    template <class T>
    Vector<T*> getObjectsByClass(bool checkSubscenes);
 

--- a/Engine/source/T3D/prefab.cpp
+++ b/Engine/source/T3D/prefab.cpp
@@ -558,6 +558,19 @@ bool Prefab::buildExportPolyList(ColladaUtils::ExportData* exportData, const Box
    return true;
 }
 
+void Prefab::getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList)
+{
+   Vector<SceneObject*> foundObjects;
+   mChildGroup->findObjectByType(foundObjects);
+
+   for (S32 i = 0; i < foundObjects.size(); i++)
+   {
+      SceneObject* child = foundObjects[i];
+
+      child->getUtilizedAssets(usedAssetsList);
+   }
+}
+
 ExplodePrefabUndoAction::ExplodePrefabUndoAction( Prefab *prefab )
 : UndoAction( "Explode Prefab" )
 {

--- a/Engine/source/T3D/prefab.h
+++ b/Engine/source/T3D/prefab.h
@@ -100,6 +100,8 @@ public:
 
    bool buildExportPolyList(ColladaUtils::ExportData* exportData, const Box3F &box, const SphereF &);
 
+   virtual void getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList);
+
 protected:
 
    void _closeFile( bool removeFileNotify );

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -511,8 +511,9 @@ bool TSStatic::_createShape()
    }
 
    //Set up the material slot vars for easy manipulation
-   S32 materialCount = mShape->materialList->getMaterialNameList().size(); //mMeshAsset->getMaterialCount();
+   /*S32 materialCount = mShape->materialList->getMaterialNameList().size(); //mMeshAsset->getMaterialCount();
 
+   //Temporarily disabled until fixup of materialName->assetId lookup logic is sorted for easy persistance
    if (isServerObject())
    {
       char matFieldName[128];
@@ -526,15 +527,13 @@ bool TSStatic::_createShape()
 
          setDataField(matFld, NULL, materialname);
       }
-   }
+   }*/
 
    return true;
 }
 
 void TSStatic::onDynamicModified(const char* slotName, const char* newValue)
 {
-   bool isSrv = isServerObject();
-
    if (FindMatch::isMatch("materialslot*", slotName, false))
    {
       if (!getShape())

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -1692,8 +1692,9 @@ void TSStatic::updateMaterials()
 
 void TSStatic::getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList)
 {
-   if(!mShapeAsset.isNull())
-      usedAssetsList->push_back_unique(mShapeAssetId);
+   if(!mShapeAsset.isNull() && mShapeAsset->getAssetId() != StringTable->insert("Core_Rendering:noShape"))
+      usedAssetsList->push_back_unique(mShapeAsset->getAssetId());
+
 }
 
 //------------------------------------------------------------------------

--- a/Engine/source/console/simSet.cpp
+++ b/Engine/source/console/simSet.cpp
@@ -843,6 +843,17 @@ bool SimGroup::processArguments(S32, ConsoleValueRef *argv)
    return true;
 }
 
+
+SimObject* SimGroup::getObject(const S32& index)
+{
+   if (index < 0 || index >= size())
+   {
+      Con::errorf("Set::getObject - index out of range.");
+      return NULL;
+   }
+
+   return (*this)[index];
+}
 //-----------------------------------------------------------------------------
 
 SimObject* SimGroupIterator::operator++()

--- a/Engine/source/console/simSet.h
+++ b/Engine/source/console/simSet.h
@@ -465,6 +465,8 @@ class SimGroup: public SimSet
 
       virtual bool processArguments( S32 argc, ConsoleValueRef *argv );
 
+      virtual SimObject* getObject(const S32& index);
+
       DECLARE_CONOBJECT( SimGroup );
 };
 

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -1423,7 +1423,7 @@ void TerrainBlock::getMinMaxHeight( F32 *minHeight, F32 *maxHeight ) const
 void TerrainBlock::getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList)
 {
    if (!mTerrainAsset.isNull())
-      usedAssetsList->push_back_unique(mTerrainAssetId);
+      usedAssetsList->push_back_unique(mTerrainAsset->getAssetId());
 }
 //-----------------------------------------------------------------------------
 // Console Methods

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.cs
@@ -446,7 +446,10 @@ function AssetBrowser::buildMaterialAssetPreview(%this, %assetDef, %previewData)
                                    @ "EditorGui.setEditor(MaterialEditorPlugin); "
                                    @ "AssetBrowser.hideDialog();";*/
                                    
-   %previewData.doubleClickCommand = "AssetBrowser.editAsset(" @ %assetDef @ ");";
+   if(%this.selectMode)
+      %previewData.doubleClickCommand = "AssetBrowser.selectAsset( AssetBrowser.selectedAsset );";
+   else
+      %previewData.doubleClickCommand = "AssetBrowser.editAsset( "@%assetDef@" );";
    
    %test = %assetDef.materialDefinitionName.diffuseMapAsset[0];
    

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.cs
@@ -247,7 +247,7 @@ function AssetBrowser::buildShapeAssetPreview(%this, %assetDef, %previewData)
    %previewData.assetName = %assetDef.assetName;
    %previewData.assetPath = %assetDef.fileName;
 
-   %previewData.previewImage = %assetDef.fileName;
+   %previewData.previewImage = "tools/assetBrowser/art/genericAssetIcon";//%assetDef.fileName;
    
    %previewData.assetFriendlyName = %assetDef.assetName;
    %previewData.assetDesc = %assetDef.description;
@@ -256,6 +256,10 @@ function AssetBrowser::buildShapeAssetPreview(%this, %assetDef, %previewData)
                            "Asset Definition ID: " @  %assetDef @ "\n" @ 
                            "Shape File path: " @ %assetDef.getShapeFile();
                            
+   if(%this.selectMode)
+      %previewData.doubleClickCommand = "AssetBrowser.selectAsset( AssetBrowser.selectedAsset );";
+   else
+      %previewData.doubleClickCommand = "AssetBrowser.editAsset( "@%assetDef@" );";
 }
 
 function AssetBrowser::onShapeAssetEditorDropped(%this, %assetDef, %position)

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/sound.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/sound.cs
@@ -4,6 +4,11 @@ function AssetBrowser::buildSoundAssetPreview(%this, %assetDef, %previewData)
    %previewData.assetPath = %assetDef.soundFilePath;
    //%previewData.doubleClickCommand = "EditorOpenFileInTorsion( "@%previewData.assetPath@", 0 );";
    
+   if(%this.selectMode)
+      %previewData.doubleClickCommand = "AssetBrowser.selectAsset( AssetBrowser.selectedAsset );";
+   else
+      %previewData.doubleClickCommand = "AssetBrowser.editAsset( "@%assetDef@" );";
+   
    %previewData.previewImage = "tools/assetBrowser/art/soundIcon";   
    
    %previewData.assetFriendlyName = %assetDef.assetName;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/directoryHandling.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/directoryHandling.cs
@@ -143,7 +143,7 @@ function directoryHandler::navigateTo(%this, %address, %historyNav, %selectionNa
    {
       %this.foreHistoryList.empty();  
       
-      if(%oldAddress !$= "") 
+      if(%this.oldAddress !$= "") 
          %this.prevHistoryList.push_front(%this.oldAddress);
    }
    

--- a/Templates/BaseGame/game/tools/gui/editorSettingsWindow.ed.cs
+++ b/Templates/BaseGame/game/tools/gui/editorSettingsWindow.ed.cs
@@ -359,8 +359,6 @@ function ESettingsWindow::getSceneEditorSettings(%this)
    SettingsInspector.startGroup("Misc");
    //SettingsInspector.addSettingsField("WorldEditor/forceLoadDAE", "Force Load DAE", "bool", "");
    SettingsInspector.addSettingsField("WorldEditor/forceLoadDAE", "Force Load DAE", "bool", "");
-   SettingsInspector.addSettingsField("WorldEditor/Tools/dropAtScreenCenterScalar", "Screen Center Scalar", "float", "");
-   SettingsInspector.addSettingsField("WorldEditor/Tools/dropAtScreenCenterMax", "Screen Center Max", "float", "");
    SettingsInspector.endGroup();
    
    SettingsInspector.startGroup("Layout");
@@ -377,6 +375,7 @@ function ESettingsWindow::getSceneEditorSettings(%this)
    SettingsInspector.addSettingsField("WorldEditor/Tools/objectsUseBoxCenter", "Objects Use Box Center", "bool", "1");
    SettingsInspector.addSettingsField("WorldEditor/Tools/dropAtScreenCenterScalar", "Drop at Sceen Center Scalar", "bool", "1");
    SettingsInspector.addSettingsField("WorldEditor/Tools/dropAtScreenCenterMax", "Drop at Screen Center Max Dist.", "float", "100");
+   SettingsInspector.addSettingsField("WorldEditor/Tools/UseGroupCenter", "Use Group Center when snapping", "bool", "0");
    SettingsInspector.endGroup();
    
    SettingsInspector.startGroup("Images");

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.cs
@@ -1651,6 +1651,7 @@ function EditorTree::onRightMouseUp( %this, %itemId, %mouse, %obj )
          %popup.item[ 1 ] = "Delete" TAB "" TAB "EWorldEditor.deleteMissionObject(" @ %popup.object @ ");";
          %popup.item[ 2 ] = "Inspect" TAB "" TAB "inspectObject(" @ %popup.object @ ");";
          %popup.item[ 3 ] = "-";
+         %popup.item[ 4 ] = "Add SimGroup" TAB "" TAB "EWorldEditor.addSimGroup( false );";
       }
       else 
       {
@@ -2067,6 +2068,9 @@ function EWorldEditor::syncGui( %this )
    ESnapOptions-->GridSize.setText( EWorldEditor.getGridSize() );
    
    ESnapOptions-->GridSnapButton.setStateOn( %this.getGridSnap() );
+   
+   %this.UseGroupCenter = EditorSettings.value("WorldEditor/Tools/UseGroupCenter");
+   
    ESnapOptions-->GroupSnapButton.setStateOn( %this.UseGroupCenter );
    SnapToBar-->objectGridSnapBtn.setStateOn( %this.getGridSnap() );
    ESnapOptions-->NoSnapButton.setStateOn( !%this.stickToGround && !%this.getSoftSnap() && !%this.getGridSnap() );
@@ -2090,7 +2094,7 @@ function EWorldEditor::syncToolPalette( %this )
 function EWorldEditor::addSimGroup( %this, %groupCurrentSelection )
 {
    %activeSelection = %this.getActiveSelection();
-   if ( %activeSelection.getObjectIndex( getScene(0) ) != -1 )
+   if ( %groupCurrentSelection && %activeSelection.getObjectIndex( getScene(0) ) != -1 )
    {
       toolsMessageBoxOK( "Error", "Cannot add Scene to a new SimGroup" );
       return;
@@ -2324,6 +2328,7 @@ function toggleSnappingOptions( %var )
    else if( %var $= "byGroup" )
    {
 	   EWorldEditor.UseGroupCenter = !EWorldEditor.UseGroupCenter;
+	   EditorSettings.setValue("WorldEditor/Tools/UseGroupCenter", EWorldEditor.UseGroupCenter );
 	   ESnapOptions->GroupSnapButton.setStateOn(EWorldEditor.UseGroupCenter);
    }
    else

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editorPrefs.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editorPrefs.ed.cs
@@ -68,6 +68,7 @@ EditorSettings.setDefaultValue(  "boundingBoxCollision",    "0"               );
 EditorSettings.setDefaultValue(  "objectsUseBoxCenter",     "1"               );
 EditorSettings.setDefaultValue(  "dropAtScreenCenterScalar","1.0"             );
 EditorSettings.setDefaultValue(  "dropAtScreenCenterMax",   "100.0"           );
+EditorSettings.setDefaultValue(  "UseGroupCenter",          "0"               );
 EditorSettings.endGroup();
 
 EditorSettings.beginGroup( "Render" );

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/objectSnapOptions.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/objectSnapOptions.ed.cs
@@ -45,6 +45,7 @@ function ESnapOptions::ToggleVisibility()
    }
    else
    {
+      EWorldEditor.syncGui();
       ESnapOptions.setVisible(true);
       ESnapOptions.selectWindow();
       ESnapOptions.setCollapseGroup(false);


### PR DESCRIPTION
Added recursive scanning for utilized assets on any object within the scene, soas to catch objects in simgroups or parented
Disabled initial materialSlot fill-out until logic for looking up assetName from material list name can be done to avoid 'unable to find assetid' spam
Added function to SimGroup to easily acquire child object by index
Some minor cleanup of commented lines in asset browser
Fixed forward/backward navigation arrow behavior in asset browser
Fixed double-click navigation when the AB is in select mode
Fixed erroneous 'could not acquire asset' messages when navigating folders in AB
Added editor setting for UseGroupSnap snap option and integrated it into the UI interface
Removed some duplicate settings from the EditorSettingsWindow