### PR TITLE
Fix/dae2dts tool

### DIFF
--- a/Engine/source/ts/loader/tsShapeLoader.cpp
+++ b/Engine/source/ts/loader/tsShapeLoader.cpp
@@ -1231,9 +1231,8 @@ void TSShapeLoader::install()
    if (TSShape::smInitOnRead)
    {
       shape->init();
+      shape->finalizeEditable();
    }
-
-   shape->finalizeEditable();
 }
 
 void TSShapeLoader::computeBounds(Box3F& bounds)

--- a/Engine/source/ts/loader/tsShapeLoader.cpp
+++ b/Engine/source/ts/loader/tsShapeLoader.cpp
@@ -1228,7 +1228,11 @@ void TSShapeLoader::install()
    shape->mRadius = (shape->mBounds.maxExtents - shape->center).len();
    shape->tubeRadius = shape->mRadius;
 
-   shape->init();
+   if (TSShape::smInitOnRead)
+   {
+      shape->init();
+   }
+
    shape->finalizeEditable();
 }
 

--- a/Tools/dae2dts/source/main.cpp
+++ b/Tools/dae2dts/source/main.cpp
@@ -122,6 +122,10 @@ S32 TorqueMain( S32 argc, const char **argv )
    {
       Con::errorf( "Error: no DAE file specified.\n" );
       printUsage();
+
+      // Clean everything up.
+      StandardMainLoop::shutdown();
+
       return -1;
    }
 

--- a/Tools/dae2dts/source/main.cpp
+++ b/Tools/dae2dts/source/main.cpp
@@ -156,6 +156,8 @@ S32 TorqueMain( S32 argc, const char **argv )
    if ( verbose )
       Con::printf( "Reading dae file...\n" );
 
+   TSShape::smInitOnRead = false;
+
    // Attempt to load the DAE file
    Resource<TSShape> shape = ResourceManager::get().load( srcPath );
    if ( !shape )

--- a/Tools/dae2dts/source/main.cpp
+++ b/Tools/dae2dts/source/main.cpp
@@ -159,64 +159,66 @@ S32 TorqueMain( S32 argc, const char **argv )
    TSShape::smInitOnRead = false;
 
    // Attempt to load the DAE file
-   Resource<TSShape> shape = ResourceManager::get().load( srcPath );
-   if ( !shape )
    {
-      Con::errorf( "Failed to convert DAE file: %s\n", srcPath.getFullPath() );
-      failed = 1;
-   }
-   else
-   {
-      if ( compatMode && !shape->canWriteOldFormat() )
+      Resource<TSShape> shape = ResourceManager::get().load( srcPath );
+      if ( !shape )
       {
-         Con::errorf( "Warning: Attempting to save to DTS v24 but the shape "
-                      "contains v26 features. Resulting DTS file may not be valid." );
+         Con::errorf( "Failed to convert DAE file: %s\n", srcPath.getFullPath() );
+         failed = 1;
       }
-
-      FileStream outStream;
-
-      if ( saveDSQ )
+      else
       {
-         Torque::Path dsqPath( destPath );
-         dsqPath.setExtension( "dsq" );
-
-         for ( S32 i = 0; i < shape->sequences.size(); i++ )
+         if ( compatMode && !shape->canWriteOldFormat() )
          {
-            const String& seqName = shape->getName( shape->sequences[i].nameIndex );
-            if ( verbose )
-               Con::printf( "Writing DSQ file for sequence '%s'...\n", seqName.c_str() );
+            Con::errorf( "Warning: Attempting to save to DTS v24 but the shape "
+                        "contains v26 features. Resulting DTS file may not be valid." );
+         }
 
-            dsqPath.setFileName( destPath.getFileName() + "_" + seqName );
+         FileStream outStream;
 
-            if ( outStream.open( dsqPath, Torque::FS::File::Write ) )
+         if ( saveDSQ )
+         {
+            Torque::Path dsqPath( destPath );
+            dsqPath.setExtension( "dsq" );
+
+            for ( S32 i = 0; i < shape->sequences.size(); i++ )
             {
-               shape->exportSequence( &outStream, shape->sequences[i], compatMode );
+               const String& seqName = shape->getName( shape->sequences[i].nameIndex );
+               if ( verbose )
+                  Con::printf( "Writing DSQ file for sequence '%s'...\n", seqName.c_str() );
+
+               dsqPath.setFileName( destPath.getFileName() + "_" + seqName );
+
+               if ( outStream.open( dsqPath, Torque::FS::File::Write ) )
+               {
+                  shape->exportSequence( &outStream, shape->sequences[i], compatMode );
+                  outStream.close();
+               }
+               else
+               {
+                  Con::errorf( "Failed to save sequence to %s\n", dsqPath.getFullPath().c_str() );
+                  failed = 1;
+               }
+            }
+         }
+         if ( saveDTS )
+         {
+            if ( verbose )
+               Con::printf( "Writing DTS file...\n" );
+
+            if ( outStream.open( destPath, Torque::FS::File::Write ) )
+            {
+               if ( saveDSQ )
+                  shape->sequences.setSize(0);
+
+               shape->write( &outStream, compatMode );
                outStream.close();
             }
             else
             {
-               Con::errorf( "Failed to save sequence to %s\n", dsqPath.getFullPath().c_str() );
+               Con::errorf( "Failed to save shape to %s\n", destPath.getFullPath().c_str() );
                failed = 1;
             }
-         }
-      }
-      if ( saveDTS )
-      {
-         if ( verbose )
-            Con::printf( "Writing DTS file...\n" );
-
-         if ( outStream.open( destPath, Torque::FS::File::Write ) )
-         {
-            if ( saveDSQ )
-               shape->sequences.setSize(0);
-
-            shape->write( &outStream, compatMode );
-            outStream.close();
-         }
-         else
-         {
-            Con::errorf( "Failed to save shape to %s\n", destPath.getFullPath().c_str() );
-            failed = 1;
          }
       }
    }


