### PR TITLE
Implementation of guiRenderTargetVizCtrl

### DIFF
--- a/Engine/source/T3D/camera.h
+++ b/Engine/source/T3D/camera.h
@@ -253,6 +253,9 @@ class Camera: public ShapeBase
       DECLARE_DESCRIPTION( "Represents a position, direction and field of view to render a scene from." );
       static F32 getMovementSpeed() { return smMovementSpeed; }
       bool isCamera() const { return true; }
+
+      //Not yet implemented
+      GFXTexHandle getCameraRenderTarget() { return GFXTexHandle(); }
 };
 
 typedef Camera::CameraMotionMode CameraMotionMode;

--- a/Engine/source/gui/utility/guiRenderTargetVizCtrl.cpp
+++ b/Engine/source/gui/utility/guiRenderTargetVizCtrl.cpp
@@ -1,0 +1,130 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2012 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+#include "platform/platform.h"
+#include "gui/utility/guiRenderTargetVizCtrl.h"
+
+#include "console/console.h"
+#include "console/consoleTypes.h"
+#include "gfx/gfxDevice.h"
+#include "gfx/gfxDrawUtil.h"
+#include "gui/core/guiCanvas.h"
+#include "gui/core/guiDefaultControlRender.h"
+
+#include "T3D/camera.h"
+
+IMPLEMENT_CONOBJECT(GuiRenderTargetVizCtrl);
+
+ConsoleDocClass(GuiRenderTargetVizCtrl,
+   "@brief The most widely used button class.\n\n"
+
+   "GuiRenderTargetVizCtrl renders seperately of, but utilizes all of the functionality of GuiBaseButtonCtrl.\n"
+   "This grants GuiRenderTargetVizCtrl the versatility to be either of the 3 button types.\n\n"
+
+   "@tsexample\n"
+   "// Create a PushButton GuiRenderTargetVizCtrl that calls randomFunction when clicked\n"
+   "%button = new GuiRenderTargetVizCtrl()\n"
+   "{\n"
+   "   profile    = \"GuiButtonProfile\";\n"
+   "   buttonType = \"PushButton\";\n"
+   "   command    = \"randomFunction();\";\n"
+   "};\n"
+   "@endtsexample\n\n"
+
+   "@ingroup GuiButtons"
+);
+
+
+//-----------------------------------------------------------------------------
+
+GuiRenderTargetVizCtrl::GuiRenderTargetVizCtrl()
+{
+   mTargetName = StringTable->EmptyString();
+
+   mTarget = nullptr;
+   mTargetTexture = nullptr;
+
+   mCameraObject = nullptr;
+}
+
+//-----------------------------------------------------------------------------
+
+bool GuiRenderTargetVizCtrl::onWake()
+{
+   if (!Parent::onWake())
+      return false;
+
+   return true;
+}
+
+void GuiRenderTargetVizCtrl::initPersistFields()
+{
+   Parent::initPersistFields();
+
+   addField("RenderTargetName", TypeString, Offset(mTargetName, GuiRenderTargetVizCtrl), "");
+   addField("cameraObject", TypeSimObjectPtr, Offset(mCameraObject, GuiRenderTargetVizCtrl), "");
+}
+
+//-----------------------------------------------------------------------------
+
+void GuiRenderTargetVizCtrl::onRender(Point2I      offset,
+   const RectI& updateRect)
+{
+   GFXDrawUtil* drawer = GFX->getDrawUtil();
+
+   RectI boundsRect(offset, getExtent());
+
+   //Draw backdrop
+   GFX->getDrawUtil()->drawRectFill(boundsRect, ColorI::BLACK);
+
+   if (mCameraObject != nullptr)
+   {
+      Camera* camObject = dynamic_cast<Camera*>(mCameraObject);
+
+      camObject = dynamic_cast<Camera*>(camObject->getClientObject());
+
+      bool servObj = camObject->isServerObject();
+
+      if (camObject)
+      {
+         GFXTexHandle targ = camObject->getCameraRenderTarget();
+
+         if (targ)
+         {
+            Point2I size = Point2I(targ->getWidth(), targ->getHeight());
+            drawer->drawBitmapStretchSR(targ, boundsRect, RectI(Point2I::Zero, size));
+         }
+         return;
+      }
+   }
+   else if (mTargetName == StringTable->EmptyString())
+      return;
+
+   NamedTexTarget* namedTarget = NamedTexTarget::find(mTargetName);
+   if (namedTarget)
+   {
+      GFXTextureObject* theTex = namedTarget->getTexture(0);
+      RectI viewport = namedTarget->getViewport();
+
+      drawer->drawBitmapStretchSR(theTex, boundsRect, viewport);
+   }
+}

