### PR TITLE
Misc asset browser/asset creation fixes

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/guis/selectPath.gui
+++ b/Templates/BaseGame/game/tools/assetBrowser/guis/selectPath.gui
@@ -250,6 +250,7 @@
          isContainer = "0";
          canSave = "1";
          canSaveDynamicFields = "0";
+         command="SelectAssetPath.selectPath();";
       };
       new GuiButtonCtrl() {
          text = "New Folder";

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.cs
@@ -593,14 +593,14 @@ function AssetBrowser::loadDirectories( %this )
    %this.loadCreatorClasses();
    
    //If set to, show core
-   if(%this.coreModulesFilter)
+   if(EditorSettings.value("Assets/Browser/showCoreModule", false) == 1)
    {
       %coreItem = AssetBrowser-->filterTree.insertItem(AssetBrowser-->filterTree.modulesIdx, "Core");
       %this.dirHandler.loadFolders("Core", %coreItem);
    }
    
    //If set to, show tools
-   if(%this.toolsModulesFilter)
+   if(EditorSettings.value("Assets/Browser/showToolsModule", false) == 1)
    {
       %toolsItem = AssetBrowser-->filterTree.insertItem(AssetBrowser-->filterTree.modulesIdx, "Tools");
       %this.dirHandler.loadFolders("Tools", %toolsItem);

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/cubemap.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/cubemap.cs
@@ -7,9 +7,10 @@ function AssetBrowser::createCubemapAsset(%this)
    %modulePath = "data/" @ %moduleName;
       
    %assetName = AssetBrowser.newAssetSettings.assetName;
+   %assetPath = AssetBrowser.dirHandler.currentAddress @ "/";  
    
-   %tamlpath = %modulePath @ "/cubemaps/" @ %assetName @ ".asset.taml";
-   %shapeFilePath = %modulePath @ "/cubemaps/" @ %assetName @ ".dae";
+   %tamlpath = %assetPath @ %assetName @ ".asset.taml";
+   %shapeFilePath = %assetPath @ %assetName @ ".dae";
    
    %asset = new CubemapAsset()
    {

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/postFX.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/postFX.cs
@@ -1,14 +1,14 @@
 function AssetBrowser::createPostEffectAsset(%this)
 {
    %moduleName = AssetBrowser.newAssetSettings.moduleName;
-   %modulePath = "data/" @ %moduleName;
       
-   %assetName = AssetBrowser.newAssetSettings.assetName;      
+   %assetName = AssetBrowser.newAssetSettings.assetName;   
+   %assetPath = AssetBrowser.dirHandler.currentAddress @ "/";
    
-   %tamlpath = %modulePath @ "/postFXs/" @ %assetName @ ".asset.taml";
-   %scriptPath = %modulePath @ "/postFXs/" @ %assetName @ ".cs";
-   %hlslPath = %modulePath @ "/postFXs/" @ %assetName @ "P.hlsl";
-   %glslPath = %modulePath @ "/postFXs/" @ %assetName @ "P.glsl";
+   %tamlpath = %assetPath @ %assetName @ ".asset.taml";
+   %scriptPath = %assetPath @ %assetName @ ".cs";
+   %hlslPath = %assetPath @ %assetName @ "P.hlsl";
+   %glslPath = %assetPath @ %assetName @ "P.glsl";
    
    %asset = new PostEffectAsset()
    {
@@ -24,13 +24,6 @@ function AssetBrowser::createPostEffectAsset(%this)
    %moduleDef = ModuleDatabase.findModule(%moduleName, 1);
 	AssetDatabase.addDeclaredAsset(%moduleDef, %tamlpath);
 
-	AssetBrowser.loadFilters();
-	
-	%treeItemId = AssetBrowserFilterTree.findItemByName(%moduleName);
-	%smItem = AssetBrowserFilterTree.findChildItemByName(%treeItemId, "PostEffectAsset");
-	
-	AssetBrowserFilterTree.onSelect(%smItem);
-	
    %file = new FileObject();
 	%templateFile = new FileObject();
 	

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/stateMachine.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/stateMachine.cs
@@ -2,6 +2,7 @@ function AssetBrowser::createStateMachineAsset(%this)
 {
    %assetName = AssetBrowser.newAssetSettings.assetName;
    %moduleName = AssetBrowser.selectedModule;
+   %assetPath = AssetBrowser.dirHandler.currentAddress @ "/";
       
    %assetQuery = new AssetQuery();
    
@@ -20,8 +21,8 @@ function AssetBrowser::createStateMachineAsset(%this)
    
    %assetQuery.delete();
    
-   %tamlpath = "data/" @ %moduleName @ "/stateMachines/" @ %assetName @ ".asset.taml";
-   %smFilePath = "data/" @ %moduleName @ "/stateMachines/" @ %assetName @ ".xml";
+   %tamlpath = %assetPath @ %assetName @ ".asset.taml";
+   %smFilePath = %assetPath @ %assetName @ ".xml";
    
    %asset = new StateMachineAsset()
    {

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/directoryHandling.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/directoryHandling.cs
@@ -180,7 +180,23 @@ function directoryHandler::navigateHistoryBack(%this)
 
 function directoryHandler::getModuleFromAddress(%this, %address)
 {
-   //break down the address
+   %moduleList = ModuleDatabase.findModules();
+   
+   for(%i=0; %i < getWordCount(%moduleList); %i++)
+   {
+      %module = getWord(%moduleList, %i);
+      %modulePath = makeRelativePath(%module.ModulePath);
+      
+      //We don't want to add stuff directly to the root core or tools modules
+      if(%modulePath $= "Core" || %modulePath $= "Tools")
+         continue;
+         
+      if(startsWith(%address, %modulePath))
+      {
+         return %module;
+      }
+   }
+   /*//break down the address
    %folderCount = getTokenCount(%address, "/");
       
    for(%f=0; %f < %folderCount; %f++)
@@ -190,7 +206,7 @@ function directoryHandler::getModuleFromAddress(%this, %address)
       %module = ModuleDatabase.findModule(%folderName);
       if(%module !$= "")
          return %module;
-   }
+   }*/
    
    return "";
 }

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/newAsset.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/newAsset.cs
@@ -156,7 +156,7 @@ function CreateNewAsset()
    //To enusre that any in-progress-of-being-edited field applies it's changes
    %lastEditField = AssetBrowser_newAsset.getFirstResponder(); 
    
-   if(%lastEditField.isMethod("forceValidateText"))
+   if(isObject(%lastEditField) && %lastEditField.isMethod("forceValidateText"))
       %lastEditField.forceValidateText();
    
    %assetName = AssetBrowser.newAssetSettings.assetName;
@@ -192,6 +192,9 @@ function CreateNewAsset()
 	//Load it
 	%moduleDef = ModuleDatabase.findModule(%moduleName,1);
 	AssetDatabase.addDeclaredAsset(%moduleDef, %assetFilePath);
+	//For utilities' sake, we'll acquire it immediately so it can be utilized 
+	//without delay if it's got any script/dependencies stuff
+	AssetDatabase.acquireAsset("\"" @ %moduleName @ ":" @ %assetName @ "\"");
 	
 	if(AssetBrowser_newAsset.callbackFunc !$= "")
 	{

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/templateFiles/postFXFile.cs.template
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/templateFiles/postFXFile.cs.template
@@ -20,12 +20,14 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+$PostFX::@@::modColor = "1 1 1 1";
+
 singleton ShaderData( @@_Shader )
 {
    DXVertexShaderFile 	= $Core::CommonShaderPath @ "/postFX/postFxV.hlsl";
-   DXPixelShaderFile 	= $Core:modulePath @ "@@P.hlsl";   
+   DXPixelShaderFile 	= "./@@P.hlsl";   
    OGLVertexShaderFile  = $Core::CommonShaderPath @ "/postFX/gl/postFxV.glsl";
-   OGLPixelShaderFile   = $Core:modulePath @ "@@P.glsl";
+   OGLPixelShaderFile   = "./@@P.glsl";
    
    samplerNames[0] = "$inputTex";
    
@@ -55,6 +57,7 @@ singleton GFXStateBlockData( @@_StateBlock )
 
 function @@::setShaderConsts( %this )
 {
+   %this.setShaderConst( "$modColor", $PostFX::@@::modColor );
 }
 
 function @@::preProcess( %this )
@@ -74,6 +77,7 @@ function @@::onEnabled( %this )
 
 function @@::onDisabled( %this )
 {
+   return true;
 }
 
 //This is used to populate the PostFXEditor's settings so the post FX can be edited
@@ -82,8 +86,19 @@ function @@::onDisabled( %this )
 function @@::populatePostFXSettings(%this)
 {
    PostEffectEditorInspector.startGroup("@@ - General");
-   PostEffectEditorInspector.addField("$PostFXManager::Settings::Enabled@@", "Enabled", "bool", "", $PostFXManager::PostFX::Enable@@, "");
+   PostEffectEditorInspector.addCallbackField("$PostFX::@@::Enabled", "Enabled", "bool", "", $PostFX::@@::Enabled, "", "toggle@@");
+   PostEffectEditorInspector.addField("$PostFX::@@::modColor", "Modifier Color", "colorI", "", $PostFX::@@::modColor, "");
    PostEffectEditorInspector.endGroup();
+}
+
+//This is called back from our callbackField defined in populatePostFXSettings to
+//Allow us to easily toggle the postFX and have it respond immediately
+function PostEffectEditorInspector::toggle@@(%this)
+{
+   if($PostFX::@@::Enabled)
+      @@.enable();
+   else
+      @@.disable();
 }
 
 //This function pair(applyFromPreset and settingsApply) are done the way they are, with the separated variables
@@ -91,10 +106,7 @@ function @@::populatePostFXSettings(%this)
 //when rendering. This allows us to modify things but still leave room for reverting or temporarily applying them
 function @@::applyFromPreset(%this)
 {
-   //@@ Settings
-   $PostFXManager::PostFX::Enable@@ = $PostFXManager::Settings::Enabled@@;
-
-   if($PostFXManager::PostFX::Enable@@)
+   if($PostFX::@@::Enabled)
       %this.enable();
    else
       %this.disable();
@@ -102,7 +114,6 @@ function @@::applyFromPreset(%this)
 
 function @@::settingsApply(%this)
 {
-   $PostFXManager::Settings::Enabled@@ = $PostFXManager::PostFX::Enable@@;
 }
 
 //Our actual postFX
@@ -126,7 +137,7 @@ singleton PostEffect( @@ )
    shader = @@_Shader;
    stateBlock = @@_StateBlock;
    texture[0] = "$backBuffer";
-   target = "$outTex";
+   target = "$backBuffer";
    targetFormat = "GFXFormatR16G16B16A16F"; 
    targetScale = "1 1";
 };

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/templateFiles/postFXFileP.glsl.template
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/templateFiles/postFXFileP.glsl.template
@@ -27,9 +27,15 @@
 
 uniform sampler2D inputTex;
 
+in vec4 modColor;
+
 out vec4 OUT_col;
 
 void main()
 {
-   OUT_col = hdrEncode( vec4(1,1,1,1) );
+   vec4 color = texture(inputTex, IN_uv0);
+   
+   color *= modColor;
+   
+   OUT_col = hdrEncode( color );
 }

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/templateFiles/postFXFileP.hlsl.template
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/templateFiles/postFXFileP.hlsl.template
@@ -25,7 +25,13 @@
 
 TORQUE_UNIFORM_SAMPLER2D(inputTex, 0);
 
+uniform float4 modColor;
+
 float4 main( PFXVertToPix IN ) : TORQUE_TARGET0
 {
-   return hdrEncode( float4(1,1,1,1) );
+   float4 color = TORQUE_TEX2D( inputTex, IN.uv0 );
+
+   color *= modColor;
+
+   return hdrEncode( color );
 }


### PR DESCRIPTION
Fixes regression of Select Asset Path selection
Fixes setting for showing core and tools dirs in Asset Browser
Fixes path for newly created PostFX, state machine and cubemap assets
Improves logic for getModuleFromAddress from asset browser directory handler
Prevents error if no field was edited in the Create New Asset window before hitting the create button
Forces acquiring newly created asset just so they can be utilized immediately
Updates PostFXAsset template files to better hook in and provide a better example of basic behaviors.