### PR TITLE
Fixes for compiling without Advanced Lighting

### DIFF
--- a/Engine/source/T3D/levelInfo.cpp
+++ b/Engine/source/T3D/levelInfo.cpp
@@ -26,8 +26,10 @@
 #include "console/consoleTypes.h"
 #include "core/stream/bitStream.h"
 #include "scene/sceneManager.h"
+#if defined(TORQUE_ADVANCED_LIGHTING)
 #include "lighting/advanced/advancedLightManager.h"
 #include "lighting/advanced/advancedLightBinManager.h"
+#endif
 #include "sfx/sfxAmbience.h"
 #include "sfx/sfxSoundscape.h"
 #include "sfx/sfxSystem.h"
@@ -101,16 +103,21 @@ LevelInfo::LevelInfo()
    mAccuTextureName = "";
    mAccuTexture = NULL;
 
+#if defined(TORQUE_ADVANCED_LIGHTING)
    // Register with the light manager activation signal, and we need to do it first
    // so the advanced light bin manager can be instructed about MRT lightmaps
    LightManager::smActivateSignal.notify(this, &LevelInfo::_onLMActivate, 0.01f);
+#endif
 }
 
 //-----------------------------------------------------------------------------
 
 LevelInfo::~LevelInfo()
 {
+#if defined(TORQUE_ADVANCED_LIGHTING)
    LightManager::smActivateSignal.remove(this, &LevelInfo::_onLMActivate);
+#endif
+
    if (!mAccuTexture.isNull())
    {
       mAccuTexture.free();
@@ -334,7 +341,7 @@ void LevelInfo::_updateSceneGraph()
    // If the level info specifies that MRT pre-pass should be used in this scene
    // enable it via the appropriate light manager
    // (Basic lighting doesn't do anything different right now)
-#ifndef TORQUE_DEDICATED
+#if !defined(TORQUE_DEDICATED) && defined(TORQUE_ADVANCED_LIGHTING)
    if(isClientObject())
       _onLMActivate(LIGHTMGR->getId(), true);
 #endif
@@ -347,7 +354,7 @@ void LevelInfo::_updateSceneGraph()
 
 void LevelInfo::_onLMActivate(const char *lm, bool enable)
 {
-#ifndef TORQUE_DEDICATED
+#if !defined(TORQUE_DEDICATED) && defined(TORQUE_ADVANCED_LIGHTING)
    // Advanced light manager
    if(enable && String(lm) == String("ADVLM"))
    {

--- a/Engine/source/shaderGen/GLSL/shaderGenGLSLInit.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderGenGLSLInit.cpp
@@ -34,7 +34,9 @@
 #include "shaderGen/GLSL/accuFeatureGLSL.h"
 
 // Deferred Shading
+#if defined(TORQUE_ADVANCED_LIGHTING)
 #include "lighting/advanced/glsl/deferredShadingFeaturesGLSL.h"
+#endif
 
 static ShaderGen::ShaderGenInitDelegate sInitDelegate;
 
@@ -98,12 +100,14 @@ void _initShaderGenGLSL( ShaderGen *shaderGen )
    FEATUREMGR->registerFeature( MFT_ImposterVert, new ImposterVertFeatureGLSL );
 
    // Deferred Shading
+#if defined(TORQUE_ADVANCED_LIGHTING)
    FEATUREMGR->registerFeature( MFT_isDeferred, new NamedFeatureGLSL( "Deferred Material" ) );
    FEATUREMGR->registerFeature( MFT_PBRConfigMap, new PBRConfigMapGLSL );
    FEATUREMGR->registerFeature( MFT_PBRConfigVars, new PBRConfigVarsGLSL );
    FEATUREMGR->registerFeature( MFT_MatInfoFlags, new MatInfoFlagsGLSL );
    FEATUREMGR->registerFeature( MFT_GlowMap, new GlowMapGLSL);
    FEATUREMGR->registerFeature( MFT_isBackground, new NamedFeatureGLSL("Background Object"));
+#endif
    FEATUREMGR->registerFeature( MFT_SkyBox, new NamedFeatureGLSL( "skybox" ) );
    FEATUREMGR->registerFeature( MFT_HardwareSkinning, new HardwareSkinningFeatureGLSL );
 }

--- a/Engine/source/shaderGen/HLSL/shaderGenHLSLInit.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderGenHLSLInit.cpp
@@ -33,7 +33,9 @@
 #include "materials/materialFeatureTypes.h"
 #include "core/module.h"
 // Deferred Shading
+#if defined(TORQUE_ADVANCED_LIGHTING)
 #include "lighting/advanced/hlsl/deferredShadingFeaturesHLSL.h"
+#endif
 #include "shaderGen/HLSL/accuFeatureHLSL.h"
 
 static ShaderGen::ShaderGenInitDelegate sInitDelegate;
@@ -100,13 +102,14 @@ void _initShaderGenHLSL( ShaderGen *shaderGen )
    FEATUREMGR->registerFeature( MFT_ForwardShading, new NamedFeatureHLSL( "Forward Shaded Material" ) );
 
    FEATUREMGR->registerFeature( MFT_ImposterVert, new ImposterVertFeatureHLSL );
-
+#if defined(TORQUE_ADVANCED_LIGHTING)
    FEATUREMGR->registerFeature( MFT_isDeferred, new NamedFeatureHLSL( "Deferred Material" ) );
    FEATUREMGR->registerFeature( MFT_PBRConfigMap, new PBRConfigMapHLSL);
    FEATUREMGR->registerFeature( MFT_PBRConfigVars, new PBRConfigVarsHLSL);
    FEATUREMGR->registerFeature( MFT_MatInfoFlags, new MatInfoFlagsHLSL );
    FEATUREMGR->registerFeature( MFT_GlowMap, new GlowMapHLSL);
    FEATUREMGR->registerFeature( MFT_isBackground, new NamedFeatureHLSL("Background Object"));
+#endif
    FEATUREMGR->registerFeature( MFT_SkyBox,  new NamedFeatureHLSL( "skybox" ) );
    FEATUREMGR->registerFeature( MFT_HardwareSkinning, new HardwareSkinningFeatureHLSL );
 }


### PR DESCRIPTION
Fix for #24 

Building without Advanced Lighting (TORQUE_ADVANCED_LIGHTING unchecked in CMake) generated linker errors and an alert when the game attempted to set the light manager. This ifdefs the offending code and changes the template (BaseGame only - I didn't update the old Full template) to try to set light managers in order, based on the existing (but unused) $lightManager::defaults pref.

_I removed the changes to the scripts, it seems to be handled differently now_

Original PR from GarageGames repo:
https://github.com/GarageGames/Torque3D/pull/2168