--- a/Engine/source/gui/utility/guiRenderTargetVizCtrl.h
+++ b/Engine/source/gui/utility/guiRenderTargetVizCtrl.h
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2012 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+#pragma once
+
+#ifndef GUIRENDERTARGETVIZCTRL_H
+#define GUIRENDERTARGETVIZCTRL_H
+
+#ifndef _GUICONTROL_H_
+#include "gui/core/guiControl.h"
+#endif
+#ifndef _TEXTARGETBIN_MGR_H_
+#include "renderInstance/renderTexTargetBinManager.h"
+#endif
+
+class GuiRenderTargetVizCtrl : public GuiControl
+{
+   typedef GuiControl Parent;
+
+   RenderTexTargetBinManager* mRTTManager;
+
+   SimObject* mCameraObject;
+
+   StringTableEntry mTargetName;
+   GFXFormat mTargetFormat;
+   Point2I mTargetSize;
+
+   GFXTextureTargetRef mTarget;
+   GFXTexHandle mTargetTexture;
+
+public:
+   DECLARE_CONOBJECT(GuiRenderTargetVizCtrl);
+   GuiRenderTargetVizCtrl();
+   bool onWake();
+   void onRender(Point2I offset, const RectI &updateRect);
+
+   static void initPersistFields();
+};
+
+#endif //GUIRENDERTARGETVIZCTRL_H

--- a/Engine/source/materials/matTextureTarget.cpp
+++ b/Engine/source/materials/matTextureTarget.cpp
@@ -146,3 +146,15 @@ void NamedTexTarget::getShaderMacros( Vector<GFXShaderMacro> *outMacros )
       outMacros->push_back( macro );
    }
 }
+
+DefineEngineFunction(getNamedTargetList, String, (), , "")
+{
+   String targetList = "";
+   NamedTexTarget::TargetMap targets = NamedTexTarget::getTargetMap();
+   for (NamedTexTarget::TargetMap::Iterator iter = targets.begin(); iter != targets.end(); iter++)
+   {
+      targetList += iter->value->getName() + " ";
+   }
+
+   return targetList;
+}

--- a/Engine/source/materials/matTextureTarget.h
+++ b/Engine/source/materials/matTextureTarget.h
@@ -117,9 +117,13 @@ public:
    ConditionerFeature* getConditioner() const { return mConditioner; }
    void getShaderMacros( Vector<GFXShaderMacro> *outMacros );
 
+   typedef Map<String, NamedTexTarget*> TargetMap;
+
+   static TargetMap getTargetMap() {
+      return smTargets;
+   }
+
 protected:
-   
-   typedef Map<String,NamedTexTarget*> TargetMap;
 
    ///
    static TargetMap smTargets;

--- a/Templates/BaseGame/game/tools/gui/renderTargetVisualizer.ed.cs
+++ b/Templates/BaseGame/game/tools/gui/renderTargetVisualizer.ed.cs
@@ -1,0 +1,33 @@
+function ToggleRenderTargetVisualizer()
+{
+   if(RenderTargetVisualizer.isAwake())
+   {
+      Canvas.popDialog(RenderTargetVisualizer); 
+   }
+   else
+   {
+      Canvas.pushDialog(RenderTargetVisualizer);
+   }
+}
+
+function RenderTargetVisualizer::onWake(%this)
+{
+   %targetsList = getNamedTargetList();
+   
+   %targetsCount = getWordCount(%targetsList);
+   for(%i=0; %i < %targetsCount; %i++)
+   {
+      %targetName = getWord(%targetsList, %i);  
+      RenderTargetsList.add(%targetName, %i);
+   }
+   
+   RenderTargetsList.setSelected( 0, false );
+   RenderTargetVizCtrl.RenderTargetName = RenderTargetsList.getValue();
+}
+
+function RenderTargetsList::updateTarget(%this)
+{
+   %target = RenderTargetsList.getValue();
+
+   RenderTargetVizCtrl.RenderTargetName = %target;
+}

