### PR TITLE
breakShape() - remove parts created with invalid object box . 

### DIFF
--- a/Engine/source/ts/tsPartInstance.cpp
+++ b/Engine/source/ts/tsPartInstance.cpp
@@ -107,10 +107,16 @@ void TSPartInstance::breakShape(TSShapeInstance * shape, S32 subShape, Vector<TS
    // update bounds (and get rid of empty parts)
    for (S32 i=0; i<partList.size(); i++)
    {
-      if (partList[i]->mMeshObjects.size())
+      if (partList[i]->mMeshObjects.size()){
          partList[i]->updateBounds();
-      else
-      {
+         // Remove any parts parts with invalid box
+         Box3F box = partList[i]->getBounds();
+         if(!box.isValidBox() ){
+            Con::warnf("TSPartInstance::breakShape - part created with invalid object box. Removing from list.");
+            partList.erase(i);
+            i--;
+         }
+      }else{
          partList.erase(i);
          i--;
       }

--- a/Engine/source/ts/tsPartInstance.cpp
+++ b/Engine/source/ts/tsPartInstance.cpp
@@ -107,19 +107,23 @@ void TSPartInstance::breakShape(TSShapeInstance * shape, S32 subShape, Vector<TS
    // update bounds (and get rid of empty parts)
    for (S32 i=0; i<partList.size(); i++)
    {
-      if (partList[i]->mMeshObjects.size()){
+      if (partList[i]->mMeshObjects.size())
+      {
          partList[i]->updateBounds();
          // Remove any parts parts with invalid box
          Box3F box = partList[i]->getBounds();
-         if(!box.isValidBox() ){
+         if (!box.isValidBox())
+         {
             Con::warnf("TSPartInstance::breakShape - part created with invalid object box. Removing from list.");
             partList.erase(i);
             i--;
          }
-      }else{
-         partList.erase(i);
-         i--;
-      }
+     }
+     else
+     {
+        partList.erase(i);
+        i--;
+     }
    }
 }
 


### PR DESCRIPTION
This fixes an invalid object box fatal assert that manifests when calling the Shapebase::blowUp() function on some (all?) .dts models. It appears this function is the only place in the engine that currently calls TsPartinstance::breakShape().

The issue might be model-specific. With some models, the routine will consistently generate a number of parts that produce an invalid object box when updateBounds() is called. This appears to happen when dealing with a denormalized min/max dimension so it is unclear if these parts are an artifact similar to empty parts. There might be an underlying issue in updateBounds() that could be cleaned up. Removing the invalid objects from the partList eliminates the crash while producing a satisfactory quantity of debris (when applied to a complex model).

This patch solves the crash for .DTS models, but the routine does not appear to produce any parts for .DAE models, and I have not looked in to this.

Original PR from GarageGames repo:
https://github.com/GarageGames/Torque3D/pull/1794