### PR TITLE
Fix cmake build on linux

### DIFF
--- a/Engine/lib/sdl/CMakeLists.txt
+++ b/Engine/lib/sdl/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "Prevented in-tree built. Please create a build directory outside of the SDL source code and call cmake from there")
 endif()
 


### PR DESCRIPTION
SDL 2.0.10 includes a bug that prevents SDL being built when the calling project is built in-tree, due to its' use of the global variables as opposed to the local variables when checking its requirement to be built out of tree.

Original PR from GarageGames repo:
https://github.com/GarageGames/Torque3D/pull/2383