### PR TITLE
Add NavMesh to World Editor

### DIFF
--- a/Templates/BaseGame/game/tools/navEditor/main.cs
+++ b/Templates/BaseGame/game/tools/navEditor/main.cs
@@ -97,6 +97,7 @@ function NavEditorPlugin::onWorldEditorStartup(%this)
 
       EWCreatorWindow.registerMissionObject("CoverPoint", "Cover point");
       EWCreatorWindow.registerMissionObject("NavPath", "Nav Path");
+	  EWCreatorWindow.registerMissionObject("NavMesh", "Navigation mesh");
 
    EWCreatorWindow.endGroup();
 }


### PR DESCRIPTION
added navMesh inside the category Navigation from the Library tab, if you don't want to deal with the editor.

Then basically just scale it, and from console navMesh.build.

Original PR from GarageGames repo:
https://github.com/GarageGames/Torque3D/pull/2152