### PR TITLE
allows different waypoints

### DIFF
--- a/Templates/BaseGame/game/tools/worldEditor/gui/objectBuilderGui.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/objectBuilderGui.ed.gui
@@ -1122,20 +1122,21 @@ function StaticShapeData::create(%data)
 
 function MissionMarkerData::create(%block)
 {
-   switch$(%block)
+   if(%block $= "SpawnSphereMarker")
    {
-      case "WayPointMarker":
-         %obj = new WayPoint() {
-            dataBlock = %block;
-            parentGroup = EWCreatorWindow.objectGroup;
-         };
-         return(%obj);
-      case "SpawnSphereMarker":
-         %obj = new SpawnSphere() {
-            datablock = %block;
-            parentGroup = EWCreatorWindow.objectGroup;
-         };
-         return(%obj);
+      %obj = new SpawnSphere() {
+         datablock = %block;
+         parentGroup = EWCreatorWindow.objectGroup;
+      };
+      return(%obj);
+   }
+   else
+   {
+      %obj = new WayPoint() {
+         dataBlock = %block;
+         parentGroup = EWCreatorWindow.objectGroup;
+      };    
+      return(%obj);
    }
 
    return(-1);


### PR DESCRIPTION
I wanted to share this for some time, not sure if this is the best way to do it, but before it falls into the void :) this will allows to have at the same time different waypoint/markers, add more "WayPointMarker"....

Well you could always add from script, but this PR allows to add it from the World Editor.

See an example, at the right the green old shape. Now you can have different shapes and colors used for enemies, allies, objects.... I can do other PR with the markers I use, it have different shapes and colors, if required.
![29991497-96c010aa-8f4d-11e7-9d28-f5b5f08c36a6](https://user-images.githubusercontent.com/2369614/94987909-f7153800-0569-11eb-88f5-9c518ddb5727.png)
![29991651-8de9e282-8f50-11e7-91a2-0d2836df54c7](https://user-images.githubusercontent.com/2369614/94987907-f67ca180-0569-11eb-90d3-793b5fcf926c.png)

Original PR from the GarageGames repo:
https://github.com/GarageGames/Torque3D/pull/2076