--- a/Templates/BaseGame/game/tools/gui/renderTargetVisualizer.ed.gui
+++ b/Templates/BaseGame/game/tools/gui/renderTargetVisualizer.ed.gui
@@ -1,0 +1,94 @@
+//--- OBJECT WRITE BEGIN ---
+%guiContent = new GuiControl(RenderTargetVisualizer) {
+   position = "0 0";
+   extent = "1024 768";
+   minExtent = "8 2";
+   horizSizing = "right";
+   vertSizing = "bottom";
+   profile = "GuiModelessDialogProfile";
+   visible = "1";
+   active = "1";
+   tooltipProfile = "GuiToolTipProfile";
+   hovertime = "1000";
+   isContainer = "1";
+   canSave = "1";
+   canSaveDynamicFields = "1";
+
+   new GuiWindowCtrl(RenderTargetVizWindow) {
+      text = "Render Target Visualizer";
+      resizeWidth = "1";
+      resizeHeight = "1";
+      canMove = "1";
+      canClose = "1";
+      canMinimize = "1";
+      canMaximize = "1";
+      canCollapse = "0";
+      closeCommand = "Canvas.popDialog(RenderTargetVisualizer);";
+      edgeSnap = "1";
+      margin = "0 0 0 0";
+      padding = "0 0 0 0";
+      anchorTop = "1";
+      anchorBottom = "0";
+      anchorLeft = "1";
+      anchorRight = "0";
+      position = "189 96";
+      extent = "637 535";
+      minExtent = "8 2";
+      horizSizing = "right";
+      vertSizing = "bottom";
+      profile = "GuiWindowProfile";
+      visible = "1";
+      active = "1";
+      tooltipProfile = "GuiToolTipProfile";
+      hovertime = "1000";
+      isContainer = "1";
+      canSave = "1";
+      canSaveDynamicFields = "0";
+
+      new GuiRenderTargetVizCtrl(RenderTargetVizCtrl) {
+         position = "0 38";
+         extent = "636 496";
+         minExtent = "8 2";
+         horizSizing = "width";
+         vertSizing = "height";
+         profile = "GuiDefaultProfile";
+         visible = "1";
+         active = "1";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "0";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+         RenderTargetName = "AL_FormatToken";
+      };
+      new GuiPopUpMenuCtrl(RenderTargetsList) {
+         maxPopupHeight = "200";
+         sbUsesNAColor = "0";
+         reverseTextList = "0";
+         bitmapBounds = "16 16";
+         text = "AL_FormatToken";
+         maxLength = "1024";
+         margin = "0 0 0 0";
+         padding = "0 0 0 0";
+         anchorTop = "1";
+         anchorBottom = "0";
+         anchorLeft = "1";
+         anchorRight = "0";
+         position = "0 20";
+         extent = "636 18";
+         minExtent = "8 2";
+         horizSizing = "width";
+         vertSizing = "bottom";
+         profile = "GuiPopUpMenuProfile";
+         visible = "1";
+         active = "1";
+         command = "RenderTargetsList.updateTarget();";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "1";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+      };
+   };
+};
+//--- OBJECT WRITE END ---

--- a/Templates/BaseGame/game/tools/worldEditor/main.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/main.cs
@@ -43,6 +43,7 @@ function initializeWorldEditor()
    exec("./gui/AddFMODProjectDlg.ed.gui");
    exec("./gui/SelectObjectsWindow.ed.gui");
    exec("./gui/ProceduralTerrainPainterGui.gui" );
+   exec("tools/gui/renderTargetVisualizer.ed.gui");
    exec("./gui/shadowViz.gui" );
    exec("./gui/probeBakeDlg.gui" );
    
@@ -75,6 +76,7 @@ function initializeWorldEditor()
    exec("./scripts/visibility/miscViz.cs");
    
    exec("tools/gui/postFxEditor.cs" );
+   exec("tools/gui/renderTargetVisualizer.ed.cs");
 
    // Load Custom Editors
    loadDirectory(expandFilename("./scripts/editors"));


### PR DESCRIPTION
Implementation of guiRenderTargetVizCtrl which allows you to feed a render target and have it display.

Also added a gui to the editor that can open a window and has a drop-down selection of named targets that can be viewed.

Original PR from GarageGames repo:
https://github.com/GarageGames/Torque3D/pull/2360