### PR TITLE
Temporary fix for the geometry feed in spotlights

### DIFF
--- a/Engine/source/lighting/advanced/advancedLightManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightManager.cpp
@@ -607,7 +607,7 @@ GFXVertexBufferHandle<AdvancedLightManager::LightVertex> AdvancedLightManager::g
       for (S32 i=1; i<numPoints + 1; i++)
       {
          S32 imod = (i - 1) % numPoints;
-         mConeGeometry[i].point = Point3F(circlePoints[imod].x,circlePoints[imod].y, -1.0f);
+         mConeGeometry[i].point = Point3F(circlePoints[imod].x*1.1,circlePoints[imod].y*1.1, -1.0f);
          mConeGeometry[i].color = ColorI::WHITE;
       }
       mConeGeometry.unlock();


### PR DESCRIPTION
Done by Azaezel
Spotlights were breaking depending of the angle and distance after a certain radius.

Preview:
![55428893-85b58d00-5560-11e9-9555-5cd536f613cd](https://user-images.githubusercontent.com/2369614/94976326-e5ee0c00-0514-11eb-9afd-87e2bd7a6d70.jpg)
![55428897-8817e700-5560-11e9-8aac-2cc9e6135562](https://user-images.githubusercontent.com/2369614/94976329-e7b7cf80-0514-11eb-8c5d-c7e98f7cf097.jpg)


Original PR on GarageGames Repo:
https://github.com/GarageGames/Torque3D/pull/2350