### PR TITLE
Replace uses of dStrCmp with new String::compare

### DIFF
--- a/Engine/source/T3D/aiClient.cpp
+++ b/Engine/source/T3D/aiClient.cpp
@@ -403,7 +403,7 @@ void AIClient::onAdd( const char *nameSpace ) {
 
    // This doesn't work...
    //
-   if( dStrcmp( nameSpace, mNameSpace->mName ) ) {
+   if( String::compare( nameSpace, mNameSpace->mName ) ) {
       Con::linkNamespaces( mNameSpace->mName, nameSpace );
       mNameSpace = Con::lookupNamespace( nameSpace );
    }
@@ -547,7 +547,7 @@ DefineEngineFunction( aiAddPlayer, S32, (const char * name, const char * ns), ("
    aiPlayer->onConnect_callback( name );
 
    // Now execute the onAdd command and feed it the namespace
-   if(dStrcmp( ns,"" ) != 0 )
+   if(String::compare( ns,"" ) != 0 )
       aiPlayer->onAdd( ns );
    else
       aiPlayer->onAdd( "AIClient" );

--- a/Engine/source/T3D/aiPlayer.cpp
+++ b/Engine/source/T3D/aiPlayer.cpp
@@ -1108,11 +1108,11 @@ DefineEngineMethod(AIPlayer, getNavMesh, S32, (),,
 DefineEngineMethod(AIPlayer, setNavSize, void, (const char *size),,
    "@brief Set the size of NavMesh this character uses. One of \"Small\", \"Regular\" or \"Large\".")
 {
-   if(!dStrcmp(size, "Small"))
+   if(!String::compare(size, "Small"))
       object->setNavSize(AIPlayer::Small);
-   else if(!dStrcmp(size, "Regular"))
+   else if(!String::compare(size, "Regular"))
       object->setNavSize(AIPlayer::Regular);
-   else if(!dStrcmp(size, "Large"))
+   else if(!String::compare(size, "Large"))
       object->setNavSize(AIPlayer::Large);
    else
       Con::errorf("AIPlayer::setNavSize: no such size '%s'.", size);

--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -2558,7 +2558,7 @@ Torque::Path AssetImporter::importImageAsset(AssetImportObject* assetItem)
 
    //If it's not a re-import, check that the file isn't being in-place imported. If it isn't, store off the original
    //file path for reimporting support later
-   if (!isReimport && dStrcmp(qualifiedFromFile, qualifiedToFile))
+   if (!isReimport && String::compare(qualifiedFromFile, qualifiedToFile))
    {
       newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, qualifiedFromFile);
    }
@@ -2578,7 +2578,7 @@ Torque::Path AssetImporter::importImageAsset(AssetImportObject* assetItem)
 
    if (!isReimport)
    {
-      bool isInPlace = !dStrcmp(qualifiedFromFile, qualifiedToFile);
+      bool isInPlace = !String::compare(qualifiedFromFile, qualifiedToFile);
 
       if (!isInPlace && !dPathCopy(qualifiedFromFile, qualifiedToFile, !isReimport))
       {
@@ -2877,7 +2877,7 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
 
    //If it's not a re-import, check that the file isn't being in-place imported. If it isn't, store off the original
    //file path for reimporting support later
-   if (!isReimport && dStrcmp(qualifiedFromFile, qualifiedToFile))
+   if (!isReimport && String::compare(qualifiedFromFile, qualifiedToFile))
    {
       newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, qualifiedFromFile);
    }
@@ -2930,7 +2930,7 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
    bool makeNewConstructor = true;
    if (!isReimport)
    {
-      bool isInPlace = !dStrcmp(qualifiedFromFile, qualifiedToFile);
+      bool isInPlace = !String::compare(qualifiedFromFile, qualifiedToFile);
 
       if (!isInPlace && !dPathCopy(qualifiedFromFile, qualifiedToFile, !isReimport))
       {
@@ -3109,7 +3109,7 @@ Torque::Path AssetImporter::importSoundAsset(AssetImportObject* assetItem)
 
    //If it's not a re-import, check that the file isn't being in-place imported. If it isn't, store off the original
    //file path for reimporting support later
-   if (!isReimport && dStrcmp(qualifiedFromFile, qualifiedToFile))
+   if (!isReimport && String::compare(qualifiedFromFile, qualifiedToFile))
    {
       newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, qualifiedFromFile);
    }
@@ -3126,7 +3126,7 @@ Torque::Path AssetImporter::importSoundAsset(AssetImportObject* assetItem)
 
    if (!isReimport)
    {
-      bool isInPlace = !dStrcmp(qualifiedFromFile, qualifiedToFile);
+      bool isInPlace = !String::compare(qualifiedFromFile, qualifiedToFile);
 
       if (!isInPlace && !dPathCopy(qualifiedFromFile, qualifiedToFile, !isReimport))
       {
@@ -3165,7 +3165,7 @@ Torque::Path AssetImporter::importShapeAnimationAsset(AssetImportObject* assetIt
 
    //If it's not a re-import, check that the file isn't being in-place imported. If it isn't, store off the original
    //file path for reimporting support later
-   if (!isReimport && dStrcmp(qualifiedFromFile, qualifiedToFile))
+   if (!isReimport && String::compare(qualifiedFromFile, qualifiedToFile))
    {
       newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, qualifiedFromFile);
    }
@@ -3182,7 +3182,7 @@ Torque::Path AssetImporter::importShapeAnimationAsset(AssetImportObject* assetIt
 
    if (!isReimport)
    {
-      bool isInPlace = !dStrcmp(qualifiedFromFile, qualifiedToFile);
+      bool isInPlace = !String::compare(qualifiedFromFile, qualifiedToFile);
 
       if (!isInPlace && !dPathCopy(qualifiedFromFile, qualifiedToFile, !isReimport))
       {

--- a/Engine/source/T3D/fx/fxShapeReplicator.cpp
+++ b/Engine/source/T3D/fx/fxShapeReplicator.cpp
@@ -209,7 +209,7 @@ void fxShapeReplicator::CreateShapes(void)
    if (mFieldData.mHideReplications) return;
 
    // Cannot continue without shapes!
-   if (dStrcmp(mFieldData.mShapeFile, "") == 0) return;
+   if (String::compare(mFieldData.mShapeFile, "") == 0) return;
 
    // Check that we can position somewhere!
    if (!(	mFieldData.mAllowOnTerrain ||

--- a/Engine/source/T3D/gameBase/gameConnection.cpp
+++ b/Engine/source/T3D/gameBase/gameConnection.cpp
@@ -454,7 +454,7 @@ bool GameConnection::readConnectRequest(BitStream *stream, const char **errorStr
    U32 currentProtocol, minProtocol;
    char gameString[256];
    stream->readString(gameString);
-   if(dStrcmp(gameString, TORQUE_APP_NAME))
+   if(String::compare(gameString, TORQUE_APP_NAME))
    {
       *errorString = "CHR_GAME";
       return false;
@@ -481,7 +481,7 @@ bool GameConnection::readConnectRequest(BitStream *stream, const char **errorStr
    const char *serverPassword = Con::getVariable("pref::Server::Password");
    if(serverPassword[0])
    {
-      if(dStrcmp(joinPassword, serverPassword))
+      if(String::compare(joinPassword, serverPassword))
       {
          *errorString = "CHR_PASSWORD";
          return false;

--- a/Engine/source/T3D/gameBase/gameConnectionEvents.cpp
+++ b/Engine/source/T3D/gameBase/gameConnectionEvents.cpp
@@ -191,7 +191,7 @@ void SimDataBlockEvent::unpack(NetConnection *cptr, BitStream *bstream)
          // An object with the given ID already exists.  Make sure it has the right class.
          
          AbstractClassRep* classRep = AbstractClassRep::findClassRep( cptr->getNetClassGroup(), NetClassTypeDataBlock, classId );
-         if( classRep && dStrcmp( classRep->getClassName(), ptr->getClassName() ) != 0 )
+         if( classRep && String::compare( classRep->getClassName(), ptr->getClassName() ) != 0 )
          {
             Con::warnf( "A '%s' datablock with id: %d already existed. "
                         "Clobbering it with new '%s' datablock from server.",

--- a/Engine/source/T3D/lighting/reflectionProbe.cpp
+++ b/Engine/source/T3D/lighting/reflectionProbe.cpp
@@ -259,11 +259,11 @@ bool ReflectionProbe::_setReflectionMode(void *object, const char *index, const 
 {
    ReflectionProbe* probe = reinterpret_cast<ReflectionProbe*>(object);
 
-   if (!dStrcmp(data,"Static Cubemap"))
+   if (!String::compare(data,"Static Cubemap"))
    {
       probe->mReflectionModeType = StaticCubemap;
    }
-   else if (!dStrcmp(data, "Baked Cubemap"))
+   else if (!String::compare(data, "Baked Cubemap"))
    {
       //Clear our cubemap if we changed it to be baked, just for cleanliness
       probe->mReflectionModeType = BakedCubemap;

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -2416,7 +2416,7 @@ void Player::getDamageLocation(const Point3F& in_rPos, const char *&out_rpVert, 
    else
       out_rpVert = "head";
 
-   if(dStrcmp(out_rpVert, "head") != 0)
+   if(String::compare(out_rpVert, "head") != 0)
    {
       if (newPoint.y >= 0.0f)
       {

--- a/Engine/source/Verve/Core/Persistence/VPersistence.h
+++ b/Engine/source/Verve/Core/Persistence/VPersistence.h
@@ -162,7 +162,7 @@ namespace VPersistence
         }
 
         const char *docVersion = rootElement->Attribute( "Version" );
-        if ( !docVersion || dStrcmp( VSFVersionString, docVersion ) != 0 )
+        if ( !docVersion || String::compare( VSFVersionString, docVersion ) != 0 )
         {
             Con::errorf( "VPersistence::readFile() - Invalid file version." );
             return false;

--- a/Engine/source/Verve/Core/VController.cpp
+++ b/Engine/source/Verve/Core/VController.cpp
@@ -1041,7 +1041,7 @@ DefineEngineMethod( VController, sortGroups, void, (),, "( void ) - Sort Groups 
             }
 
             // Swap?
-            if ( dStrcmp( groupA->getLabel(), groupB->getLabel() ) > 0 )
+            if ( String::compare( groupA->getLabel(), groupB->getLabel() ) > 0 )
             {
                 // Get Outer Siblings.
                 ITreeNode *prevNode = groupA->mSiblingPrevNode;
@@ -1100,7 +1100,7 @@ DefineEngineMethod( VController, sortTracks, void, (),, "( void ) - Sort Tracks 
                 }
 
                 // Swap?
-                if ( dStrcmp( trackA->getLabel(), trackB->getLabel() ) > 0 )
+                if ( String::compare( trackA->getLabel(), trackB->getLabel() ) > 0 )
                 {
                     // Get Outer Siblings.
                     ITreeNode *prevNode = trackA->mSiblingPrevNode;

--- a/Engine/source/Verve/VPath/VPath.cpp
+++ b/Engine/source/Verve/VPath/VPath.cpp
@@ -538,7 +538,7 @@ VectorF VPath::getMountVelocity( const U32 &pIndex )
 void VPath::readFields( void )
 {
     const char *nodeData = "";
-    for ( S32 nodeIndex = 0; dStrcmp( nodeData = getDataField( StringTable->insert( avar( "Node%d", nodeIndex ) ), NULL ), "" ) != 0; nodeIndex++ )
+    for ( S32 nodeIndex = 0; String::compare( nodeData = getDataField( StringTable->insert( avar( "Node%d", nodeIndex ) ), NULL ), "" ) != 0; nodeIndex++ )
     {
         // Create Node.
         VPathNode *node = createNode();

--- a/Engine/source/afx/afxConstraint.cpp
+++ b/Engine/source/afx/afxConstraint.cpp
@@ -156,7 +156,7 @@ bool afxConstraintDef::parseSpec(const char* spec, bool runs_on_server,
   // move words to words2 while extracting #center and #history
   for (S32 i = 0; i < n_words; i++)
   {
-    if (dStrcmp(words[i], "#center") == 0)
+    if (String::compare(words[i], "#center") == 0)
       mPos_at_box_center = true;
     else if (dStrncmp(words[i], "#history(", 9) == 0)
       hist_spec = words[i];

--- a/Engine/source/app/mainLoop.cpp
+++ b/Engine/source/app/mainLoop.cpp
@@ -466,7 +466,7 @@ bool StandardMainLoop::handleCommandLine( S32 argc, const char **argv )
    if (argc > 1)
    {
       // If so, check if the first parameter is a file to open.
-      if ( (dStrcmp(argv[1], "") != 0 ) && (str.open(argv[1], Torque::FS::File::Read)) )
+      if ( (String::compare(argv[1], "") != 0 ) && (str.open(argv[1], Torque::FS::File::Read)) )
       {
          // If it opens, we assume it is the script to run.
          useDefaultScript = false;

--- a/Engine/source/app/net/serverQuery.cpp
+++ b/Engine/source/app/net/serverQuery.cpp
@@ -508,14 +508,14 @@ void queryMasterServer(U8 flags, const char* gameType, const char* missionType,
       sActiveFilter.type = ServerFilter::Normal;
 
       // Update the active filter:
-      if ( !sActiveFilter.gameType || dStrcmp( sActiveFilter.gameType, gameType ) != 0 )
+      if ( !sActiveFilter.gameType || String::compare( sActiveFilter.gameType, gameType ) != 0 )
       {
          dsize_t gameTypeLen = dStrlen(gameType) + 1;
          sActiveFilter.gameType = (char*) dRealloc( sActiveFilter.gameType, gameTypeLen );
          dStrcpy( sActiveFilter.gameType, gameType, gameTypeLen );
       }
 
-      if ( !sActiveFilter.missionType || dStrcmp( sActiveFilter.missionType, missionType ) != 0 )
+      if ( !sActiveFilter.missionType || String::compare( sActiveFilter.missionType, missionType ) != 0 )
       {
          dsize_t missionTypeLen = dStrlen(missionType) + 1;
          sActiveFilter.missionType = (char*) dRealloc( sActiveFilter.missionType, missionTypeLen );
@@ -1855,7 +1855,7 @@ static void handleGamePingResponse( const NetAddress* address, BitStream* stream
    // Verify the version:
    char buf[256];
    stream->readString( buf );
-   if ( dStrcmp( buf, versionString ) != 0 )
+   if ( String::compare( buf, versionString ) != 0 )
    {
       // Version is different, so remove it from consideration:
       Con::printf( "Server %s is a different version.", addrString );
@@ -2070,7 +2070,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
 
    // Get the mission type:
    stream->readString( stringBuf );
-   if ( !si->missionType || dStrcmp( si->missionType, stringBuf ) != 0 )
+   if ( !si->missionType || String::compare( si->missionType, stringBuf ) != 0 )
    {
       dsize_t missionTypeLen = dStrlen(stringBuf) + 1;
       si->missionType = (char*) dRealloc( (void*) si->missionType, missionTypeLen );
@@ -2092,7 +2092,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
    char* temp = dStrstr( static_cast<char*>( stringBuf ), const_cast<char*>( ".mis" ) );
    if ( temp )
       *temp = '\0';
-   if ( !si->missionName || dStrcmp( si->missionName, stringBuf ) != 0 )
+   if ( !si->missionName || String::compare( si->missionName, stringBuf ) != 0 )
    {
       dsize_t missionNameLen = dStrlen(stringBuf) + 1;
       si->missionName = (char*) dRealloc( (void*) si->missionName, missionNameLen );
@@ -2162,7 +2162,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
 
    // Get the server info:
    stream->readString( stringBuf );
-   if ( !si->statusString || ( isUpdate && dStrcmp( si->statusString, stringBuf ) != 0 ) )
+   if ( !si->statusString || ( isUpdate && String::compare( si->statusString, stringBuf ) != 0 ) )
    {
       dsize_t infoLen = dStrlen(stringBuf) + 1;
       si->infoString = (char*) dRealloc( (void*) si->infoString, infoLen );
@@ -2171,7 +2171,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
 
    // Get the content string:
    readLongCString( stream, stringBuf );
-   if ( !si->statusString || ( isUpdate && dStrcmp( si->statusString, stringBuf ) != 0 ) )
+   if ( !si->statusString || ( isUpdate && String::compare( si->statusString, stringBuf ) != 0 ) )
    {
       dsize_t statusLen = dStrlen(stringBuf) + 1;
       si->statusString = (char*) dRealloc( (void*) si->statusString, statusLen );

--- a/Engine/source/console/compiler.cpp
+++ b/Engine/source/console/compiler.cpp
@@ -142,7 +142,7 @@ U32 CompilerStringTable::add(const char *str, bool caseSens, bool tag)
 
       if (caseSens)
       {
-         if (!dStrcmp((*walk)->string, str))
+         if (!String::compare((*walk)->string, str))
             return (*walk)->start;
       }
       else

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -437,7 +437,7 @@ U32 tabComplete(char* inputBuffer, U32 cursorPos, U32 maxResultLength, bool forw
    }
 
    // See if this is the same partial text as last checked.
-   if (dStrcmp(tabBuffer, inputBuffer)) 
+   if (String::compare(tabBuffer, inputBuffer)) 
    {
       // If not...
       // Save it for checking next time.

--- a/Engine/source/console/consoleDoc.cpp
+++ b/Engine/source/console/consoleDoc.cpp
@@ -135,7 +135,7 @@ void printClassHeader(const char* usage, const char * className, const char * su
          }
 
          // Print all fields that aren't associated with the 'field' keyword.
-         if( dStrcmp( keyword, "field" ) )
+         if( String::compare( keyword, "field" ) )
             Con::printf( "%s", lineStr );    // print lineStr as an unformatted string (otherwise '%' characters in the string could cause problems)
 
 

--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -1188,7 +1188,7 @@ DefineEngineFunction( isValidIP, bool, ( const char* str),,
    "@endtsexample\n"
    "@ingroup Strings" )
 {
-   if(dStrcmp(str, "localhost") == 0)
+   if(String::compare(str, "localhost") == 0)
    {
       return true;
    }

--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -266,7 +266,7 @@ DefineEngineFunction( strcmp, S32, ( const char* str1, const char* str2 ),,
    "@see strnatcmp\n"
    "@ingroup Strings" )
 {
-   return dStrcmp( str1, str2 );
+   return String::compare( str1, str2 );
 }
 
 //-----------------------------------------------------------------------------
@@ -949,7 +949,7 @@ DefineEngineFunction( endsWith, bool, ( const char* str, const char* suffix, boo
       return false;
       
    if( caseSensitive )
-      return ( dStrcmp( &str[ srcLen - targetLen ], suffix ) == 0 );
+      return ( String::compare( &str[ srcLen - targetLen ], suffix ) == 0 );
 
    // both src and target are non empty, create temp buffers for lowercase operation
    char* srcBuf = new char[ srcLen + 1 ];
@@ -967,7 +967,7 @@ DefineEngineFunction( endsWith, bool, ( const char* str, const char* suffix, boo
    str += srcLen - targetLen;
 
    // do the comparison
-   bool endsWith = dStrcmp( str, suffix ) == 0;
+   bool endsWith = String::compare( str, suffix ) == 0;
 
    // delete temp buffers
    delete [] srcBuf;
@@ -2577,7 +2577,7 @@ DefineEngineFunction( isDefined, bool, ( const char* varName, const char* varVal
    else
    {
       // Is it an object?
-      if (dStrcmp(varName, "0") && dStrcmp(varName, "") && (Sim::findObject(varName) != NULL))
+      if (String::compare(varName, "0") && String::compare(varName, "") && (Sim::findObject(varName) != NULL))
          return true;
       else if (!String::isEmpty(varValue))
       {

--- a/Engine/source/console/consoleInternal.cpp
+++ b/Engine/source/console/consoleInternal.cpp
@@ -1616,13 +1616,13 @@ namespace {
       if (dStrncmp(nativeType, "const ", 6) == 0)
          nativeType += 6;
 
-      if (dStrcmp(nativeType, "char*") == 0 || dStrcmp(nativeType, "char *") == 0)
+      if (String::compare(nativeType, "char*") == 0 || String::compare(nativeType, "char *") == 0)
          return "string";
-      else if (dStrcmp(nativeType, "S32") == 0)
+      else if (String::compare(nativeType, "S32") == 0)
          return "int";
-      else if (dStrcmp(nativeType, "U32") == 0)
+      else if (String::compare(nativeType, "U32") == 0)
          return "uint";
-      else if (dStrcmp(nativeType, "F32") == 0)
+      else if (String::compare(nativeType, "F32") == 0)
          return "float";
 
       const U32 length = dStrlen(nativeType);

--- a/Engine/source/console/consoleObject.cpp
+++ b/Engine/source/console/consoleObject.cpp
@@ -140,7 +140,7 @@ void AbstractClassRep::registerClassRep(AbstractClassRep* in_pRep)
 #ifdef TORQUE_DEBUG  // assert if this class is already registered.
    for(AbstractClassRep *walk = classLinkList; walk; walk = walk->nextClass)
    {
-      AssertFatal(dStrcmp(in_pRep->mClassName, walk->mClassName),
+      AssertFatal(String::compare(in_pRep->mClassName, walk->mClassName),
          "Duplicate class name registered in AbstractClassRep::registerClassRep()");
    }
 #endif

--- a/Engine/source/console/dynamicTypes.cpp
+++ b/Engine/source/console/dynamicTypes.cpp
@@ -93,7 +93,7 @@ ConsoleBaseType* ConsoleBaseType::getTypeByName(const char *typeName)
    ConsoleBaseType* walk = getListHead();
    while( walk != NULL )
    {
-      if( dStrcmp( walk->getTypeName(), typeName ) == 0 )
+      if( String::compare( walk->getTypeName(), typeName ) == 0 )
          return walk;
 
       walk = walk->getListNext();
@@ -109,7 +109,7 @@ ConsoleBaseType * ConsoleBaseType::getTypeByClassName(const char *typeName)
    ConsoleBaseType *walk = getListHead();
    while( walk != NULL )
    {
-      if( dStrcmp( walk->getTypeClassName(), typeName ) == 0 )
+      if( String::compare( walk->getTypeClassName(), typeName ) == 0 )
          return walk;
 
       walk = walk->getListNext();

--- a/Engine/source/console/fieldBrushObject.cpp
+++ b/Engine/source/console/fieldBrushObject.cpp
@@ -391,7 +391,7 @@ DefineEngineMethod(FieldBrushObject, copyFields, void, (const char* simObjName, 
 void FieldBrushObject::copyFields( SimObject* pSimObject, const char* fieldList )
 {
     // FieldBrushObject class?   
-    if ( dStrcmp(pSimObject->getClassName(), getClassName()) == 0 )
+    if ( String::compare(pSimObject->getClassName(), getClassName()) == 0 )
     {
         // Yes, so warn.
         Con::warnf("FieldBrushObject::copyFields() - Cannot copy FieldBrushObject objects!");
@@ -522,7 +522,7 @@ DefineEngineMethod(FieldBrushObject, pasteFields, void, (const char* simObjName)
 void FieldBrushObject::pasteFields( SimObject* pSimObject )
 {
     // FieldBrushObject class?   
-    if ( dStrcmp(pSimObject->getClassName(), getClassName()) == 0 )
+    if ( String::compare(pSimObject->getClassName(), getClassName()) == 0 )
     {
         // Yes, so warn.
         Con::warnf("FieldBrushObject::pasteFields() - Cannot paste FieldBrushObject objects!");
@@ -575,7 +575,7 @@ void FieldBrushObject::pasteFields( SimObject* pSimObject )
                         staticField.type != AbstractClassRep::DeprecatedFieldType )
                 {
                     // Target field?
-                    if ( dStrcmp(staticField.pFieldname, pInternalField) == 0 )
+                    if ( String::compare(staticField.pFieldname, pInternalField) == 0 )
                     {
                         // Yes, so set data.
                         pSimObject->setDataField( staticField.pFieldname, NULL, fieldEntry->value );

--- a/Engine/source/console/fileSystemFunctions.cpp
+++ b/Engine/source/console/fileSystemFunctions.cpp
@@ -463,7 +463,7 @@ DefineEngineFunction(getDirectoryList, String, ( const char* path, S32 depth ), 
 {
    // Grab the full path.
    char fullpath[1024];
-   Platform::makeFullPathName(dStrcmp(path, "/") == 0 ? "" : path, fullpath, sizeof(fullpath));
+   Platform::makeFullPathName(String::compare(path, "/") == 0 ? "" : path, fullpath, sizeof(fullpath));
 
    //dSprintf(fullpath, 511, "%s/%s", Platform::getWorkingDirectory(), path);
 

--- a/Engine/source/console/persistenceManager.cpp
+++ b/Engine/source/console/persistenceManager.cpp
@@ -2247,7 +2247,7 @@ DefineEngineMethod( PersistenceManager, isDirty, bool, ( const char * objName ),
               "Returns true if the SimObject is on the dirty list.")
 {
    SimObject *dirtyObject = NULL;
-   if (dStrcmp ( objName,"")!=0)
+   if (String::compare ( objName,"")!=0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {
@@ -2328,7 +2328,7 @@ DefineEngineMethod( PersistenceManager, saveDirtyObject, bool, (const char * obj
               "Save a dirty SimObject to it's file.")
 {
    SimObject *dirtyObject = NULL;
-   if (dStrcmp (  objName, "")!=0)
+   if (String::compare (  objName, "")!=0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {
@@ -2353,7 +2353,7 @@ DefineEngineMethod( PersistenceManager, removeObjectFromFile, void, (const char 
                the one it was created in.")
 {
    SimObject *dirtyObject = NULL;
-   if (dStrcmp ( objName , "")!=0)
+   if (String::compare ( objName , "")!=0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {

--- a/Engine/source/console/persistenceManager.cpp
+++ b/Engine/source/console/persistenceManager.cpp
@@ -890,10 +890,10 @@ PersistenceManager::ParsedObject* PersistenceManager::findParsedObject(SimObject
          {
             const ParsedProperty &prop = testObj->properties[j];
 
-            if (  dStrcmp( prop.name, "internalName" ) == 0 && 
-               dStrcmp( prop.value, object->getInternalName() ) == 0 )
+            if (  String::compare( prop.name, "internalName" ) == 0 && 
+               String::compare( prop.value, object->getInternalName() ) == 0 )
                return testObj;
-            else if ( dStrcmp(prop.name, "internalName") == 0)
+            else if ( String::compare(prop.name, "internalName") == 0)
                break;
          }
       }
@@ -1544,7 +1544,7 @@ void PersistenceManager::updateObject(SimObject* object, ParsedObject* parentObj
          if( object->getCopySource() )
          {
             const char* copySourceFieldValue = object->getCopySource()->getDataField( entry->slotName, NULL );
-            if( dStrcmp( copySourceFieldValue, entry->value ) == 0 )
+            if( String::compare( copySourceFieldValue, entry->value ) == 0 )
             {
                removeField( prop );
                continue;
@@ -1576,7 +1576,7 @@ void PersistenceManager::updateObject(SimObject* object, ParsedObject* parentObj
          if( object->getCopySource() )
          {
             const char* copySourceFieldValue = object->getCopySource()->getDataField( entry->slotName, NULL );
-            if( dStrcmp( copySourceFieldValue, entry->value ) == 0 )
+            if( String::compare( copySourceFieldValue, entry->value ) == 0 )
                continue;
          }
 
@@ -2201,7 +2201,7 @@ DefineEngineMethod( PersistenceManager, setDirty, void,  ( const char * objName,
               "Mark an existing SimObject as dirty (will be written out when saveDirty() is called).")
 {
    SimObject *dirtyObject = NULL;
-   if (dStrcmp(objName,"") != 0)
+   if (String::compare(objName,"") != 0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {
@@ -2219,7 +2219,7 @@ DefineEngineMethod( PersistenceManager, setDirty, void,  ( const char * objName,
 
    if (dirtyObject)
    {
-      if (dStrcmp( fileName,"")!=0)
+      if (String::compare( fileName,"")!=0)
          object->setDirty(dirtyObject, fileName);
       else
          object->setDirty(dirtyObject);
@@ -2230,7 +2230,7 @@ DefineEngineMethod( PersistenceManager, removeDirty, void, ( const char * objNam
               "Remove a SimObject from the dirty list.")
 {
    SimObject *dirtyObject = NULL;
-   if (dStrcmp(  objName,"")!=0)
+	if (String::compare(  objName,"")!=0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {
@@ -2364,7 +2364,7 @@ DefineEngineMethod( PersistenceManager, removeObjectFromFile, void, (const char 
 
    if (dirtyObject)
    {
-      if (dStrcmp( filename,"")!=0)
+      if (String::compare( filename,"")!=0)
          object->removeObjectFromFile(dirtyObject, filename);
       else
          object->removeObjectFromFile(dirtyObject);
@@ -2375,7 +2375,7 @@ DefineEngineMethod( PersistenceManager, removeField, void, (const char * objName
               "Remove a specific field from an object declaration.")
 {
    SimObject *dirtyObject = NULL;
-   if (dStrcmp(objName,"")!=0)
+   if (String::compare(objName,"")!=0)
    {
       if (!Sim::findObject(objName, dirtyObject))
       {
@@ -2386,7 +2386,7 @@ DefineEngineMethod( PersistenceManager, removeField, void, (const char * objName
 
    if (dirtyObject)
    {
-      if (dStrcmp(fieldName,"") != 0)
+      if (String::compare(fieldName,"") != 0)
          object->addRemoveField(dirtyObject, fieldName);
    }
 }

--- a/Engine/source/console/sim.cpp
+++ b/Engine/source/console/sim.cpp
@@ -97,7 +97,7 @@ DefineEngineFunction( nameToID, S32, (const char * objectName), ,"nameToID(objec
 
 DefineEngineFunction( isObject, bool, (const char * objectName), ,"isObject(object)")
 {
-   if (!dStrcmp(objectName, "0") || !dStrcmp(objectName, ""))
+   if (!String::compare(objectName, "0") || !String::compare(objectName, ""))
       return false;
    else
       return (Sim::findObject(objectName) != NULL);

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -421,7 +421,7 @@ bool SimObject::save(const char *pcFileName, bool bOnlySelected, const char *pre
    while(!f.isEOF())
    {
       buffer = (const char *) f.readLine();
-      if(!dStrcmp(buffer, beginMessage))
+      if(!String::compare(buffer, beginMessage))
          break;
       stream->write(dStrlen(buffer), buffer);
       stream->write(2, "\r\n");
@@ -436,7 +436,7 @@ bool SimObject::save(const char *pcFileName, bool bOnlySelected, const char *pre
    while(!f.isEOF())
    {
       buffer = (const char *) f.readLine();
-      if(!dStrcmp(buffer, endMessage))
+      if(!String::compare(buffer, endMessage))
          break;
    }
    while(!f.isEOF())

--- a/Engine/source/core/fileObject.cpp
+++ b/Engine/source/core/fileObject.cpp
@@ -493,7 +493,7 @@ DefineEngineMethod( FileObject, writeObject, void,  (const char * simName, const
       Con::printf("FileObject::writeObject - Invalid Object!");
       return;
    }
-	if (!dStrcmp(objName,""))
+	if (!String::compare(objName,""))
        objName = NULL;
 
    object->writeObject( obj, (const U8*)objName );

--- a/Engine/source/core/stringTable.cpp
+++ b/Engine/source/core/stringTable.cpp
@@ -134,7 +134,7 @@ StringTableEntry _StringTable::insert(const char* _val, const bool caseSens)
    U32 key = hashString(val);
    walk = &buckets[key % numBuckets];
    while((temp = *walk) != NULL)   {
-      if(caseSens && !dStrcmp(temp->val, val))
+      if(caseSens && !String::compare(temp->val, val))
          return temp->val;
       else if(!caseSens && !dStricmp(temp->val, val))
          return temp->val;
@@ -175,7 +175,7 @@ StringTableEntry _StringTable::lookup(const char* val, const bool  caseSens)
    U32 key = hashString(val);
    walk = &buckets[key % numBuckets];
    while((temp = *walk) != NULL)   {
-      if(caseSens && !dStrcmp(temp->val, val))
+      if(caseSens && !String::compare(temp->val, val))
             return temp->val;
       else if(!caseSens && !dStricmp(temp->val, val))
          return temp->val;

--- a/Engine/source/core/stringTable.h
+++ b/Engine/source/core/stringTable.h
@@ -59,7 +59,7 @@
 /// pointer mapped to it. As a pointer is an integer value (usually an unsigned int),
 /// so we can do several neat things:
 ///      - StringTableEntrys can be compared directly for equality, instead of using
-///        the time-consuming dStrcmp() or dStricmp() function.
+///        the time-consuming String::compare() or dStricmp() function.
 ///      - For things like object names, we can avoid storing multiple copies of the
 ///        string containing the name. The StringTable ensures that we only ever store
 ///        one copy.

--- a/Engine/source/core/strings/stringFunctions.cpp
+++ b/Engine/source/core/strings/stringFunctions.cpp
@@ -329,7 +329,7 @@ char* dStrcpyl(char *dst, dsize_t dstSize, ...)
 }
 
 
-S32 dStrcmp( const UTF16 *str1, const UTF16 *str2)
+S32 dStrcmp(const UTF16 *str1, const UTF16 *str2)
 {
 #if defined(TORQUE_OS_WIN)
    return wcscmp( reinterpret_cast<const wchar_t *>( str1 ), reinterpret_cast<const wchar_t *>( str2 ) );
@@ -546,7 +546,7 @@ bool dStrEqual(const char* str1, const char* str2)
    if (!str1 || !str2)
       return false;
    else
-      return (dStrcmp(str1, str2) == 0);
+      return (String::compare(str1, str2) == 0);
 }
 
 /// Check if one string starts with another

--- a/Engine/source/core/util/str.cpp
+++ b/Engine/source/core/util/str.cpp
@@ -439,7 +439,7 @@ namespace KeyCmp
    template<>
    inline bool equals<>( String::StringData* const& d1, String::StringData* const& d2 )
    {
-      return ( dStrcmp( d1->utf8(), d2->utf8() ) == 0 );
+      return ( String::compare( d1->utf8(), d2->utf8() ) == 0 );
    }
 }
 
@@ -1027,6 +1027,28 @@ S32 String::compare(const String &str, SizeType len, U32 mode) const
       return 0;
 
    return compare( str.c_str(), len, mode );
+}
+
+S32 String::compare(const char *str1, const char *str2)
+{
+   return strcmp(str1, str2);
+}
+
+S32 String::compare(const UTF16 *str1, const UTF16 *str2)
+{
+#if defined(TORQUE_OS_WIN) || defined(TORQUE_OS_XBOX) || defined(TORQUE_OS_XENON)
+   return wcscmp(reinterpret_cast<const wchar_t *>(str1), reinterpret_cast<const wchar_t *>(str2));
+#else
+   S32 ret;
+   const UTF16 *a, *b;
+   a = str1;
+   b = str2;
+
+   while (((ret = *a - *b) == 0) && *a && *b)
+      a++, b++;
+
+   return ret;
+#endif
 }
 
 bool String::equal(const String &str, U32 mode) const

--- a/Engine/source/core/util/str.h
+++ b/Engine/source/core/util/str.h
@@ -103,6 +103,8 @@ public:
    */
    S32 compare(const StringChar *str, SizeType len = 0, U32 mode = Case|Left) const;
    S32 compare(const String &str, SizeType len = 0, U32 mode = Case|Left) const; ///< @see compare(const StringChar *, SizeType, U32) const
+   static S32 compare(const char *str1, const char *str2);
+   static S32 compare(const UTF16 *str1, const UTF16 *str2);
 
    /**
       Compare two strings for equality.

--- a/Engine/source/core/util/tDictionary.h
+++ b/Engine/source/core/util/tDictionary.h
@@ -142,7 +142,7 @@ namespace KeyCmp
    template<>
    inline bool equals<>( const char * const &keya, const char * const &keyb )
    {
-      return ( dStrcmp( keya, keyb ) == 0 );
+      return ( String::compare( keya, keyb ) == 0 );
    }
 };
 

--- a/Engine/source/core/util/test/strTest.cpp
+++ b/Engine/source/core/util/test/strTest.cpp
@@ -103,8 +103,8 @@ TEST_FIX(Str, Test1)
       EXPECT_TRUE( !data.mData || dMemcmp( str.utf16(), data.mUTF16, str.length() * sizeof( UTF16 ) ) == 0 );
       EXPECT_TRUE( !data.mData || dMemcmp( str16.utf8(), data.mData, str.length() ) == 0 );
 
-      EXPECT_TRUE( !data.mData || dStrcmp( str.utf8(), data.mData ) == 0 );
-      EXPECT_TRUE( !data.mData || dStrcmp( str.utf16(), data.mUTF16 ) == 0 );
+      EXPECT_TRUE( !data.mData || String::compare( str.utf8(), data.mData ) == 0 );
+      EXPECT_TRUE( !data.mData || String::compare( str.utf16(), data.mUTF16 ) == 0 );
    }
 }
 

--- a/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
@@ -1457,7 +1457,7 @@ DefineEngineMethod( GuiRiverEditorCtrl, setNodeNormal, void, (Point3F normal), ,
 
 DefineEngineMethod( GuiRiverEditorCtrl, setSelectedRiver, void, (const char * objName), (""), "" )
 {
-   if (dStrcmp( objName,"" )==0)
+   if (String::compare( objName,"" )==0)
       object->setSelectedRiver(NULL);
    else
    {

--- a/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
@@ -1080,7 +1080,7 @@ DefineEngineMethod( GuiRoadEditorCtrl, setNodePosition, void, ( Point3F pos ), ,
 
 DefineEngineMethod( GuiRoadEditorCtrl, setSelectedRoad, void, ( const char * pathRoad ), (""), "" )
 {
-   if (dStrcmp( pathRoad,"")==0 )
+   if (String::compare( pathRoad,"")==0 )
       object->setSelectedRoad(NULL);
    else
    {

--- a/Engine/source/gfx/D3D11/gfxD3D11Shader.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Shader.cpp
@@ -1060,7 +1060,7 @@ void GFXD3D11Shader::_getShaderConstants( ID3D11ShaderReflection *refTable,
    #ifdef TORQUE_DEBUG
          AssertFatal(constantBufferDesc.Type == D3D_CT_CBUFFER, "Only scalar cbuffers supported for now.");
 
-         if (dStrcmp(constantBufferDesc.Name, "$Globals") != 0 && dStrcmp(constantBufferDesc.Name, "$Params") != 0)
+         if (String::compare(constantBufferDesc.Name, "$Globals") != 0 && String::compare(constantBufferDesc.Name, "$Params") != 0)
             AssertFatal(false, "Only $Global and $Params cbuffer supported for now.");
    #endif
    #ifdef D3D11_DEBUG_SPEW

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -1120,7 +1120,7 @@ DefineEngineFunction(saveCompositeTexture, void, (const char* pathR, const char*
 {
    U32 inputKey[4] = {0,0,0,0};
 
-   if (dStrcmp(inputKeyString, "") != 0)
+   if (String::compare(inputKeyString, "") != 0)
    {
       dSscanf(inputKeyString, "%i %i %i %i", &inputKey[0], &inputKey[1], &inputKey[2], &inputKey[3]);
    }

--- a/Engine/source/gui/controls/guiFileTreeCtrl.cpp
+++ b/Engine/source/gui/controls/guiFileTreeCtrl.cpp
@@ -315,7 +315,7 @@ void GuiFileTreeCtrl::recurseInsert( Item* parent, StringTableEntry path )
    {
       bool allowed = (_isDirInMainDotCsPath(value) || matchesFilters(value));
       Item *exists = parent->findChildByValue( szValue );
-      if( allowed && !exists && dStrcmp( curPos, "" ) != 0 )
+      if( allowed && !exists && String::compare( curPos, "" ) != 0 )
       {
          // Since we're adding a child this parent can't be a virtual parent, so clear that flag
          parent->setVirtualParent( false );
@@ -357,7 +357,7 @@ void GuiFileTreeCtrl::recurseInsert( Item* parent, StringTableEntry path )
    }
    if( delim )
    {
-      if( ( dStrcmp( delim, "" ) == 0 ) && item )
+      if( ( String::compare( delim, "" ) == 0 ) && item )
       {
          item->setExpanded( false );
          if( parent && _hasChildren( item->getValue() ) )

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -500,7 +500,7 @@ void GuiGameListMenuCtrl::addRow(const char* label, const char* optionsList, boo
       const char* option = StringUnit::getUnit(optionsList, i, DELIM);
       options.push_back(StringTable->insert(option, true));
 
-      if (dStrcmp(option, defaultValue) == 0)
+      if (String::compare(option, defaultValue) == 0)
          defaultOption = options.size() - 1;
    }
    row->mOptions = options;
@@ -1073,7 +1073,7 @@ bool GuiGameListMenuCtrl::selectOption(S32 rowIndex, const char* theOption)
 
    for (Vector<StringTableEntry>::iterator anOption = row->mOptions.begin(); anOption < row->mOptions.end(); ++anOption)
    {
-      if (dStrcmp(*anOption, theOption) == 0)
+      if (String::compare(*anOption, theOption) == 0)
       {
          S32 newIndex = anOption - row->mOptions.begin();
          row->mSelectedOption = newIndex;

--- a/Engine/source/gui/controls/guiGameListOptionsCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListOptionsCtrl.cpp
@@ -408,7 +408,7 @@ bool GuiGameListOptionsCtrl::selectOption(S32 rowIndex, const char * theOption)
 
    for (Vector<StringTableEntry>::iterator anOption = row->mOptions.begin(); anOption < row->mOptions.end(); ++anOption)
    {
-      if (dStrcmp(*anOption, theOption) == 0)
+      if (String::compare(*anOption, theOption) == 0)
       {
          S32 newIndex = anOption - row->mOptions.begin();
          row->mSelectedOption = newIndex;

--- a/Engine/source/gui/controls/guiListBoxCtrl.cpp
+++ b/Engine/source/gui/controls/guiListBoxCtrl.cpp
@@ -513,7 +513,7 @@ S32 GuiListBoxCtrl::findItemText( StringTableEntry text, bool caseSensitive )
    for( S32 i = 0; i < mItems.size(); i++ )
    {
       // Case Sensitive Compare?
-      if( caseSensitive && ( dStrcmp( mItems[i]->itemText, text ) == 0 ) )
+      if( caseSensitive && ( String::compare( mItems[i]->itemText, text ) == 0 ) )
          return i;
       else if (!caseSensitive && ( dStricmp( mItems[i]->itemText, text ) == 0 ))
          return i;
@@ -1584,7 +1584,7 @@ void GuiListBoxCtrl::addFilteredItem( String item )
    for ( S32 i = 0; i < mSelectedItems.size(); i++ ) 
    {
       String itemText = mSelectedItems[i]->itemText;
-      if ( dStrcmp( itemText.c_str(), item.c_str() ) == 0 ) 
+      if ( String::compare( itemText.c_str(), item.c_str() ) == 0 ) 
       {
          mSelectedItems.erase_fast( i );
          break;
@@ -1594,7 +1594,7 @@ void GuiListBoxCtrl::addFilteredItem( String item )
    for ( S32 i = 0; i < mItems.size(); i++ ) 
    {
       String itemText = mItems[i]->itemText;
-      if( dStrcmp( itemText.c_str(), item.c_str() ) == 0 )
+      if( String::compare( itemText.c_str(), item.c_str() ) == 0 )
       {  
          mItems[i]->isSelected = false;      
          mFilteredItems.push_front( mItems[i] );
@@ -1627,7 +1627,7 @@ void GuiListBoxCtrl::removeFilteredItem( String item )
    for ( S32 i = 0; i < mFilteredItems.size(); i++ ) 
    {
       String itemText = mFilteredItems[i]->itemText;
-      if( dStrcmp( itemText.c_str(), item.c_str() ) == 0 )
+      if( String::compare( itemText.c_str(), item.c_str() ) == 0 )
       {        
          mItems.push_front( mFilteredItems[i] );
          mFilteredItems.erase( &mFilteredItems[i] );

--- a/Engine/source/gui/controls/guiPopUpCtrl.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrl.cpp
@@ -629,7 +629,7 @@ void GuiPopUpMenuCtrl::addEntry( const char *buf, S32 id, U32 scheme )
    // Ensure that there are no other entries with exactly the same name
    for ( U32 i = 0; i < mEntries.size(); i++ )
    {
-      if ( dStrcmp( mEntries[i].buf, buf ) == 0 )
+      if ( String::compare( mEntries[i].buf, buf ) == 0 )
          return;
    }
 
@@ -745,7 +745,7 @@ S32 GuiPopUpMenuCtrl::findText( const char* text )
 {
    for ( U32 i = 0; i < mEntries.size(); i++ )
    {
-      if ( dStrcmp( text, mEntries[i].buf ) == 0 )
+      if ( String::compare( text, mEntries[i].buf ) == 0 )
          return( mEntries[i].id );        
    }
    return( -1 );

--- a/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
@@ -832,7 +832,7 @@ void GuiPopUpMenuCtrlEx::addEntry(const char *buf, S32 id, U32 scheme)
    // Ensure that there are no other entries with exactly the same name
    for ( U32 i = 0; i < mEntries.size(); i++ )
    {
-      if ( dStrcmp( mEntries[i].buf, buf ) == 0 )
+      if ( String::compare( mEntries[i].buf, buf ) == 0 )
          return;
    }
 
@@ -930,7 +930,7 @@ S32 GuiPopUpMenuCtrlEx::findText( const char* text )
 {
    for ( U32 i = 0; i < mEntries.size(); i++ )
    {
-      if ( dStrcmp( text, mEntries[i].buf ) == 0 )
+      if ( String::compare( text, mEntries[i].buf ) == 0 )
          return( mEntries[i].id );        
    }
    return( -1 );

--- a/Engine/source/gui/controls/guiTextEditCtrl.cpp
+++ b/Engine/source/gui/controls/guiTextEditCtrl.cpp
@@ -239,7 +239,7 @@ void GuiTextEditCtrl::updateHistory( StringBuffer *inTxt, bool moveIndex )
       return;
 
    // see if it's already in
-   if(mHistoryLast == -1 || dStrcmp(txt, mHistoryBuf[mHistoryLast]))
+   if(mHistoryLast == -1 || String::compare(txt, mHistoryBuf[mHistoryLast]))
    {
       if(mHistoryLast == mHistorySize-1) // we're at the history limit... shuffle the pointers around:
       {

--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -4372,7 +4372,7 @@ S32 GuiTreeViewCtrl::findItemByName(const char *name)
          continue;
       if( mItems[i]->mState.test( Item::InspectorData ) )
          continue;
-      if (mItems[i] && dStrcmp(mItems[i]->getText(),name) == 0) 
+      if (mItems[i] && String::compare(mItems[i]->getText(),name) == 0) 
          return mItems[i]->mId;
    }
 
@@ -4389,7 +4389,7 @@ S32 GuiTreeViewCtrl::findItemByValue(const char *name)
          continue;
       if( mItems[i]->mState.test( Item::InspectorData ) )
          continue;
-      if (mItems[i] && dStrcmp(mItems[i]->getValue(),name) == 0) 
+      if (mItems[i] && String::compare(mItems[i]->getValue(),name) == 0) 
          return mItems[i]->mId;
    }
 
@@ -5330,7 +5330,7 @@ DefineEngineMethod( GuiTreeViewCtrl, getTextToRoot, const char*, (S32 itemId, co
    "@param delimiter (Optional) delimiter to use between each branch concatenation."
    "@return text from the current node to the root.")
 {
-   if (!dStrcmp(delimiter, "" ))
+   if (!String::compare(delimiter, "" ))
    {
       Con::warnf("GuiTreeViewCtrl::getTextToRoot - Invalid number of arguments!");
       return ("");

--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -692,7 +692,7 @@ bool GuiControl::onAdd()
    const char *cName = getClassName();
 
    // if we're a pure GuiControl, then we're a container by default.
-   if ( dStrcmp( "GuiControl", cName ) == 0 )
+   if ( String::compare( "GuiControl", cName ) == 0 )
       mIsContainer = true;
 
    // Add to root group.

--- a/Engine/source/gui/editor/guiPopupMenuCtrl.cpp
+++ b/Engine/source/gui/editor/guiPopupMenuCtrl.cpp
@@ -108,7 +108,7 @@ void GuiPopupMenuTextListCtrl::onRenderCell(Point2I offset, Point2I cell, bool s
    }
    else
    {
-      if (dStrcmp(mList[cell.y].text + 3, "-\t")) //  Was: dStrcmp(mList[cell.y].text + 2, "-\t")) but has been changed to take into account the submenu flag
+      if (String::compare(mList[cell.y].text + 3, "-\t")) //  Was: String::compare(mList[cell.y].text + 2, "-\t")) but has been changed to take into account the submenu flag
       {
          Parent::onRenderCell(offset, cell, selected, mouseOver);
       }

--- a/Engine/source/gui/editor/inspector/dynamicField.cpp
+++ b/Engine/source/gui/editor/inspector/dynamicField.cpp
@@ -70,7 +70,7 @@ void GuiInspectorDynamicField::setData( const char* data, bool callbacks )
       const char *oldData = target->getDataField( mDynField->slotName, NULL );
       if ( !oldData )
          oldData = "";
-      if ( dStrcmp( oldData, data ) != 0 )
+      if ( String::compare( oldData, data ) != 0 )
       {
          target->inspectPreApply();
          

--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -648,7 +648,7 @@ bool GuiInspectorField::hasSameValueInAllObjects()
       if( !value2 )
          value2 = "";
 
-      if( dStrcmp( value1, value2 ) != 0 )
+      if( String::compare( value1, value2 ) != 0 )
          return false;
    }
          

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
@@ -132,7 +132,7 @@ bool GuiConvexEditorCtrl::onWake()
    SimGroup::iterator itr = scene->begin();
    for ( ; itr != scene->end(); itr++ )
    {
-      if ( dStrcmp( (*itr)->getClassName(), "ConvexShape" ) == 0 )
+      if ( String::compare( (*itr)->getClassName(), "ConvexShape" ) == 0 )
       {
          mConvexSEL = static_cast<ConvexShape*>( *itr );
          mGizmo->set( mConvexSEL->getTransform(), mConvexSEL->getPosition(), mConvexSEL->getScale() );

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
@@ -1974,11 +1974,11 @@ void GuiConvexEditorCtrl::setSelectedFaceMaterial(const char* materialName)
    bool found = false;
    U32 oldmatID = mConvexSEL->mSurfaceUVs[mFaceSEL].matID;
 
-   if (dStrcmp(materialName, mConvexSEL->getMaterialName().c_str()))
+   if (String::compare(materialName, mConvexSEL->getMaterialName().c_str()))
    {
       for (U32 i = 0; i < mConvexSEL->mSurfaceTextures.size(); i++)
       {
-         if (!dStrcmp(mConvexSEL->mSurfaceTextures[i].materialName, materialName))
+         if (!String::compare(mConvexSEL->mSurfaceTextures[i].materialName, materialName))
          {
             //found a match
             mConvexSEL->mSurfaceUVs[mFaceSEL].matID = i + 1;
@@ -2958,7 +2958,7 @@ DefineEngineMethod(GuiConvexEditorCtrl, setSelectedFaceMaterial, void, (const ch
    "@return true if successful, false if failed (objB is not valid)")
 {
    //return Point2F(0, 0);
-   if (!dStrcmp(materialName, ""))
+   if (!String::compare(materialName, ""))
       return;
 
    object->setSelectedFaceMaterial(materialName);

--- a/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
@@ -881,7 +881,7 @@ DefineEngineMethod( GuiDecalEditorCtrl, getSelectionCount, S32, (), , "" )
 
 DefineEngineMethod( GuiDecalEditorCtrl, retargetDecalDatablock, void, ( const char * dbFrom, const char * dbTo ), , "" )
 {
-   if( dStrcmp( dbFrom, "" ) != 0 && dStrcmp( dbTo, "" ) != 0 )
+   if( String::compare( dbFrom, "" ) != 0 && String::compare( dbTo, "" ) != 0 )
 		object->retargetDecalDatablock( dbFrom, dbTo );
 }
 

--- a/Engine/source/gui/worldEditor/guiMissionAreaEditor.cpp
+++ b/Engine/source/gui/worldEditor/guiMissionAreaEditor.cpp
@@ -97,7 +97,7 @@ void GuiMissionAreaEditorCtrl::setSelectedMissionArea( MissionArea *missionArea 
 
 DefineEngineMethod( GuiMissionAreaEditorCtrl, setSelectedMissionArea, void, (const char * missionAreaName), (""), "" )
 {
-   if ( dStrcmp( missionAreaName, "" )==0 )
+   if ( String::compare( missionAreaName, "" )==0 )
       object->setSelectedMissionArea(NULL);
    else
    {

--- a/Engine/source/gui/worldEditor/terrainEditor.cpp
+++ b/Engine/source/gui/worldEditor/terrainEditor.cpp
@@ -867,7 +867,7 @@ bool TerrainEditor::isMainTile(const GridPoint & gPoint) const
    const S32 blockSize = (S32)gPoint.terrainBlock->getBlockSize();
 
    Point2I testPos = gPoint.gridPos;
-   if (!dStrcmp(getCurrentAction(),"paintMaterial"))
+   if (!String::compare(getCurrentAction(),"paintMaterial"))
    {
       if (testPos.x == blockSize)
          testPos.x--;
@@ -1181,7 +1181,7 @@ TerrainBlock* TerrainEditor::collide(const Gui3DMouseEvent & evt, Point3F & pos)
    if (mTerrainBlocks.size() == 0)
       return NULL;
 
-   if ( mMouseDown && !dStrcmp(getCurrentAction(),"paintMaterial") )
+   if ( mMouseDown && !String::compare(getCurrentAction(),"paintMaterial") )
    {
       if ( !mActiveTerrain )
          return NULL;
@@ -1780,7 +1780,7 @@ void TerrainEditor::on3DMouseDown(const Gui3DMouseEvent & event)
    if(mTerrainBlocks.size() == 0)
       return;
 
-   if (!dStrcmp(getCurrentAction(),"paintMaterial"))
+   if (!String::compare(getCurrentAction(),"paintMaterial"))
    {
       Point3F pos;
       TerrainBlock* hitTerrain = collide(event, pos);
@@ -1805,7 +1805,7 @@ void TerrainEditor::on3DMouseDown(const Gui3DMouseEvent & event)
          return;
       }
    }
-   else if ((event.modifier & SI_ALT) && !dStrcmp(getCurrentAction(),"setHeight"))
+   else if ((event.modifier & SI_ALT) && !String::compare(getCurrentAction(),"setHeight"))
    {
       // Set value to terrain height at mouse position
       GridInfo info;
@@ -1847,7 +1847,7 @@ void TerrainEditor::on3DMouseMove(const Gui3DMouseEvent & event)
       // We do not change the active terrain as the mouse moves when
       // in painting mode.  This is because it causes the material 
       // window to change as you cursor over to it.
-      if ( dStrcmp(getCurrentAction(),"paintMaterial") != 0 )
+      if ( String::compare(getCurrentAction(),"paintMaterial") != 0 )
       {
          // Set the active terrain
          bool changed = mActiveTerrain != hitTerrain;
@@ -2028,7 +2028,7 @@ void TerrainEditor::getTerrainBlocksMaterialList(Vector<StringTableEntry>& list)
 
 void TerrainEditor::setBrushType( const char *type )
 {
-   if ( mMouseBrush && dStrcmp( mMouseBrush->getType(), type ) == 0 )
+   if ( mMouseBrush && String::compare( mMouseBrush->getType(), type ) == 0 )
       return;
 
    if(!dStricmp(type, "box"))
@@ -2199,7 +2199,7 @@ void TerrainEditor::processAction(const char* sAction)
       return;
 
    TerrainAction * action = mCurrentAction;
-   if (dStrcmp(sAction, "") != 0)
+   if (String::compare(sAction, "") != 0)
    {
       action = lookupAction(sAction);
 

--- a/Engine/source/gui/worldEditor/terrainEditor.cpp
+++ b/Engine/source/gui/worldEditor/terrainEditor.cpp
@@ -2415,7 +2415,7 @@ DefineEngineMethod( TerrainEditor, attachTerrain, void, (const char * terrain), 
    VectorPtr<TerrainBlock*> terrains;
 
    // attach to first found terrainBlock
-   if (dStrcmp (terrain,"")==0)
+   if (String::compare (terrain,"")==0)
    {
       for(SimSetIterator itr(scene); *itr; ++itr)
       {

--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -707,33 +707,33 @@ DefineEngineMethod( Material, getAnimFlags, const char*, (U32 id), , "" )
 
    if(object->mAnimFlags[ id ] & Material::Scroll)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Scroll", 512 );
    }
    if(object->mAnimFlags[ id ] & Material::Rotate)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Rotate", 512 );
 	   else
 			dStrcat( animFlags, " | $Rotate", 512);
    }
    if(object->mAnimFlags[ id ] & Material::Wave)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Wave", 512 );
 	   else
 			dStrcat( animFlags, " | $Wave", 512);
    }
    if(object->mAnimFlags[ id ] & Material::Scale)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Scale", 512 );
 	   else
 			dStrcat( animFlags, " | $Scale", 512);
    }
    if(object->mAnimFlags[ id ] & Material::Sequence)
    {
-	   if(dStrcmp( animFlags, "" ) == 0)
+	   if(String::compare( animFlags, "" ) == 0)
 	      dStrcpy( animFlags, "$Sequence", 512 );
 	   else
 			dStrcat( animFlags, " | $Sequence", 512);

--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -323,7 +323,7 @@ void ProcessedShaderMaterial::_determineFeatures(  U32 stageNum,
 
    // TODO: This sort of sucks... BL should somehow force this
    // feature on from the outside and not this way.
-   if (dStrcmp(LIGHTMGR->getId(), "BLM") == 0)
+   if (String::compare(LIGHTMGR->getId(), "BLM") == 0)
    {
       fd.features.addFeature(MFT_ForwardShading);
       fd.features.addFeature(MFT_ReflectionProbes);

--- a/Engine/source/module/moduleManager.cpp
+++ b/Engine/source/module/moduleManager.cpp
@@ -83,7 +83,7 @@ S32 QSORT_CALLBACK moduleDependencySort(const void* a, const void* b)
    bool foundDependant = false;
    for (ModuleDefinition::typeModuleDependencyVector::const_iterator dependencyItr = moduleDependencies.begin(); dependencyItr != moduleDependencies.end(); ++dependencyItr)
    {
-      if (dStrcmp(dependencyItr->mModuleId, pDefinition2->getModuleId())
+      if (String::compare(dependencyItr->mModuleId, pDefinition2->getModuleId())
          && (dependencyItr->mVersionId == pDefinition2->getVersionId()))
             foundDependant = true;
    }

--- a/Engine/source/navigation/navPath.cpp
+++ b/Engine/source/navigation/navPath.cpp
@@ -136,7 +136,7 @@ bool NavPath::setProtectedFrom(void *obj, const char *index, const char *data)
 {
    NavPath *object = static_cast<NavPath*>(obj);
 
-   if(dStrcmp(data, ""))
+   if(String::compare(data, ""))
    {
       object->mFromSet = true;
       return true;
@@ -152,7 +152,7 @@ bool NavPath::setProtectedTo(void *obj, const char *index, const char *data)
 {
    NavPath *object = static_cast<NavPath*>(obj);
 
-   if(dStrcmp(data, ""))
+   if(String::compare(data, ""))
    {
       object->mToSet = true;
       return true;
@@ -713,7 +713,7 @@ DefineEngineMethod(NavPath, plan, bool, (),,
 DefineEngineMethod(NavPath, onNavMeshUpdate, void, (const char *data),,
    "@brief Callback when this path's NavMesh is loaded or rebuilt.")
 {
-   if(object->mMesh && !dStrcmp(data, object->mMesh->getIdString()))
+   if(object->mMesh && !String::compare(data, object->mMesh->getIdString()))
       object->plan();
 }
 

--- a/Engine/source/platform/nativeDialogs/fileDialog.cpp
+++ b/Engine/source/platform/nativeDialogs/fileDialog.cpp
@@ -198,7 +198,7 @@ bool FileDialog::Execute()
       //The first of each pair is the name, which we'll skip because NFD doesn't support named filters atm
       String filter = StringUnit::getUnit(mData.mFilters, i, "|");
 
-      if (!dStrcmp(filter.c_str(), "*.*"))
+      if (!String::compare(filter.c_str(), "*.*"))
          continue;
 
       U32 subFilterCount = StringUnit::getUnitCount(filter, ";");

--- a/Engine/source/platform/platformFileIO.cpp
+++ b/Engine/source/platform/platformFileIO.cpp
@@ -206,7 +206,7 @@ void Platform::clearExcludedDirectories()
 bool Platform::isExcludedDirectory(const char *pDir)
 {
    for(CharVector::iterator i=gPlatformDirectoryExcludeList.begin(); i!=gPlatformDirectoryExcludeList.end(); i++)
-      if(!dStrcmp(pDir, *i))
+      if(!String::compare(pDir, *i))
          return true;
 
    return false;
@@ -349,18 +349,18 @@ char * Platform::makeFullPathName(const char *path, char *buffer, U32 size, cons
 
          // Directory
 
-         if(dStrcmp(ptr, "..") == 0)
+         if(String::compare(ptr, "..") == 0)
          {
             // Parent
             endptr = dStrrchr(buffer, '/');
             if (endptr)
                *endptr-- = 0;
          }
-         else if(dStrcmp(ptr, ".") == 0)
+         else if(String::compare(ptr, ".") == 0)
          {
             // Current dir
          }
-         else if(dStrcmp(ptr, "~") == 0)
+         else if(String::compare(ptr, "~") == 0)
          {
             catPath(endptr, defaultDir, size - (endptr - buffer));
             endptr += dStrlen(endptr) - 1;

--- a/Engine/source/platform/platformFileIO.cpp
+++ b/Engine/source/platform/platformFileIO.cpp
@@ -101,7 +101,7 @@ static bool deleteDirectoryRecusrive(const char* pPath)
       StringTableEntry basePath = *basePathItr;
 
       // Skip if the base path.
-      if (basePathItr == directories.begin() && dStrcmp(pPath, basePath) == 0)
+      if (basePathItr == directories.begin() && String::compare(pPath, basePath) == 0)
          continue;
 
       // Delete any directories recursively.

--- a/Engine/source/platform/platformRedBook.cpp
+++ b/Engine/source/platform/platformRedBook.cpp
@@ -215,7 +215,7 @@ DefineEngineFunction( redbookOpen, bool, (const char * device), (""), "(string d
 				"@brief Deprecated\n\n"
 				"@internal")
 {
-   if(dStrcmp(device,"")==0)
+   if(String::compare(device,"")==0)
       return(RedBook::open(RedBook::getDeviceName(0)));
    else
       return(RedBook::open(device));

--- a/Engine/source/platform/profiler.cpp
+++ b/Engine/source/platform/profiler.cpp
@@ -260,7 +260,7 @@ static Profiler aProfiler; // allocate the global profiler
 ProfilerRootData::ProfilerRootData(const char *name)
 {
    for(ProfilerRootData *walk = sRootList; walk; walk = walk->mNextRoot)
-      if(!dStrcmp(walk->mName, name))
+      if(!String::compare(walk->mName, name))
          AssertFatal( false, avar( "Duplicate profile name: %s", name ) );
 
    mName = name;
@@ -702,7 +702,7 @@ void Profiler::enableMarker(const char *marker, bool enable)
       }
       else
       {
-         if(!dStrcmp(marker, data->mName))
+         if(!String::compare(marker, data->mName))
             data->mEnabled = enable;
       }
    }

--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -625,7 +625,7 @@ static bool recurseDumpPath(const char *path, const char *pattern, Vector<Platfo
             continue;
 
          // skip . and .. directories
-         if (dStrcmp( findData.cFileName, TEXT( "." ) ) == 0 || dStrcmp( findData.cFileName, TEXT( ".." ) ) == 0)
+         if (String::compare( findData.cFileName, TEXT( "." ) ) == 0 || String::compare( findData.cFileName, TEXT( ".." ) ) == 0)
             continue;
 
          // Skip excluded directores
@@ -1096,7 +1096,7 @@ bool Platform::isSubDirectory(const char *pParent, const char *pDir)
          //FIXME: this has to be dStrcasecmp but there's no implementation for Unicode
 
          // and the names match
-         if (dStrcmp(dir, findData.cFileName ) == 0)
+         if (String::compare(dir, findData.cFileName ) == 0)
          {
             // then we have a real sub directory
             FindClose(handle);
@@ -1282,7 +1282,7 @@ bool Platform::hasSubDirectory(const char *pPath)
       if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
       {
          // skip . and .. directories
-         if (dStrcmp(findData.cFileName, TEXT( "." ) ) == 0 || dStrcmp(findData.cFileName, TEXT( ".." ) ) == 0)
+         if (String::compare(findData.cFileName, TEXT( "." ) ) == 0 || String::compare(findData.cFileName, TEXT( ".." ) ) == 0)
             continue;
 
 #ifdef UNICODE
@@ -1417,7 +1417,7 @@ static bool recurseDumpDirectories(const char *basePath, const char *subPath, Ve
       if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
       {
          // skip . and .. directories
-         if (dStrcmp(findData.cFileName, TEXT( "." )) == 0 || dStrcmp(findData.cFileName, TEXT( ".." )) == 0)
+         if (String::compare(findData.cFileName, TEXT( "." )) == 0 || String::compare(findData.cFileName, TEXT( ".." )) == 0)
             continue;
 
 #ifdef UNICODE

--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -1874,7 +1874,7 @@ DefineEngineMethod(SceneObject, attachToParent, bool, (const char*_sceneObject),
     }
     else
     {      
-        if ((!dStrcmp("0", _sceneObject))|| (!dStrcmp("", _sceneObject)))
+        if ((!String::compare("0", _sceneObject))|| (!String::compare("", _sceneObject)))
             return object->attachToParent(NULL);
         else
         {

--- a/Engine/source/sfx/openal/aldlist.cpp
+++ b/Engine/source/sfx/openal/aldlist.cpp
@@ -61,7 +61,7 @@ ALDeviceList::ALDeviceList( const OPENALFNTABLE &oalft )
       index = 0;
       // go through device list (each device terminated with a single NULL, list terminated with double NULL)
       while (*devices != 0) {
-         if (dStrcmp(defaultDeviceName, devices) == 0) {
+         if (String::compare(defaultDeviceName, devices) == 0) {
             defaultDeviceIndex = index;
          }
          ALCdevice *device = ALFunction.alcOpenDevice(devices);
@@ -73,7 +73,7 @@ ALDeviceList::ALDeviceList( const OPENALFNTABLE &oalft )
                actualDeviceName = ALFunction.alcGetString(device, ALC_DEVICE_SPECIFIER);
                bool bNewName = true;
                for (int i = 0; i < GetNumDevices(); i++) {
-                  if (dStrcmp(GetDeviceName(i), actualDeviceName) == 0) {
+                  if (String::compare(GetDeviceName(i), actualDeviceName) == 0) {
                      bNewName = false;
                   }
                }

--- a/Engine/source/sfx/sfxSource.cpp
+++ b/Engine/source/sfx/sfxSource.cpp
@@ -1576,14 +1576,14 @@ DefineEngineMethod( SFXSource, setTransform, void, ( const char * position, cons
 {
    MatrixF mat = object->getTransform();
 
-   if(dStrcmp( position , "")!=0 )
+   if(String::compare( position , "")!=0 )
    {
       Point3F pos;
       dSscanf( position, "%g %g %g", &pos.x, &pos.y, &pos.z );
       mat.setPosition( pos );
    }
    
-   if(dStrcmp( direction ,"")!=0 )
+   if(String::compare( direction ,"")!=0 )
    {
       Point3F dir;
       dSscanf( direction, "%g %g %g", &dir.x, &dir.y, &dir.z );

--- a/Engine/source/shaderGen/GLSL/shaderCompGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderCompGLSL.cpp
@@ -309,7 +309,7 @@ void VertPixelConnectorGLSL::print( Stream &stream, bool isVerterShader )
       U8 output[256];
 
       Var *var = mElementList[i];
-      if(!dStrcmp((const char*)var->name, "gl_Position"))
+      if(!String::compare((const char*)var->name, "gl_Position"))
          continue;
 
       if(var->arraySize <= 1)
@@ -339,7 +339,7 @@ void VertPixelConnectorGLSL::printOnMain( Stream &stream, bool isVerterShader )
       U8 output[256];
 
       Var *var = mElementList[i];
-      if(!dStrcmp((const char*)var->name, "gl_Position"))
+      if(!String::compare((const char*)var->name, "gl_Position"))
          continue;
   
       dSprintf((char*)output, sizeof(output), "   %s IN_%s = _%s_;\r\n", var->type, var->name, var->connectName);      
@@ -415,7 +415,7 @@ void VertPixelConnectorGLSL::printStructDefines( Stream &stream, bool in )
       U8 output[256];
 
       Var *var = mElementList[i];
-      if(!dStrcmp((const char*)var->name, "gl_Position"))
+      if(!String::compare((const char*)var->name, "gl_Position"))
          continue;      
   
       if(!in)

--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -195,14 +195,14 @@ Var * ShaderFeatureGLSL::getVertTexCoord( const String &name )
 
    for( U32 i=0; i<LangElement::elementList.size(); i++ )
    {
-      if( !dStrcmp( (char*)LangElement::elementList[i]->name, name.c_str() ) )
+      if( !String::compare( (char*)LangElement::elementList[i]->name, name.c_str() ) )
       {
          inTex = dynamic_cast<Var*>( LangElement::elementList[i] );
 			if ( inTex )
 			{
             // NOTE: This used to do this check...
             //
-            // dStrcmp( (char*)inTex->structName, "IN" )
+            // String::compare( (char*)inTex->structName, "IN" )
             //
             // ... to ensure that the var was from the input
             // vertex structure, but this kept some features
@@ -389,7 +389,7 @@ Var* ShaderFeatureGLSL::getOutTexCoord(   const char *name,
 		}
 	}
 
-   AssertFatal( dStrcmp( type, (const char*)texCoord->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)texCoord->type ) == 0,
       "ShaderFeatureGLSL::getOutTexCoord - Type mismatch!" );
 
    return texCoord;
@@ -409,7 +409,7 @@ Var* ShaderFeatureGLSL::getInTexCoord( const char *name,
       texCoord->setType( type );
    }
 
-   AssertFatal( dStrcmp( type, (const char*)texCoord->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)texCoord->type ) == 0,
       "ShaderFeatureGLSL::getInTexCoord - Type mismatch!" );
 
    return texCoord;
@@ -429,7 +429,7 @@ Var* ShaderFeatureGLSL::getInColor( const char *name,
       inColor->setType( type );
    }
 
-   AssertFatal( dStrcmp( type, (const char*)inColor->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)inColor->type ) == 0,
       "ShaderFeatureGLSL::getInColor - Type mismatch!" );
 
    return inColor;

--- a/Engine/source/shaderGen/HLSL/shaderCompHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderCompHLSL.cpp
@@ -297,19 +297,19 @@ void ParamsDefHLSL::assignConstantNumbers()
             {
                var->constNum = mCurrConst;
                // Increment our constant number based on the variable type
-               if (dStrcmp((const char*)var->type, "float4x4") == 0)
+               if (String::compare((const char*)var->type, "float4x4") == 0)
                {
                   mCurrConst += (4 * var->arraySize);
                }
                else
                {
-                  if (dStrcmp((const char*)var->type, "float3x3") == 0)
+                  if (String::compare((const char*)var->type, "float3x3") == 0)
                   {
                      mCurrConst += (3 * var->arraySize);
                   }
                   else
                   {
-                     if (dStrcmp((const char*)var->type, "float4x3") == 0)
+                     if (String::compare((const char*)var->type, "float4x3") == 0)
                      {
                         mCurrConst += (3 * var->arraySize);
                      }

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -195,14 +195,14 @@ Var * ShaderFeatureHLSL::getVertTexCoord( const String &name )
 
    for( U32 i=0; i<LangElement::elementList.size(); i++ )
    {
-      if( !dStrcmp( (char*)LangElement::elementList[i]->name, name.c_str() ) )
+      if( !String::compare( (char*)LangElement::elementList[i]->name, name.c_str() ) )
       {
          inTex = dynamic_cast<Var*>( LangElement::elementList[i] );
          if ( inTex )
          {
             // NOTE: This used to do this check...
             //
-            // dStrcmp( (char*)inTex->structName, "IN" )
+            // String::compare( (char*)inTex->structName, "IN" )
             //
             // ... to ensure that the var was from the input
             // vertex structure, but this kept some features
@@ -389,7 +389,7 @@ Var* ShaderFeatureHLSL::getOutTexCoord(   const char *name,
       }
    }
 
-   AssertFatal( dStrcmp( type, (const char*)texCoord->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)texCoord->type ) == 0, 
       "ShaderFeatureHLSL::getOutTexCoord - Type mismatch!" );
 
    return texCoord;
@@ -409,7 +409,7 @@ Var* ShaderFeatureHLSL::getInTexCoord( const char *name,
       texCoord->setType( type );
    }
 
-   AssertFatal( dStrcmp( type, (const char*)texCoord->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)texCoord->type ) == 0, 
       "ShaderFeatureHLSL::getInTexCoord - Type mismatch!" );
 
    return texCoord;
@@ -429,7 +429,7 @@ Var* ShaderFeatureHLSL::getInColor( const char *name,
       inColor->setType( type );
    }
 
-   AssertFatal( dStrcmp( type, (const char*)inColor->type ) == 0, 
+   AssertFatal( String::compare( type, (const char*)inColor->type ) == 0, 
       "ShaderFeatureHLSL::getInColor - Type mismatch!" );
 
    return inColor;

--- a/Engine/source/shaderGen/langElement.cpp
+++ b/Engine/source/shaderGen/langElement.cpp
@@ -48,7 +48,7 @@ LangElement * LangElement::find( const char *name )
 {
    for( U32 i=0; i<elementList.size(); i++ )
    {
-      if( !dStrcmp( (char*)elementList[i]->name, name ) )
+      if( !String::compare( (char*)elementList[i]->name, name ) )
       {
          return elementList[i];
       }

--- a/Engine/source/sim/netConnection.cpp
+++ b/Engine/source/sim/netConnection.cpp
@@ -1141,7 +1141,7 @@ void NetConnection::packString(BitStream *stream, const char *str)
       char buf[16];
       S32 num = dAtoi(str);
       dSprintf(buf, sizeof(buf), "%d", num);
-      if(!dStrcmp(buf, str))
+      if(!String::compare(buf, str))
       {
          stream->writeInt(Integer, 2);
          if(stream->writeFlag(num < 0))

--- a/Engine/source/sim/netStringTable.cpp
+++ b/Engine/source/sim/netStringTable.cpp
@@ -72,7 +72,7 @@ U32 NetStringTable::addString(const char *string)
    U32 bucket = hash % HashTableSize;
    for(U32 walk = hashTable[bucket];walk; walk = table[walk].next)
    {
-      if(!dStrcmp(table[walk].string, string))
+      if(!String::compare(table[walk].string, string))
       {
          table[walk].refCount++;
          return walk;

--- a/Engine/source/terrain/terrCell.cpp
+++ b/Engine/source/terrain/terrCell.cpp
@@ -1073,7 +1073,7 @@ void TerrCell::preloadMaterials()
       material->getReflectMat();
 
       if (  GFX->getPixelShaderVersion() > 2.0f && 
-            dStrcmp( LIGHTMGR->getId(), "BLM" ) != 0)
+            String::compare( LIGHTMGR->getId(), "BLM" ) != 0)
          material->getDeferredMat();
    }
 

--- a/Engine/source/terrain/terrCellMaterial.cpp
+++ b/Engine/source/terrain/terrCellMaterial.cpp
@@ -347,7 +347,7 @@ bool TerrainCellMaterial::_createPass( Vector<MaterialInfo*> *materials,
    // TODO: This seems ugly... we should trigger
    // features like this differently in the future.
    //
-   bool useBLM = dStrcmp( LIGHTMGR->getId(), "BLM" ) == 0;
+   bool useBLM = String::compare( LIGHTMGR->getId(), "BLM" ) == 0;
 
    // Do we need to disable normal mapping?
    const bool disableNormalMaps = MATMGR->getExclusionFeatures().hasFeature( MFT_NormalMap ) || useBLM;

--- a/Engine/source/ts/assimp/assimpAppMaterial.cpp
+++ b/Engine/source/ts/assimp/assimpAppMaterial.cpp
@@ -129,7 +129,7 @@ void AssimpAppMaterial::initMaterial(const Torque::Path& path, Material* mat) co
       aiString opacityMode;
       if (AI_SUCCESS == mAIMat->Get("$mat.gltf.alphaMode", 0, 0, opacityMode))
       {
-         if (dStrcmp("MASK", opacityMode.C_Str()) == 0)
+         if (String::compare("MASK", opacityMode.C_Str()) == 0)
          {
             translucent = true;
             blendOp = Material::None;
@@ -141,7 +141,7 @@ void AssimpAppMaterial::initMaterial(const Torque::Path& path, Material* mat) co
                mat->mAlphaTest = true;
             }
          }
-         else if (dStrcmp("BLEND", opacityMode.C_Str()) == 0)
+         else if (String::compare("BLEND", opacityMode.C_Str()) == 0)
          {
             translucent = true;
             blendOp = Material::LerpAlpha;

--- a/Engine/source/ts/collada/colladaExtensions.h
+++ b/Engine/source/ts/collada/colladaExtensions.h
@@ -90,7 +90,7 @@ protected:
          // search the technique contents for the desired parameter
          for (S32 iParam = 0; iParam < pTechnique->getContents().getCount(); iParam++) {
             const domAny* param = daeSafeCast<domAny>(pTechnique->getContents()[iParam]);
-            if (param && !dStrcmp(param->getElementName(), name))
+            if (param && !String::compare(param->getElementName(), name))
                return param;
          }
       }

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -530,7 +530,7 @@ bool ColladaShapeLoader::canLoadCachedDTS(const Torque::Path& path)
 
    //assume the dts is good since it was zipped on purpose
    Torque::FS::FileSystemRef ref = Torque::FS::GetFileSystem(cachedPath);
-   if (ref && !dStrcmp("Zip", ref->getTypeStr()))
+   if (ref && !String::compare("Zip", ref->getTypeStr()))
    {
       bool forceLoadDAE = Con::getBoolVariable("$collada::forceLoadDAE", false);
 
@@ -722,7 +722,7 @@ TSShape* loadColladaShape(const Torque::Path &path)
          if (dtsStream.open(cachedPath.getFullPath(), Torque::FS::File::Write))
          {
             Torque::FS::FileSystemRef ref = Torque::FS::GetFileSystem(daePath);
-            if (ref && !dStrcmp("Zip", ref->getTypeStr()))
+            if (ref && !String::compare("Zip", ref->getTypeStr()))
                Con::errorf("No cached dts file found in archive for %s. Forcing cache to disk.", daePath.getFullFileName().c_str());
 
             Con::printf("Writing cached COLLADA shape to %s", cachedPath.getFullPath().c_str());

--- a/Engine/source/ts/collada/colladaUtils.cpp
+++ b/Engine/source/ts/collada/colladaUtils.cpp
@@ -269,7 +269,7 @@ void AnimData::parseTargetString(const char* target, S32 fullCount, const char* 
    else if (const char* p2 = dStrrchr(target, '.')) {
       // Check for named elements
       for (S32 iElem = 0; elements[iElem][0] != 0; iElem++) {
-         if (!dStrcmp(p2, elements[iElem])) {
+         if (!String::compare(p2, elements[iElem])) {
             targetValueOffset = iElem;
             targetValueCount = 1;
             break;

--- a/Engine/source/ts/tsShapeConstruct.cpp
+++ b/Engine/source/ts/tsShapeConstruct.cpp
@@ -735,7 +735,7 @@ DefineTSShapeConstructorMethod( writeChangeSet, void, (),,
    while ( !f.isEOF() )
    {
       const char* buffer = (const char *) f.readLine();
-      if ( !dStrcmp( buffer, beginMessage ))
+      if ( !String::compare( buffer, beginMessage ))
          break;
       stream->writeText( buffer );
       stream->writeText( "\r\n" );
@@ -756,7 +756,7 @@ DefineTSShapeConstructorMethod( writeChangeSet, void, (),,
    while ( !f.isEOF() )
    {
       const char* buffer = (const char *) f.readLine();
-      if ( !dStrcmp( buffer, endMessage ))
+      if ( !String::compare( buffer, endMessage ))
          break;
    }
 

--- a/Engine/source/ts/tsShapeEdit.cpp
+++ b/Engine/source/ts/tsShapeEdit.cpp
@@ -425,7 +425,7 @@ bool TSShape::addNode(const String& name, const String& parentName, const Point3
 
    // Find the parent node (OK for name to be empty => node is at root level)
    S32 parentIndex = -1;
-   if (dStrcmp(parentName, ""))
+   if (String::compare(parentName, ""))
    {
       parentIndex = findNode(parentName);
       if (parentIndex < 0)

--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -497,7 +497,7 @@ void TSShapeInstance::setMeshForceHidden( const char *meshName, bool hidden )
       S32 nameIndex = iter->object->nameIndex;
       const char *name = mShape->names[ nameIndex ];
 
-      if ( dStrcmp( meshName, name ) == 0 )
+      if ( String::compare( meshName, name ) == 0 )
       {
          iter->forceHidden = hidden;
          return;

--- a/Engine/source/util/messaging/eventManager.cpp
+++ b/Engine/source/util/messaging/eventManager.cpp
@@ -508,7 +508,7 @@ DefineEngineMethod( EventManager, dumpSubscribers, void, ( const char * listener
               "Print all subscribers to an event to the console.\n"
               "@param event The event whose subscribers are to be printed. If this parameter isn't specified, all events will be dumped." )
 {
-   if (dStrcmp(listenerName, "") != 0)
+   if (String::compare(listenerName, "") != 0)
       object->dumpSubscribers( listenerName );
    else
       object->dumpSubscribers();

--- a/Engine/source/util/settings.cpp
+++ b/Engine/source/util/settings.cpp
@@ -92,9 +92,9 @@ const UTF8 *Settings::value(const UTF8 *settingName, const UTF8 *defaultValue)
    const UTF8 *storedDefaultValue = getDataField(defaultNameEntry, NULL);
    setModStaticFields(true);
 
-   if(dStrcmp(value, "") != 0)
+   if(String::compare(value, "") != 0)
       return value;
-   else if(dStrcmp(storedDefaultValue, "") != 0)
+   else if(String::compare(storedDefaultValue, "") != 0)
       return storedDefaultValue;
    else
 	  return defaultValue;
@@ -124,9 +124,9 @@ void Settings::remove(const UTF8 *settingName, bool includeDefaults)
         SimFieldDictionary::Entry* fieldEntry = *itr;
 
         // is this a field of our current group
-        if ( (dStrcmp(nameEntry, "") == 0) || 
-					dStrcmp( nameEntry, fieldEntry->slotName ) == 0 ||
-					(includeDefaults && dStrcmp( nameEntryDefault, fieldEntry->slotName ) == 0) )
+        if ( (String::compare(nameEntry, "") == 0) || 
+					String::compare( nameEntry, fieldEntry->slotName ) == 0 ||
+					(includeDefaults && String::compare( nameEntryDefault, fieldEntry->slotName ) == 0) )
         {
             // Yes, so remove it.
             pFieldDictionary->setFieldValue( fieldEntry->slotName, "" );
@@ -297,7 +297,7 @@ void Settings::readLayer(SimXMLDocument *document, String groupStack)
 	  const UTF8 *name = document->attribute("name");
 	  const UTF8 *value = document->getText();
 	  
-	  if(dStrcmp(type, "Group") == 0)
+	  if(String::compare(type, "Group") == 0)
 	  {
 		 String newStack = groupStack;
 
@@ -306,7 +306,7 @@ void Settings::readLayer(SimXMLDocument *document, String groupStack)
 
 		 newStack += name;
          readLayer(document, newStack);
-	  } else if(dStrcmp(type, "Setting") == 0)
+	  } else if(String::compare(type, "Setting") == 0)
 	  {
 		 String nameString = groupStack;
          
@@ -678,9 +678,9 @@ DefineEngineMethod(Settings, value, const char*, (const char * settingName, cons
 {
    StringTableEntry fieldName = StringTable->insert( settingName );
    
-   if (dStrcmp(defaultValue, "") != 0)
+   if (String::compare(defaultValue, "") != 0)
       return object->value( fieldName, defaultValue );
-   else if (dStrcmp(settingName, "") != 0)
+   else if (String::compare(settingName, "") != 0)
       return object->value( fieldName );
 
    return "";

--- a/Engine/source/windowManager/win32/winDispatch.cpp
+++ b/Engine/source/windowManager/win32/winDispatch.cpp
@@ -391,7 +391,7 @@ static bool _dispatch(HWND hWnd,UINT message,WPARAM wParam,WPARAM lParam)
 
 			// FIXME [tom, 5/1/2007] Hard coding this is lame since there's a const in win32Window.cpp
 			// CodeReview - this fails if there is a second jug app in the arena.
-			if (hwnd == NULL || dStrcmp(classBuf, L"TorqueJuggernaughtWindow") != 0)
+			if (hwnd == NULL || String::compare(classBuf, L"TorqueJuggernaughtWindow") != 0)
 			{
 				// We are being made inactive and the window being made active isn't
 				// a jugg window. Thus, we need to deactivate input.


### PR DESCRIPTION
Moves from using dStrCmp to the new String::compare static functions keeps things cleaner, consistent, and works with intellisense.

This is the part of the move to replace usage of the old dStr___ functions for the more standard String namespace approach.

Original PR at GarageGames repo:
https://github.com/GarageGames/Torque3D/pull/1323