### PR DESCRIPTION
This fixes the dae2dts tool when compiled using VisualStudio 2012.

The first compilation issue is that the compiler cannot open `nfd.h`. This is because `${libDir}/nativeFileDialogs/include` is not added to the project include paths when `TORQUE_SDL` is disabled. I fixed this by moving `#include <nfd.h>` to within the `#if defined(TORQUE_SDL)` preprocessor directive.
 
The second compilation issue is that the compiler cannot open `al/al.h`. This is because `openal/win32` is added to the project include paths instead of `openal-soft/include`. I fixed this by updating the include paths in the core and T3D project generator modules.
 
The last compilation issue is that `Component::setOwner(class Entity *)` is undefined. This is because the `T3D/components` engine source directory is not included. I fixed this by adding it to the T3D project generator module.
 
After getting the program to compile it then generates a fatal error `SimObject::object missing call to SimObject::onRemove` when run without specifying a DAE file. This is because the program terminates without shutting down the platform. I fixed this by shutting down the platform before terminating.
 
When you run the program again with a DAE file, it generates an error when `TSShapeLoader` initializes the `TSShape`, as there is no GFX device to initialize the vertex buffers. I fixed this by setting `TSShape::smInitOnRead` to `false` and making `TSShapeLoader` adhere to this setting when initializing the `TSShape`.

After fixing this the program converts DAE models to DTS shapes successfully, however generates a write access violation error when the program exits. This is because the `TSShape` resource is not unloaded until it goes out of scope, after the platform has shutdown. I fixed this by adding a block scope to the `TSShape` resource to ensure it goes out of scope before the platform is shutdown.
 
To generate the project files I am doing the following:

* Open the dae2dts directory
* Run generateProjects.bat
* Open the buildFiles directory
* Copy torque.ico and Torque.rc from VisualStudio 2008\projects to VisualStudio 2012\projects
* Open VisualStudio 2012\dae2dts.sln
* On the dae2dts project, go to it's properties, then:
  
  * Change Configuration Properties -> General -> Configuration Type to `Application (.exe)`
  * Change Configuration Properties -> Linker -> General -> Output File to `$(OutDir)dae2dts_DEBUG.exe`
  * Remove Configuration Properties -> Linker -> Input -> Module Definition File

I am not sure if this is the correct way to fix all of these issues so please let me know if you have any feedback.

...

I also had to modify `TSShapeLoader `to prevent clearing the `TSShape `split vertex lists when `TSShape::smInitOnRead` is set to `false`, as the split vertex lists are not being stored in a vertex buffer and are still required.

I tested this using [teapot.dae](https://raw.githubusercontent.com/cathyatseneca/c3dl/master/tutorials/tutorial8/teapot.dae) and the `--compat` command line argument and verified the model loaded correctly in Torque ShowTool Pro.

...

Looks like this solution only works when writing the shape in the old format because the new format depends on the vertex buffers and generates a "vertex size mismatch" error when loaded. Not really sure how to go about solving this.



Original PR from GarageGames repo:
https://github.com/GarageGames/Torque3D/pull/1950