### PR TITLE
minor cleanups:

### DIFF
--- a/Engine/source/gfx/gl/gfxGLTextureObject.cpp
+++ b/Engine/source/gfx/gl/gfxGLTextureObject.cpp
@@ -185,8 +185,6 @@ bool GFXGLTextureObject::copyToBmp(GBitmap * bmp)
       U8* orig = (U8*)mem.alloc(srcPixelCount * srcBytesPerPixel);
 
       glGetTexImage(mBinding, mip, GFXGLTextureFormat[mFormat], GFXGLTextureType[mFormat], orig);
-
-      PROFILE_START(GFXGLTextureObject_copyToBmp_pixCopy);
       if (mFormat == GFXFormatR16G16B16A16F)
       {
          dMemcpy(dest, orig, srcPixelCount * srcBytesPerPixel);
@@ -207,7 +205,6 @@ bool GFXGLTextureObject::copyToBmp(GBitmap * bmp)
       }
    }
    glBindTexture(mBinding, NULL);
-   PROFILE_END();
 
    return true;
 }

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.h
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.h
@@ -164,7 +164,7 @@ public:
    void addRow(const char* label, const char* bitmapName, const char* callback, S32 icon, S32 yPad, bool enabled, const char* tooltip);
 
    //Removes row at the provided index
-   void GuiGameListMenuCtrl::removeRow(const S32& row);
+   void removeRow(const S32& row);
 
    /// Gets the text for the currently selected option of the given row.
    ///


### PR DESCRIPTION
clean up mismatched  PROFILE_START+PROFILE_END() that was in/out of the mip packign for loop on the gl side, leaving just the self-cleaning PROFILE_SCOPE(GFXGLTextureObject_copyToBmp); similar to the dx11 side
   void GuiGameListMenuCtrl::removeRow(const S32& row); (the GuiGameListMenuCtrl:: bit in the class iteslf is redundant and making linux unhappy)