### PR TITLE
Overhauls the handling of probes to utilize an active probe list

### DIFF
--- a/Engine/source/T3D/lighting/boxEnvironmentProbe.cpp
+++ b/Engine/source/T3D/lighting/boxEnvironmentProbe.cpp
@@ -158,11 +158,8 @@ void BoxEnvironmentProbe::unpackUpdate(NetConnection *conn, BitStream *stream)
 
 void BoxEnvironmentProbe::updateProbeParams()
 {
-   if (!mProbeInfo)
-      return;
-
    mProbeShapeType = ProbeRenderInst::Box;
-   mProbeInfo->mAtten = mAtten;
+   mProbeInfo.mAtten = mAtten;
 
    Parent::updateProbeParams();
 }

--- a/Engine/source/T3D/lighting/reflectionProbe.cpp
+++ b/Engine/source/T3D/lighting/reflectionProbe.cpp
@@ -83,17 +83,13 @@ ImplementEnumType(ReflectionModeEnum,
 { ReflectionProbe::NoReflection, "No Reflections", "This probe does not provide any local reflection data"},
 { ReflectionProbe::StaticCubemap, "Static Cubemap", "Uses a static CubemapData" },
 { ReflectionProbe::BakedCubemap, "Baked Cubemap", "Uses a cubemap baked from the probe's current position" },
-{ ReflectionProbe::DynamicCubemap, "Dynamic Cubemap", "Uses a cubemap baked from the probe's current position, updated at a set rate" },
+//{ ReflectionProbe::DynamicCubemap, "Dynamic Cubemap", "Uses a cubemap baked from the probe's current position, updated at a set rate" },
    EndImplementEnumType;
 
 //-----------------------------------------------------------------------------
 // Object setup and teardown
 //-----------------------------------------------------------------------------
-ReflectionProbe::ReflectionProbe() :
-   cubeDescId(0),
-   reflectorDesc(nullptr),
-   mSphereVertCount(0),
-   mSpherePrimitiveCount(0)
+ReflectionProbe::ReflectionProbe()
 {
    // Flag this object so that it will always
    // be sent across the network to clients
@@ -106,8 +102,7 @@ ReflectionProbe::ReflectionProbe() :
    mReflectionModeType = BakedCubemap;
 
    mEnabled = true;
-   mBake = false;
-   mDirty = false;
+   mBakeReflections = false;
    mCubemapDirty = false;
 
    mRadius = 10;
@@ -122,17 +117,14 @@ ReflectionProbe::ReflectionProbe() :
    mEditorShapeInst = NULL;
    mEditorShape = NULL;
 
-   mRefreshRateMS = 500;
+   mRefreshRateMS = 200;
    mDynamicLastBakeMS = 0;
 
    mMaxDrawDistance = 75;
 
    mResourcesCreated = false;
-
-   mProbeInfo = nullptr;
-
    mPrefilterSize = 64;
-   mPrefilterMipLevels = mLog2(F32(mPrefilterSize))+1;
+   mPrefilterMipLevels = mLog2(F32(mPrefilterSize));
    mPrefilterMap = nullptr;
    mIrridianceMap = nullptr;
 
@@ -158,7 +150,7 @@ void ReflectionProbe::initPersistFields()
 {
    addGroup("Rendering");
       addProtectedField("enabled", TypeBool, Offset(mEnabled, ReflectionProbe),
-         &_setEnabled, &defaultProtectedGetFn, "Regenerate Voxel Grid");
+         &_setEnabled, &defaultProtectedGetFn, "Is the probe enabled or not");
    endGroup("Rendering");
 
    addGroup("Reflection");
@@ -168,18 +160,18 @@ void ReflectionProbe::initPersistFields()
       addProtectedField("EditPosOffset", TypeBool, Offset(mEditPosOffset, ReflectionProbe),
       &_toggleEditPosOffset, &defaultProtectedGetFn, "Toggle Edit Pos Offset Mode", AbstractClassRep::FieldFlags::FIELD_ComponentInspectors);
 
-	   addField("refOffset", TypePoint3F, Offset(mProbeRefOffset, ReflectionProbe), "");
-      addField("refScale", TypePoint3F, Offset(mProbeRefScale, ReflectionProbe), "");
+	   addField("refOffset", TypePoint3F, Offset(mProbeRefOffset, ReflectionProbe), "The reference positional offset for the probe. This is used for adjusting the perceived center and area of influence.\nHelpful in adjusting parallax issues");
+      addField("refScale", TypePoint3F, Offset(mProbeRefScale, ReflectionProbe), "The reference scale for the probe. This is used for adjusting the perceived center and area of influence.\nHelpful in adjusting parallax issues");
 
       addProtectedField("ReflectionMode", TypeReflectionModeEnum, Offset(mReflectionModeType, ReflectionProbe), &_setReflectionMode, &defaultProtectedGetFn,
-         "The type of mesh data to use for collision queries.");
+         "Used to dictate what sort of cubemap the probes use when using IBL.");
 
-      addField("StaticCubemap", TypeCubemapName, Offset(mCubemapName, ReflectionProbe), "Cubemap used instead of reflection texture if fullReflect is off.");
+      addField("StaticCubemap", TypeCubemapName, Offset(mCubemapName, ReflectionProbe), "This is used when a static cubemap is used. The name of the cubemap is looked up and loaded for the IBL calculations.");
 
-      addField("DynamicReflectionRefreshMS", TypeS32, Offset(mRefreshRateMS, ReflectionProbe), "How often the dynamic cubemap is refreshed in milliseconds. Only works when the ReflectionMode is set to DynamicCubemap.");
+      //addField("DynamicReflectionRefreshMS", TypeS32, Offset(mRefreshRateMS, ReflectionProbe), "How often the dynamic cubemap is refreshed in milliseconds. Only works when the ReflectionMode is set to DynamicCubemap.");
 
-      addProtectedField("Bake", TypeBool, Offset(mBake, ReflectionProbe),
-         &_doBake, &defaultProtectedGetFn, "Regenerate Voxel Grid", AbstractClassRep::FieldFlags::FIELD_ComponentInspectors);
+      addProtectedField("Bake", TypeBool, Offset(mBakeReflections, ReflectionProbe),
+         &_doBake, &defaultProtectedGetFn, "Bake Probe Reflections", AbstractClassRep::FieldFlags::FIELD_ComponentInspectors);
    endGroup("Reflection");
 
    Con::addVariable("$Light::renderReflectionProbes", TypeBool, &RenderProbeMgr::smRenderReflectionProbes,
@@ -319,8 +311,7 @@ void ReflectionProbe::onRemove()
 {
    if (isClientObject())
    {
-      PROBEMGR->unregisterProbe(mProbeInfo->mProbeIdx);
-      mProbeInfo = nullptr;
+      PROBEMGR->unregisterProbe(mProbeInfo.mProbeIdx);
    }
 
    // Remove this object from the scene
@@ -436,7 +427,6 @@ U32 ReflectionProbe::packUpdate(NetConnection *conn, U32 mask, BitStream *stream
       stream->write(mProbeUniqueID);
       stream->write((U32)mReflectionModeType);
       stream->write(mCubemapName);
-      stream->write(mRefreshRateMS);
    }
 
    if (stream->writeFlag(mask & EnabledMask))
@@ -463,7 +453,7 @@ void ReflectionProbe::unpackUpdate(NetConnection *conn, BitStream *stream)
       resetWorldBox();
 
       mathRead(*stream, &mProbeRefOffset);
-      mathRead(*stream, &mProbeRefScale);      
+      mathRead(*stream, &mProbeRefScale);
 
       mDirty = true;
    }
@@ -490,8 +480,6 @@ void ReflectionProbe::unpackUpdate(NetConnection *conn, BitStream *stream)
       if(oldReflectModeType != mReflectionModeType || oldCubemapName != mCubemapName)
          mCubemapDirty = true;
 
-      stream->read(&mRefreshRateMS);
-
       mDirty = true;
    }
 
@@ -501,11 +489,6 @@ void ReflectionProbe::unpackUpdate(NetConnection *conn, BitStream *stream)
 
       mDirty = true;
    }
-
-   if (mDirty)
-   {
-      updateProbeParams();
-   }
 }
 
 //-----------------------------------------------------------------------------
@@ -513,12 +496,9 @@ void ReflectionProbe::unpackUpdate(NetConnection *conn, BitStream *stream)
 //-----------------------------------------------------------------------------
 void ReflectionProbe::updateProbeParams()
 {
-   if (!mProbeInfo)
-      return;
+   mProbeInfo.mIsEnabled = mEnabled;
 
-   mProbeInfo->mIsEnabled = mEnabled;
-
-   mProbeInfo->mProbeShapeType = mProbeShapeType;
+   mProbeInfo.mProbeShapeType = mProbeShapeType;
 
    if (mProbeShapeType == ProbeRenderInst::Sphere)
       mObjScale.set(mRadius, mRadius, mRadius);
@@ -527,10 +507,8 @@ void ReflectionProbe::updateProbeParams()
 
    if (mProbeShapeType == ProbeRenderInst::Skylight)
    {
-      mProbeInfo->mPosition = Point3F::Zero;
-      mProbeInfo->mTransform = MatrixF::Identity;
-
-      mProbeInfo->mIsSkylight = true;
+      mProbeInfo.mPosition = Point3F::Zero;
+      mProbeInfo.mTransform = MatrixF::Identity;
 
       F32 visDist = gClientSceneGraph->getVisibleDistance();
       Box3F skylightBounds = Box3F(visDist * 2);
@@ -541,21 +519,19 @@ void ReflectionProbe::updateProbeParams()
 
       setGlobalBounds();
 
-      mProbeInfo->mScore = -1.0f;
+      mProbeInfo.mScore = 10000.0f;
    }
    else
    {
       MatrixF transform = getTransform();
-      mProbeInfo->mPosition = getPosition();
+      mProbeInfo.mPosition = getPosition();
 
       transform.scale(getScale());
-      mProbeInfo->mTransform = transform.inverse();
-
-      mProbeInfo->mIsSkylight = false;
+      mProbeInfo.mTransform = transform.inverse();
 
       bounds = mWorldBox;
 
-      mProbeInfo->mScore = mMaxDrawDistance;
+      mProbeInfo.mScore = 1;
    }
 
    // Skip our transform... it just dirties mask bits.
@@ -563,14 +539,14 @@ void ReflectionProbe::updateProbeParams()
 
    resetWorldBox();
 
-   mProbeInfo->mBounds = bounds;
-   mProbeInfo->mExtents = getScale();
-   mProbeInfo->mRadius = mRadius;
+   mProbeInfo.mBounds = bounds;
+   mProbeInfo.mExtents = getScale();
+   mProbeInfo.mRadius = mRadius;
 
-   mProbeInfo->mProbeRefOffset = mProbeRefOffset;
-   mProbeInfo->mProbeRefScale = mProbeRefScale;
+   mProbeInfo.mProbeRefOffset = mProbeRefOffset;
+   mProbeInfo.mProbeRefScale = mProbeRefScale;
 
-   mProbeInfo->mDirty = true;
+   mProbeInfo.mDirty = true;
 
    if (mCubemapDirty)
    {
@@ -587,108 +563,12 @@ void ReflectionProbe::updateProbeParams()
 
 void ReflectionProbe::processDynamicCubemap()
 {
-   /*if (!mProbeInfo)
-      return;
-
-   mEnabled = false;
-
-   if (mReflectionModeType == DynamicCubemap && !mDynamicCubemap.isNull())
-   {
-      mProbeInfo->mPrefilterCubemap = mDynamicCubemap;
-
-      if (reflectorDesc == nullptr)
-      {
-         //find it
-         if (!Sim::findObject("DefaultCubeDesc", reflectorDesc))
-         {
-            mProbeInfo->mIsEnabled = false;
-            return;
-         }
-      }
-
-      mCubeReflector.unregisterReflector();
-      mCubeReflector.registerReflector(this, reflectorDesc); //need to decide how we wanna do the reflectorDesc. static name or a field
-   }
-
-   if (mEnabled)
-      mProbeInfo->mIsEnabled = true;
-   else
-      mProbeInfo->mIsEnabled = false;
-
-   mCubemapDirty = false;
-
-   //Update the probe manager with our new texture!
-   //if (!mProbeInfo->mIsSkylight && mProbeInfo->mPrefilterCubemap->isInitialized() && mProbeInfo->mIrradianceCubemap->isInitialized())
-   //   PROBEMGR->updateProbeTexture(mProbeInfo->mProbeIdx);*/
-
-   if (!mProbeInfo)
-      return;
-
-   mProbeInfo->mIsEnabled = false;
-
-   if (mReflectionModeType != DynamicCubemap)
-      return;
-
-   if (reflectorDesc == nullptr)
-   {
-      //find it
-      if (!Sim::findObject("DefaultCubeDesc", reflectorDesc))
-      {
-         mProbeInfo->mIsEnabled = false;
-         return;
-      }
-
-      mCubeReflector.unregisterReflector();
-      mCubeReflector.registerReflector(this, reflectorDesc); //need to decide how we wanna do the reflectorDesc. static name or a field
-   }
-
-   if (mCubeReflector.getCubemap())
-   {
-      U32 resolution = Con::getIntVariable("$pref::ReflectionProbes::BakeResolution", 64);
-      U32 prefilterMipLevels = mLog2(F32(resolution))+1;
-
-      //Prep it with whatever resolution we've dictated for our bake
-      mIrridianceMap->mCubemap->initDynamic(resolution, PROBEMGR->PROBE_FORMAT);
-      mPrefilterMap->mCubemap->initDynamic(resolution, PROBEMGR->PROBE_FORMAT);
-
-      GFXTextureTargetRef renderTarget = GFX->allocRenderToTextureTarget(false);
-
-      IBLUtilities::GenerateIrradianceMap(renderTarget, mCubeReflector.getCubemap(), mIrridianceMap->mCubemap);
-      IBLUtilities::GeneratePrefilterMap(renderTarget, mCubeReflector.getCubemap(), prefilterMipLevels, mPrefilterMap->mCubemap);
-   }
-
-   if (mIrridianceMap == nullptr || mIrridianceMap->mCubemap.isNull())
-   {
-      Con::errorf("ReflectionProbe::processDynamicCubemap() - Unable to load baked irradiance map at %s", getIrradianceMapPath().c_str());
-      return;
-   }
-
-   if (mPrefilterMap == nullptr || mPrefilterMap->mCubemap.isNull())
-   {
-      Con::errorf("ReflectionProbe::processDynamicCubemap() - Unable to load baked prefilter map at %s", getPrefilterMapPath().c_str());
-      return;
-   }
-
-   mProbeInfo->mPrefilterCubemap = mPrefilterMap->mCubemap;
-   mProbeInfo->mIrradianceCubemap = mIrridianceMap->mCubemap;
-
-   if (mEnabled && mProbeInfo->mPrefilterCubemap->isInitialized() && mProbeInfo->mIrradianceCubemap->isInitialized())
-   {
-      mProbeInfo->mIsEnabled = true;
-
-      mCubemapDirty = false;
-
-      //Update the probe manager with our new texture!
-      PROBEMGR->updateProbeTexture(mProbeInfo);
-   }
+   
 }
 
 void ReflectionProbe::processBakedCubemap()
 {
-   if (!mProbeInfo)
-      return;
-
-   mProbeInfo->mIsEnabled = false;
+   mProbeInfo.mIsEnabled = false;
 
    if ((mReflectionModeType != BakedCubemap) || mProbeUniqueID.isEmpty())
       return;
@@ -700,7 +580,7 @@ void ReflectionProbe::processBakedCubemap()
       mIrridianceMap->updateFaces();
    }
 
-   if (mIrridianceMap == nullptr || !mIrridianceMap->mCubemap->isInitialized())
+   if (mIrridianceMap == nullptr || mIrridianceMap->mCubemap.isNull())
    {
       Con::errorf("ReflectionProbe::processDynamicCubemap() - Unable to load baked irradiance map at %s", getIrradianceMapPath().c_str());
       return;
@@ -713,32 +593,33 @@ void ReflectionProbe::processBakedCubemap()
       mPrefilterMap->updateFaces();
    }
 
-   if (mPrefilterMap == nullptr || !mPrefilterMap->mCubemap->isInitialized())
+   if (mPrefilterMap == nullptr || mPrefilterMap->mCubemap.isNull())
    {
       Con::errorf("ReflectionProbe::processDynamicCubemap() - Unable to load baked prefilter map at %s", getPrefilterMapPath().c_str());
       return;
    }
 
-   mProbeInfo->mPrefilterCubemap = mPrefilterMap->mCubemap;
-   mProbeInfo->mIrradianceCubemap = mIrridianceMap->mCubemap;
+   mProbeInfo.mPrefilterCubemap = mPrefilterMap->mCubemap;
+   mProbeInfo.mIrradianceCubemap = mIrridianceMap->mCubemap;
 
-   if (mEnabled && mProbeInfo->mPrefilterCubemap->isInitialized() && mProbeInfo->mIrradianceCubemap->isInitialized())
+   if (mEnabled && mProbeInfo.mPrefilterCubemap->isInitialized() && mProbeInfo.mIrradianceCubemap->isInitialized())
    {
-      mProbeInfo->mIsEnabled = true;
+      mProbeInfo.mIsEnabled = true;
 
       mCubemapDirty = false;
 
       //Update the probe manager with our new texture!
-      PROBEMGR->updateProbeTexture(mProbeInfo);
+      PROBEMGR->updateProbeTexture(&mProbeInfo);
+
+      //now, cleanup
+      mProbeInfo.mPrefilterCubemap.free();
+      mProbeInfo.mIrradianceCubemap.free();
    }
 }
 
 void ReflectionProbe::processStaticCubemap()
 {
-   if (!mProbeInfo)
-      return;
-
-   mProbeInfo->mIsEnabled = false;
+   mProbeInfo.mIsEnabled = false;
 
    String path = Con::getVariable("$pref::ReflectionProbes::CurrentLevelPath", "levels/");
 
@@ -747,21 +628,14 @@ void ReflectionProbe::processStaticCubemap()
 
    if (Platform::isFile(irradFileName))
    {
-      if (mIrridianceMap == nullptr)
-      {
-         Con::errorf("ReflectionProbe::processStaticCubemap() - Unable to load baked irradiance map at %s", irradFileName);
-         return;
-      }
-
       mIrridianceMap->setCubemapFile(FileName(irradFileName));
-
-      if (mIrridianceMap->mCubemap.isNull())
-      {
-         Con::errorf("ReflectionProbe::processStaticCubemap() - Unable to load baked irradiance map at %s", irradFileName);
-         return;
-      }
-
       mIrridianceMap->updateFaces();
+   }
+
+   if (mIrridianceMap == nullptr || mIrridianceMap->mCubemap.isNull())
+   {
+      Con::errorf("ReflectionProbe::processStaticCubemap() - Unable to load baked irradiance map at %s", irradFileName);
+      return;
    }
 
    char prefilterFileName[256];
@@ -769,21 +643,14 @@ void ReflectionProbe::processStaticCubemap()
 
    if (Platform::isFile(prefilterFileName))
    {
-      if (mPrefilterMap == nullptr)
-      {
-         Con::errorf("ReflectionProbe::processStaticCubemap() - Unable to load baked prefilter map at %s", prefilterFileName);
-         return;
-      }
-
       mPrefilterMap->setCubemapFile(FileName(prefilterFileName));
-
-      if (mPrefilterMap->mCubemap.isNull())
-      {
-         Con::errorf("ReflectionProbe::processStaticCubemap() - Unable to load baked prefilter map at %s", prefilterFileName);
-         return;
-      }
-
       mPrefilterMap->updateFaces();
+   }
+
+   if (mPrefilterMap == nullptr || mPrefilterMap->mCubemap.isNull())
+   {
+      Con::errorf("ReflectionProbe::processStaticCubemap() - Unable to load baked prefilter map at %s", prefilterFileName);
+      return;
    }
 
    if (!Platform::isFile(prefilterFileName) || !Platform::isFile(irradFileName))
@@ -823,34 +690,29 @@ void ReflectionProbe::processStaticCubemap()
       IBLUtilities::SaveCubeMap(prefilterFileName, mPrefilterMap->mCubemap);
    }
 
-   if ((mIrridianceMap != nullptr && !mIrridianceMap->mCubemap.isNull()) && (mPrefilterMap != nullptr && !mPrefilterMap->mCubemap.isNull()))
+   if ((mIrridianceMap != nullptr || !mIrridianceMap->mCubemap.isNull()) && (mPrefilterMap != nullptr || !mPrefilterMap->mCubemap.isNull()))
    {
-      mProbeInfo->mPrefilterCubemap = mPrefilterMap->mCubemap;
-      mProbeInfo->mIrradianceCubemap = mIrridianceMap->mCubemap;
+      mProbeInfo.mPrefilterCubemap = mPrefilterMap->mCubemap;
+      mProbeInfo.mIrradianceCubemap = mIrridianceMap->mCubemap;
    }
 
-   if (mEnabled && mProbeInfo->mPrefilterCubemap->isInitialized() && mProbeInfo->mIrradianceCubemap->isInitialized())
+   if (mEnabled && mProbeInfo.mPrefilterCubemap->isInitialized() && mProbeInfo.mIrradianceCubemap->isInitialized())
    {
-      mProbeInfo->mIsEnabled = true;
+      mProbeInfo.mIsEnabled = true;
 
       mCubemapDirty = false;
 
       //Update the probe manager with our new texture!
-      PROBEMGR->updateProbeTexture(mProbeInfo);
+      PROBEMGR->updateProbeTexture(&mProbeInfo);
    }
 }
 
 bool ReflectionProbe::createClientResources()
 {
-   if (mProbeInfo == nullptr)
-   {
-      mProbeInfo = PROBEMGR->registerProbe();
-      if (!mProbeInfo)
-         return false;
+   PROBEMGR->registerProbe(&mProbeInfo);
 
-      mProbeInfo->mIsEnabled = false;
-   }
-
+   mProbeInfo.mIsEnabled = false;
+   
    //irridiance resources
    if (!mIrridianceMap)
    {
@@ -909,12 +771,10 @@ String ReflectionProbe::getIrradianceMapPath()
 
 void ReflectionProbe::bake()
 {
-   bool writeFile = mReflectionModeType == BakedCubemap ? true : false;
-
-   if (mReflectionModeType == StaticCubemap)
+   if (mReflectionModeType != BakedCubemap)
       return;
 
-   PROBEMGR->bakeProbe(this, writeFile);
+   PROBEMGR->bakeProbe(this);
 
    setMaskBits(-1);
 }
@@ -922,8 +782,9 @@ void ReflectionProbe::bake()
 //-----------------------------------------------------------------------------
 //Rendering of editing/debug stuff
 //-----------------------------------------------------------------------------
-void ReflectionProbe::createGeometry()
+void ReflectionProbe::createEditorResources()
 {
+#ifdef TORQUE_TOOLS
    // Clean up our previous shape
    if (mEditorShapeInst)
       SAFE_DELETE(mEditorShapeInst);
@@ -938,6 +799,7 @@ void ReflectionProbe::createGeometry()
    {
       mEditorShapeInst = new TSShapeInstance(mEditorShape, isClientObject());
    }
+#endif
 }
 
 void ReflectionProbe::prepRenderImage(SceneRenderState *state)
@@ -951,16 +813,14 @@ void ReflectionProbe::prepRenderImage(SceneRenderState *state)
    //Culling distance. Can be adjusted for performance options considerations via the scalar
    if (dist > mMaxDrawDistance * Con::getFloatVariable("$pref::GI::ProbeDrawDistScale", 1.0))
    {
-      mProbeInfo->mScore = mMaxDrawDistance;
+      mProbeInfo.mScore = mMaxDrawDistance;
       return;
    }
 
    if (mReflectionModeType == DynamicCubemap && mRefreshRateMS < (Platform::getRealMilliseconds() - mDynamicLastBakeMS))
    {
-      //bake();
+      bake();
       mDynamicLastBakeMS = Platform::getRealMilliseconds();
-
-      processDynamicCubemap();
    }
 
    //Submit our probe to actually do the probe action
@@ -968,20 +828,20 @@ void ReflectionProbe::prepRenderImage(SceneRenderState *state)
    //RenderPassManager *renderPass = state->getRenderPass();
 
    //Update our score based on our radius, distance
-   mProbeInfo->mScore = mProbeInfo->mRadius/mMax(dist,1.0f);
+   mProbeInfo.mScore = mMax(dist, 1.0f);
 
    Point3F vect = distVec;
    vect.normalizeSafe();
 
-   mProbeInfo->mScore *= mMax(mAbs(mDot(vect, state->getCameraTransform().getForwardVector())),0.001f);
+   //mProbeInfo.mScore *= mMax(mAbs(mDot(vect, state->getCameraTransform().getForwardVector())),0.001f);
 
-   //Register
-   //PROBEMGR->registerProbe(mProbeInfoIdx);
+   PROBEMGR->submitProbe(mProbeInfo);
 
+#ifdef TORQUE_TOOLS
    if (ReflectionProbe::smRenderPreviewProbes && gEditingMission && mPrefilterMap != nullptr)
    {
       if(!mEditorShapeInst)
-         createGeometry();
+         createEditorResources();
 
       GFXTransformSaver saver;
 
@@ -1039,7 +899,7 @@ void ReflectionProbe::prepRenderImage(SceneRenderState *state)
       saver.restore();
    }
 
-   // If the light is selected or light visualization
+   // If the probe is selected or probe visualization
    // is enabled then register the callback.
    const bool isSelectedInEditor = (gEditingMission && isSelected());
    if (isSelectedInEditor)
@@ -1049,6 +909,7 @@ void ReflectionProbe::prepRenderImage(SceneRenderState *state)
       ri->type = RenderPassManager::RIT_Editor;
       state->getRenderPass()->addInst(ri);
    }
+#endif
 }
 
 void ReflectionProbe::_onRenderViz(ObjectRenderInst *ri,
@@ -1127,7 +988,7 @@ DefineEngineMethod(ReflectionProbe, postApply, void, (), ,
 }
 
 DefineEngineMethod(ReflectionProbe, Bake, void, (), ,
-   "@brief returns true if control object is inside the fog\n\n.")
+   "@brief Bakes the cubemaps for a reflection probe\n\n.")
 {
    ReflectionProbe *clientProbe = (ReflectionProbe*)object->getClientObject();
 

--- a/Engine/source/T3D/lighting/reflectionProbe.h
+++ b/Engine/source/T3D/lighting/reflectionProbe.h
@@ -63,6 +63,9 @@ class ReflectionProbe : public SceneObject
 
 public:
 
+   /// <summary>
+   /// Used to dictate what sort of cubemap the probes use when using IBL
+   /// </summary>
    enum ReflectionModeType
    {
       NoReflection = 0,
@@ -87,36 +90,84 @@ protected:
       NextFreeMask = Parent::NextFreeMask << 3
    };
 
-   bool mBake;
+   /// <summary>
+   /// Only used for interfacing with the editor's inspector bake button
+   /// </summary>
+   bool mBakeReflections;
+
+   /// <summary>
+   /// Whether this probe is enabled or not
+   /// </summary>
    bool mEnabled;
+   
    bool mDirty;
+
+   /// <summary>
+   /// Whether this probe's cubemap is dirty or not
+   /// </summary>
    bool mCubemapDirty;
 
+#ifdef TORQUE_TOOLS
+   /// <summary>
+   /// Used only when the editor is loaded, this is the shape data used for the probe viewing(aka, a sphere)
+   /// </summary>
    Resource<TSShape> mEditorShape;
+   /// <summary>
+   /// This is the shape instance of the editor shape data
+   /// </summary>
    TSShapeInstance* mEditorShapeInst;
+#endif // TORQUE_TOOLS
 
    //--------------------------------------------------------------------------
    // Rendering variables
    //--------------------------------------------------------------------------
+   /// <summary>
+   /// The shape of the probe
+   /// </summary>
    ProbeRenderInst::ProbeShapeType mProbeShapeType;
 
-   ProbeRenderInst* mProbeInfo;
+   /// <summary>
+   /// This is effectively a packed cache of the probe data actually utilized for rendering.
+   /// The RenderProbeManager uses this via the probe calling registerProbe on creation, and unregisterProbe on destruction
+   /// When the manager goes to render it has the compacted data to read over more efficiently for setting up what probes should
+   /// Actually render in that frame
+   /// </summary>
+   ProbeRenderInst mProbeInfo;
 
-   //Reflection Contribution stuff
+   /// <summary>
+   /// Used to dictate what sort of cubemap the probes use when using IBL
+   /// </summary>
    ReflectionModeType mReflectionModeType;
 
+   /// <summary>
+   /// The radius of the probe's influence. Only really relevent in Sphere probes
+   /// </summary>
    F32 mRadius;
+   /// <summary>
+   /// The reference positional offset for the probe. This is used for adjusting the perceived center and area of influence.
+   /// Helpful in adjusting parallax issues
+   /// </summary>
    Point3F mProbeRefOffset;
+   /// <summary>
+   /// The reference scale for the probe. This is used for adjusting the perceived center and area of influence.
+   /// Helpful in adjusting parallax issues
+   /// </summary>
    Point3F mProbeRefScale;
+
+   /// <summary>
+   /// Only used for interfacing with the editor's inspector edit offset button
+   /// </summary>
    bool mEditPosOffset;
 
+   /// <summary>
+   /// This is used when a static cubemap is used. The name of the cubemap is looked up and loaded for the IBL calculations
+   /// </summary>
    String mCubemapName;
    CubemapData *mStaticCubemap;
    GFXCubemapHandle  mDynamicCubemap;
 
    String cubeDescName;
    U32 cubeDescId;
-   CubeReflector mCubeReflector;
    ReflectorDesc *reflectorDesc;
 
    //Utilized in dynamic reflections
@@ -133,18 +184,11 @@ protected:
    U32 mPrefilterMipLevels;
    U32 mPrefilterSize;
 
+   /// <summary>
+   /// This is calculated based on the object's persistantID. Effectively a unique hash ID to set it apart from other probes
+   /// Used to ensure the cubemaps named when baking are unique
+   /// </summary>
    String mProbeUniqueID;
-
-   // Define our vertex format here so we don't have to
-   // change it in multiple spots later
-   typedef GFXVertexPNTTB VertexType;
-
-   // The GFX vertex and primitive buffers
-   GFXVertexBufferHandle< VertexType > mVertexBuffer;
-   GFXPrimitiveBufferHandle            mPrimitiveBuffer;
-
-   U32 mSphereVertCount;
-   U32 mSpherePrimitiveCount;
 
    //Debug rendering
    static bool smRenderPreviewProbes;
@@ -188,6 +232,10 @@ public:
    bool onAdd();
    void onRemove();
 
+   /// <summary>
+   /// This is called when the object is deleted. It allows us to do special-case cleanup actions
+   /// In probes' case, it's used to delete baked cubemap files
+   /// </summary>
    virtual void handleDeleteAction();
 
    // Override this so that we can dirty the network flag when it is called
@@ -215,14 +263,26 @@ public:
    //--------------------------------------------------------------------------
 
    // Create the geometry for rendering
-   void createGeometry();
+   void createEditorResources();
 
+   /// <summary>
+   /// Updates the probe rendering data
+   /// </summary>
    virtual void updateProbeParams();
-
+   
    bool createClientResources();
 
+   /// <summary>
+   /// Updates the probe's cubemaps in the array when using dynamic reflections
+   /// </summary>
    void processDynamicCubemap();
+   /// <summary>
+   /// Updates the probe's cubemaps in the array when using baked cubemaps
+   /// </summary>
    void processBakedCubemap();
+   /// <summary>
+   /// Updates the probe's cubemaps in the array when using a static cubemaps
+   /// </summary>
    void processStaticCubemap();
 
    // This is the function that allows this object to submit itself for rendering
@@ -234,9 +294,22 @@ public:
 
    void setPreviewMatParameters(SceneRenderState* renderState, BaseMatInstance* mat);
 
-   //Baking
+   /// <summary>
+   /// This gets the filepath to the prefilter cubemap associated to this probe.
+   /// In the event the probe is set to use a static cubemap, it is the prefiltered version of the cubemap's file
+   /// </summary>
+   /// <returns>The filepath to the prefilter cubemap</returns>
    String getPrefilterMapPath();
+   /// <summary>
+   /// This gets the filepath to the irradiance cubemap associated to this probe.
+   /// In the event the probe is set to use a static cubemap, it is the irradiance version of the cubemap's file
+   /// </summary>
+   /// <returns>The filepath to the irradiance cubemap</returns>
    String getIrradianceMapPath();
+
+   /// <summary>
+   /// Invokes a cubemap bake action for this probe
+   /// </summary>
    void bake();
 };
 

--- a/Engine/source/T3D/lighting/skylight.cpp
+++ b/Engine/source/T3D/lighting/skylight.cpp
@@ -135,6 +135,11 @@ void Skylight::unpackUpdate(NetConnection *conn, BitStream *stream)
 {
    // Let the Parent read any info it sent
    Parent::unpackUpdate(conn, stream);
+
+   if (mDirty)
+   {
+      updateProbeParams();
+   }
 }
 
 //-----------------------------------------------------------------------------
@@ -143,9 +148,6 @@ void Skylight::unpackUpdate(NetConnection *conn, BitStream *stream)
 
 void Skylight::updateProbeParams()
 {
-   if (!mProbeInfo)
-      return;
-
    mProbeShapeType = ProbeRenderInst::Skylight;
    Parent::updateProbeParams();
 }
@@ -157,24 +159,17 @@ void Skylight::prepRenderImage(SceneRenderState *state)
 
    //special hook-in for skylights
    Point3F camPos = state->getCameraPosition();
-   mProbeInfo->mBounds.setCenter(camPos);
+   mProbeInfo.mBounds.setCenter(camPos);
 
-   mProbeInfo->setPosition(camPos);
-
-   if (mReflectionModeType == DynamicCubemap && mRefreshRateMS < (Platform::getRealMilliseconds() - mDynamicLastBakeMS))
-   {
-      //bake();
-      mDynamicLastBakeMS = Platform::getRealMilliseconds();
-
-      processDynamicCubemap();
-   }
+   mProbeInfo.setPosition(camPos);
 
    //Submit our probe to actually do the probe action
    // Get a handy pointer to our RenderPassmanager
    //RenderPassManager *renderPass = state->getRenderPass();
 
-   //PROBEMGR->registerSkylight(mProbeInfo, this);
+   PROBEMGR->submitProbe(mProbeInfo);
 
+#ifdef TORQUE_TOOLS
    if (Skylight::smRenderPreviewProbes && gEditingMission && mEditorShapeInst && mPrefilterMap != nullptr)
    {
       GFXTransformSaver saver;
@@ -235,6 +230,7 @@ void Skylight::prepRenderImage(SceneRenderState *state)
    if (isSelectedInEditor)
    {
    }
+#endif
 }
 
 void Skylight::setPreviewMatParameters(SceneRenderState* renderState, BaseMatInstance* mat)

--- a/Engine/source/T3D/lighting/sphereEnvironmentProbe.cpp
+++ b/Engine/source/T3D/lighting/sphereEnvironmentProbe.cpp
@@ -131,6 +131,11 @@ void SphereEnvironmentProbe::unpackUpdate(NetConnection *conn, BitStream *stream
 {
    // Let the Parent read any info it sent
    Parent::unpackUpdate(conn, stream);
+
+   if (mDirty)
+   {
+      updateProbeParams();
+   }
 }
 
 //-----------------------------------------------------------------------------
@@ -139,9 +144,6 @@ void SphereEnvironmentProbe::unpackUpdate(NetConnection *conn, BitStream *stream
 
 void SphereEnvironmentProbe::updateProbeParams()
 {
-   if (!mProbeInfo)
-      return;
-
    mProbeShapeType = ProbeRenderInst::Sphere;
    Parent::updateProbeParams();
 }
@@ -151,6 +153,7 @@ void SphereEnvironmentProbe::prepRenderImage(SceneRenderState *state)
    if (!mEnabled || !ReflectionProbe::smRenderPreviewProbes)
       return;
 
+#ifdef TORQUE_TOOLS
    if (ReflectionProbe::smRenderPreviewProbes && gEditingMission && mEditorShapeInst && mPrefilterMap != nullptr)
    {
       GFXTransformSaver saver;
@@ -215,6 +218,7 @@ void SphereEnvironmentProbe::prepRenderImage(SceneRenderState *state)
       ri->type = RenderPassManager::RIT_Editor;
       state->getRenderPass()->addInst(ri);
    }
+#endif
 }
 
 void SphereEnvironmentProbe::setPreviewMatParameters(SceneRenderState* renderState, BaseMatInstance* mat)

--- a/Engine/source/console/simSet.h
+++ b/Engine/source/console/simSet.h
@@ -332,7 +332,7 @@ void SimSet::findObjectByType( Vector<T*> &foundObjects )
       curSet = dynamic_cast<SimSet*>( *itr );
 
       // If child object is a set, call recursively into it.
-      if ( curSet )
+      if ( curSet && curSet->size() != 0)
          curSet->findObjectByType( foundObjects ); 
 
       // Add this child object if appropriate.

--- a/Engine/source/scene/reflector.cpp
+++ b/Engine/source/scene/reflector.cpp
@@ -295,7 +295,7 @@ void CubeReflector::unregisterReflector()
    mEnabled = false;
 }
 
-void CubeReflector::updateReflection( const ReflectParams &params )
+void CubeReflector::updateReflection( const ReflectParams &params, Point3F explicitPostion)
 {
    GFXDEBUGEVENT_SCOPE( CubeReflector_UpdateReflection, ColorI::WHITE );
 
@@ -336,7 +336,7 @@ void CubeReflector::updateReflection( const ReflectParams &params )
 
 
    for ( U32 i = 0; i < 6; i++ )
-      updateFace( params, i );
+      updateFace( params, i, explicitPostion);
    
 
    GFX->popActiveRenderTarget();
@@ -347,7 +347,7 @@ void CubeReflector::updateReflection( const ReflectParams &params )
    mLastTexSize = texDim;
 }
 
-void CubeReflector::updateFace( const ReflectParams &params, U32 faceidx )
+void CubeReflector::updateFace( const ReflectParams &params, U32 faceidx, Point3F explicitPostion)
 {
    GFXDEBUGEVENT_SCOPE( CubeReflector_UpdateFace, ColorI::WHITE );
 
@@ -402,7 +402,15 @@ void CubeReflector::updateFace( const ReflectParams &params, U32 faceidx )
    matView.setColumn( 0, cross );
    matView.setColumn( 1, vLookatPt );
    matView.setColumn( 2, vUpVec );
-   matView.setPosition( mObject->getPosition() );
+
+   if (explicitPostion == Point3F::Max)
+   {
+      matView.setPosition(mObject->getPosition());
+   }
+   else
+   {
+      matView.setPosition(explicitPostion);
+   }
    matView.inverse();
 
    GFX->setWorldMatrix(matView);

--- a/Engine/source/scene/reflector.h
+++ b/Engine/source/scene/reflector.h
@@ -151,11 +151,11 @@ public:
                            ReflectorDesc *inDesc );
 
    virtual void unregisterReflector();
-   virtual void updateReflection( const ReflectParams &params );   
+   virtual void updateReflection( const ReflectParams &params, Point3F explicitPostion = Point3F::Max);
 
    GFXCubemap* getCubemap() const { return mCubemap; }
 
-   void updateFace( const ReflectParams &params, U32 faceidx );
+   void updateFace( const ReflectParams &params, U32 faceidx, Point3F explicitPostion = Point3F::Max);
    F32 calcFaceScore( const ReflectParams &params, U32 faceidx );
 
 protected:

--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -3004,15 +3004,10 @@ void ReflectionProbeFeatGLSL::processPix(Vector<ShaderComponent*>& componentList
    inRefPosArray->uniform = true;
    inRefPosArray->constSortPos = cspPotentialPrimitive;
 
-   Var * refBoxMinArray = new Var("inRefBoxMin", "vec4");
-   refBoxMinArray->arraySize = MAX_FORWARD_PROBES;
-   refBoxMinArray->uniform = true;
-   refBoxMinArray->constSortPos = cspPotentialPrimitive;
-
-   Var * refBoxMaxArray = new Var("inRefBoxMax", "vec4");
-   refBoxMaxArray->arraySize = MAX_FORWARD_PROBES;
-   refBoxMaxArray->uniform = true;
-   refBoxMaxArray->constSortPos = cspPotentialPrimitive;
+   Var * refScaleArray = new Var("inRefScale", "vec4");
+   refScaleArray->arraySize = MAX_FORWARD_PROBES;
+   refScaleArray->uniform = true;
+   refScaleArray->constSortPos = cspPotentialPrimitive;
 
    Var * probeConfigData = new Var("probeConfigData", "vec4");
    probeConfigData->arraySize = MAX_FORWARD_PROBES;
@@ -3053,11 +3048,11 @@ void ReflectionProbeFeatGLSL::processPix(Vector<ShaderComponent*>& componentList
    Var *curColor = (Var*)LangElement::find(getOutputTargetVarName(ShaderFeature::DefaultTarget));
       
    //Reflection vec
-   String computeForwardProbes = String("   @.rgb = computeForwardProbes(@,@,@,@,@,@,@,@,@,\r\n\t\t");
+   String computeForwardProbes = String("   @.rgb = computeForwardProbes(@,@,@,@,@,@,@,@,\r\n\t\t");
    computeForwardProbes += String("@,@,\r\n\t\t");
    computeForwardProbes += String("@,@).rgb; \r\n");
 
-   meta->addStatement(new GenOp(computeForwardProbes.c_str(), curColor, surface, cubeMips, numProbes, worldToObjArray, probeConfigData, inProbePosArray, refBoxMinArray, refBoxMaxArray, inRefPosArray,
+   meta->addStatement(new GenOp(computeForwardProbes.c_str(), curColor, surface, cubeMips, numProbes, worldToObjArray, probeConfigData, inProbePosArray, refScaleArray, inRefPosArray,
       skylightCubemapIdx, BRDFTexture,
       irradianceCubemapAR, specularCubemapAR));
 

--- a/Engine/source/shaderGen/HLSL/debugVizFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/debugVizFeatureHLSL.cpp
@@ -140,8 +140,7 @@ void DebugVizHLSL::processPix(Vector<ShaderComponent*>& componentList,
       Var* skylightCubemapIdx = (Var*)LangElement::find("skylightCubemapIdx");
       Var* inProbePosArray = (Var*)LangElement::find("inProbePosArray");
       Var* inRefPosArray = (Var*)LangElement::find("inRefPosArray");
-      Var* refBoxMinArray = (Var*)LangElement::find("inRefBoxMin");
-      Var* refBoxMaxArray = (Var*)LangElement::find("inRefBoxMax");
+      Var* refScaleArray = (Var*)LangElement::find("inRefScale");
 
       Var* probeConfigData = (Var*)LangElement::find("probeConfigData");
       Var* worldToObjArray = (Var*)LangElement::find("worldToObjArray");
@@ -181,11 +180,11 @@ void DebugVizHLSL::processPix(Vector<ShaderComponent*>& componentList,
       dSprintf(buf, sizeof(buf), "   @ = %s;\r\n", showDiff);
       meta->addStatement(new GenOp(buf, new DecOp(showDiffVar)));
 
-      String computeForwardProbes = String::String("   @ = debugVizForwardProbes(@,@,@,@,@,@,@,@,@,\r\n\t\t");
+      String computeForwardProbes = String::String("   @ = debugVizForwardProbes(@,@,@,@,@,@,@,@,\r\n\t\t");
       computeForwardProbes += String::String("@,TORQUE_SAMPLER2D_MAKEARG(@),\r\n\t\t");
       computeForwardProbes += String::String("TORQUE_SAMPLERCUBEARRAY_MAKEARG(@),TORQUE_SAMPLERCUBEARRAY_MAKEARG(@), @, @, @, @).rgb; \r\n");
 
-      meta->addStatement(new GenOp(computeForwardProbes.c_str(), ibl, surface, cubeMips, numProbes, worldToObjArray, probeConfigData, inProbePosArray, refBoxMinArray, refBoxMaxArray, inRefPosArray,
+      meta->addStatement(new GenOp(computeForwardProbes.c_str(), ibl, surface, cubeMips, numProbes, worldToObjArray, probeConfigData, inProbePosArray, refScaleArray, inRefPosArray,
          skylightCubemapIdx, BRDFTexture,
          irradianceCubemapAR, specularCubemapAR,
          showAttenVar, showContribVar, showSpecVar, showDiffVar));

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -3075,15 +3075,10 @@ void ReflectionProbeFeatHLSL::processPix(Vector<ShaderComponent*> &componentList
    inRefPosArray->uniform = true;
    inRefPosArray->constSortPos = cspPotentialPrimitive;
 
-   Var * refBoxMinArray = new Var("inRefBoxMin", "float4");
-   refBoxMinArray->arraySize = MAX_FORWARD_PROBES;
-   refBoxMinArray->uniform = true;
-   refBoxMinArray->constSortPos = cspPotentialPrimitive;
-
-   Var * refBoxMaxArray = new Var("inRefBoxMax", "float4");
-   refBoxMaxArray->arraySize = MAX_FORWARD_PROBES;
-   refBoxMaxArray->uniform = true;
-   refBoxMaxArray->constSortPos = cspPotentialPrimitive;
+   Var * refScaleArray = new Var("inRefScale", "float4");
+   refScaleArray->arraySize = MAX_FORWARD_PROBES;
+   refScaleArray->uniform = true;
+   refScaleArray->constSortPos = cspPotentialPrimitive;
 
    Var *probeConfigData = new Var("probeConfigData", "float4");
    probeConfigData->arraySize = MAX_FORWARD_PROBES;
@@ -3142,11 +3137,11 @@ void ReflectionProbeFeatHLSL::processPix(Vector<ShaderComponent*> &componentList
       ibl = new Var("ibl", "float3");
    }
 
-   String computeForwardProbes = String::String("   @ = computeForwardProbes(@,@,@,@,@,@,@,@,@,\r\n\t\t");
+   String computeForwardProbes = String::String("   @ = computeForwardProbes(@,@,@,@,@,@,@,@,\r\n\t\t");
    computeForwardProbes += String::String("@,TORQUE_SAMPLER2D_MAKEARG(@),\r\n\t\t"); 
    computeForwardProbes += String::String("TORQUE_SAMPLERCUBEARRAY_MAKEARG(@),TORQUE_SAMPLERCUBEARRAY_MAKEARG(@)).rgb; \r\n");
       
-   meta->addStatement(new GenOp(computeForwardProbes.c_str(), new DecOp(ibl), surface, cubeMips, numProbes, worldToObjArray, probeConfigData, inProbePosArray, refBoxMinArray, refBoxMaxArray, inRefPosArray,
+   meta->addStatement(new GenOp(computeForwardProbes.c_str(), new DecOp(ibl), surface, cubeMips, numProbes, worldToObjArray, probeConfigData, inProbePosArray, refScaleArray, inRefPosArray,
       skylightCubemapIdx, BRDFTexture,
       irradianceCubemapAR, specularCubemapAR));
 

--- a/Engine/source/shaderGen/shaderGenVars.cpp
+++ b/Engine/source/shaderGen/shaderGenVars.cpp
@@ -81,8 +81,7 @@ const String ShaderGenVars::glowMul("$glowMul");
 //Reflection Probes
 const String ShaderGenVars::probePosition("$inProbePosArray");
 const String ShaderGenVars::probeRefPos("$inRefPosArray");
-const String ShaderGenVars::refBoxMin("$inRefBoxMin");
-const String ShaderGenVars::refBoxMax("$inRefBoxMax");
+const String ShaderGenVars::refScale("$inRefScale");
 const String ShaderGenVars::worldToObjArray("$worldToObjArray");
 const String ShaderGenVars::probeConfigData("$probeConfigData");
 const String ShaderGenVars::specularCubemapAR("$specularCubemapAR");

--- a/Engine/source/shaderGen/shaderGenVars.h
+++ b/Engine/source/shaderGen/shaderGenVars.h
@@ -93,8 +93,7 @@ struct ShaderGenVars
    //Reflection Probes
    const static String probePosition;
    const static String probeRefPos;
-   const static String refBoxMin;
-   const static String refBoxMax;
+   const static String refScale;
    const static String worldToObjArray;
    const static String probeConfigData;
    const static String specularCubemapAR;

--- a/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
@@ -44,7 +44,10 @@ uniform vec4 albedo;
 
 #endif // !TORQUE_SHADERGEN
 
-#define MAX_PROBES 50
+#ifndef MAX_PROBES
+#define MAX_PROBES 8
+#endif
+
 #define MAX_FORWARD_PROBES 4
 
 #define MAX_FORWARD_LIGHT 4
@@ -216,7 +219,12 @@ vec3 evaluateStandardBRDF(Surface surface, SurfaceToLight surfaceToLight)
    float D = D_GGX(surfaceToLight.NdotH, surface.linearRoughnessSq);
    vec3 Fr = D * F * Vis;
 
+#if CAPTURING == true
+   return mix(Fd + Fr,surface.f0,surface.metalness);
+#else
    return Fd + Fr;
+#endif
+
 }
 
 vec3 getDirectionalLight(Surface surface, SurfaceToLight surfaceToLight, vec3 lightColor, float lightIntensity, float shadow)
@@ -331,14 +339,14 @@ float defineBoxSpaceInfluence(vec3 wsPosition, mat4 worldToObj, float attenuatio
 // Box Projected IBL Lighting
 // Based on: http://www.gamedev.net/topic/568829-box-projected-cubemap-environment-mapping/
 // and https://seblagarde.wordpress.com/2012/09/29/image-based-lighting-approaches-and-parallax-corrected-cubemap/
-vec3 boxProject(vec3 wsPosition, vec3 wsReflectVec, mat4 worldToObj, vec3 refBoxMin, vec3 refBoxMax, vec3 refPosition)
+vec3 boxProject(vec3 wsPosition, vec3 wsReflectVec, mat4 worldToObj, vec3 refScale, vec3 refPosition)
 {
    vec3 RayLS = tMul(worldToObj, vec4(wsReflectVec, 0.0)).xyz;
    vec3 PositionLS = tMul(worldToObj, vec4(wsPosition, 1.0)).xyz;
 
-   vec3 unit = refBoxMax.xyz - refBoxMin.xyz;
-   vec3 plane1vec = (unit / 2 - PositionLS) / RayLS;
-   vec3 plane2vec = (-unit / 2 - PositionLS) / RayLS;
+   vec3 unit = refScale;
+   vec3 plane1vec = (unit - PositionLS) / RayLS;
+   vec3 plane2vec = (-unit - PositionLS) / RayLS;
    vec3 furthestPlane = max(plane1vec, plane2vec);
    float dist = min(min(furthestPlane.x, furthestPlane.y), furthestPlane.z);
    vec3 posonbox = wsPosition + wsReflectVec * dist;
@@ -348,7 +356,7 @@ vec3 boxProject(vec3 wsPosition, vec3 wsReflectVec, mat4 worldToObj, vec3 refBox
 
 vec4 computeForwardProbes(Surface surface,
     float cubeMips, int numProbes, mat4x4 worldToObjArray[MAX_FORWARD_PROBES], vec4 probeConfigData[MAX_FORWARD_PROBES], 
-    vec4 inProbePosArray[MAX_FORWARD_PROBES], vec4 refBoxMinArray[MAX_FORWARD_PROBES], vec4 refBoxMaxArray[MAX_FORWARD_PROBES], vec4 inRefPosArray[MAX_FORWARD_PROBES],
+    vec4 inProbePosArray[MAX_FORWARD_PROBES], vec4 refScaleArray[MAX_FORWARD_PROBES], vec4 inRefPosArray[MAX_FORWARD_PROBES],
     float skylightCubemapIdx, sampler2D BRDFTexture, 
 	samplerCubeArray irradianceCubemapAR, samplerCubeArray specularCubemapAR)
 {
@@ -452,7 +460,7 @@ vec4 computeForwardProbes(Surface surface,
       if (contrib > 0.0f)
       {
          float cubemapIdx = int(probeConfigData[i].a);
-         vec3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refBoxMinArray[i].xyz, refBoxMaxArray[i].xyz, inRefPosArray[i].xyz);
+         vec3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refScaleArray[i].xyz, inRefPosArray[i].xyz);
 
          irradiance += textureLod(irradianceCubemapAR, vec4(dir, cubemapIdx), 0).xyz * contrib;
          specular += textureLod(specularCubemapAR, vec4(dir, cubemapIdx), lod).xyz * contrib;
@@ -490,7 +498,7 @@ vec4 computeForwardProbes(Surface surface,
 
 vec4 debugVizForwardProbes(Surface surface,
     float cubeMips, int numProbes, mat4 worldToObjArray[MAX_FORWARD_PROBES], vec4 probeConfigData[MAX_FORWARD_PROBES], 
-    vec4 inProbePosArray[MAX_FORWARD_PROBES], vec4 refBoxMinArray[MAX_FORWARD_PROBES], vec4 refBoxMaxArray[MAX_FORWARD_PROBES], vec4 inRefPosArray[MAX_FORWARD_PROBES],
+    vec4 inProbePosArray[MAX_FORWARD_PROBES], vec4 refScaleArray[MAX_FORWARD_PROBES], vec4 inRefPosArray[MAX_FORWARD_PROBES],
     float skylightCubemapIdx, sampler2D BRDFTexture, 
 	 samplerCubeArray irradianceCubemapAR, samplerCubeArray specularCubemapAR, int showAtten, int showContrib, int showSpec, int showDiff)
 {
@@ -601,7 +609,7 @@ vec4 debugVizForwardProbes(Surface surface,
       if (contrib > 0.0f)
       {
          float cubemapIdx = probeConfigData[i].a;
-         vec3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refBoxMinArray[i].xyz, refBoxMaxArray[i].xyz, inRefPosArray[i].xyz);
+         vec3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refScaleArray[i].xyz, inRefPosArray[i].xyz);
 
          irradiance += textureLod(irradianceCubemapAR, vec4(dir, cubemapIdx), 0).xyz * contrib;
          specular += textureLod(specularCubemapAR, vec4(dir, cubemapIdx), lod).xyz * contrib;

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
@@ -45,7 +45,10 @@ uniform float4 albedo;
 
 #endif // !TORQUE_SHADERGEN
 
-#define MAX_PROBES 50
+#ifndef MAX_PROBES
+#define MAX_PROBES 8
+#endif
+
 #define MAX_FORWARD_PROBES 4
 
 #define MAX_FORWARD_LIGHT 4
@@ -216,8 +219,13 @@ float3 evaluateStandardBRDF(Surface surface, SurfaceToLight surfaceToLight)
    float Vis = V_SmithGGXCorrelated(surface.NdotV, surfaceToLight.NdotL, surface.linearRoughnessSq);
    float D = D_GGX(surfaceToLight.NdotH, surface.linearRoughnessSq);
    float3 Fr = D * F * Vis;
-
+   
+#if CAPTURING == true
+    return lerp(Fd + Fr,surface.f0,surface.metalness);
+#else
    return Fd + Fr;
+#endif
+
 }
 
 float3 getDirectionalLight(Surface surface, SurfaceToLight surfaceToLight, float3 lightColor, float lightIntensity, float shadow)
@@ -335,14 +343,14 @@ float defineBoxSpaceInfluence(float3 wsPosition, float4x4 worldToObj, float atte
 // Box Projected IBL Lighting
 // Based on: http://www.gamedev.net/topic/568829-box-projected-cubemap-environment-mapping/
 // and https://seblagarde.wordpress.com/2012/09/29/image-based-lighting-approaches-and-parallax-corrected-cubemap/
-float3 boxProject(float3 wsPosition, float3 wsReflectVec, float4x4 worldToObj, float3 refBoxMin, float3 refBoxMax, float3 refPosition)
+float3 boxProject(float3 wsPosition, float3 wsReflectVec, float4x4 worldToObj, float3 refScale, float3 refPosition)
 {
    float3 RayLS = mul(worldToObj, float4(wsReflectVec, 0.0)).xyz;
    float3 PositionLS = mul(worldToObj, float4(wsPosition, 1.0)).xyz;
 
-   float3 unit = refBoxMax.xyz - refBoxMin.xyz;
-   float3 plane1vec = (unit / 2 - PositionLS) / RayLS;
-   float3 plane2vec = (-unit / 2 - PositionLS) / RayLS;
+   float3 unit = refScale;
+   float3 plane1vec = (unit - PositionLS) / RayLS;
+   float3 plane2vec = (-unit - PositionLS) / RayLS;
    float3 furthestPlane = max(plane1vec, plane2vec);
    float dist = min(min(furthestPlane.x, furthestPlane.y), furthestPlane.z);
    float3 posonbox = wsPosition + wsReflectVec * dist;
@@ -352,7 +360,7 @@ float3 boxProject(float3 wsPosition, float3 wsReflectVec, float4x4 worldToObj, f
 
 float4 computeForwardProbes(Surface surface,
     float cubeMips, int numProbes, float4x4 worldToObjArray[MAX_FORWARD_PROBES], float4 probeConfigData[MAX_FORWARD_PROBES], 
-    float4 inProbePosArray[MAX_FORWARD_PROBES], float4 refBoxMinArray[MAX_FORWARD_PROBES], float4 refBoxMaxArray[MAX_FORWARD_PROBES], float4 inRefPosArray[MAX_FORWARD_PROBES],
+    float4 inProbePosArray[MAX_FORWARD_PROBES], float4 refScaleArray[MAX_FORWARD_PROBES], float4 inRefPosArray[MAX_FORWARD_PROBES],
     float skylightCubemapIdx, TORQUE_SAMPLER2D(BRDFTexture), 
 	 TORQUE_SAMPLERCUBEARRAY(irradianceCubemapAR), TORQUE_SAMPLERCUBEARRAY(specularCubemapAR))
 {
@@ -456,7 +464,7 @@ float4 computeForwardProbes(Surface surface,
       if (contrib > 0.0f)
       {
          int cubemapIdx = probeConfigData[i].a;
-         float3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refBoxMinArray[i].xyz, refBoxMaxArray[i].xyz, inRefPosArray[i].xyz);
+         float3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refScaleArray[i].xyz, inRefPosArray[i].xyz);
 
          irradiance += TORQUE_TEXCUBEARRAYLOD(irradianceCubemapAR, dir, cubemapIdx, 0).xyz * contrib;
          specular += TORQUE_TEXCUBEARRAYLOD(specularCubemapAR, dir, cubemapIdx, lod).xyz * contrib;
@@ -494,7 +502,7 @@ float4 computeForwardProbes(Surface surface,
 
 float4 debugVizForwardProbes(Surface surface,
     float cubeMips, int numProbes, float4x4 worldToObjArray[MAX_FORWARD_PROBES], float4 probeConfigData[MAX_FORWARD_PROBES], 
-    float4 inProbePosArray[MAX_FORWARD_PROBES], float4 refBoxMinArray[MAX_FORWARD_PROBES], float4 refBoxMaxArray[MAX_FORWARD_PROBES], float4 inRefPosArray[MAX_FORWARD_PROBES],
+    float4 inProbePosArray[MAX_FORWARD_PROBES], float4 refScaleArray[MAX_FORWARD_PROBES], float4 inRefPosArray[MAX_FORWARD_PROBES],
     float skylightCubemapIdx, TORQUE_SAMPLER2D(BRDFTexture), 
 	 TORQUE_SAMPLERCUBEARRAY(irradianceCubemapAR), TORQUE_SAMPLERCUBEARRAY(specularCubemapAR), int showAtten, int showContrib, int showSpec, int showDiff)
 {
@@ -605,7 +613,7 @@ float4 debugVizForwardProbes(Surface surface,
       if (contrib > 0.0f)
       {
          int cubemapIdx = probeConfigData[i].a;
-         float3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refBoxMinArray[i].xyz, refBoxMaxArray[i].xyz, inRefPosArray[i].xyz);
+         float3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refScaleArray[i].xyz, inRefPosArray[i].xyz);
 
          irradiance += TORQUE_TEXCUBEARRAYLOD(irradianceCubemapAR, dir, cubemapIdx, 0).xyz * contrib;
          specular += TORQUE_TEXCUBEARRAYLOD(specularCubemapAR, dir, cubemapIdx, lod).xyz * contrib;

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/prefilterP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/prefilterP.glsl
@@ -127,4 +127,5 @@ void main()
 {   
 	vec3 N = getCubeDir(face, uv0);
 	OUT_col = prefilterEnvMap(N);
+	OUT_col.a = 1;
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
@@ -33,8 +33,7 @@ uniform vec4 rtParams6;
 uniform vec4    inProbePosArray[MAX_PROBES];
 uniform vec4    inRefPosArray[MAX_PROBES];
 uniform mat4    worldToObjArray[MAX_PROBES];
-uniform vec4    refBoxMinArray[MAX_PROBES];
-uniform vec4    refBoxMaxArray[MAX_PROBES];
+uniform vec4    refScaleArray[MAX_PROBES];
 uniform vec4    probeConfigData[MAX_PROBES];   //r,g,b/mode,radius,atten
 
 #if DEBUGVIZ_CONTRIB
@@ -180,7 +179,7 @@ void main()
       if (contrib > 0.0f)
       {
          float cubemapIdx = probeConfigData[i].a;
-         vec3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refBoxMinArray[i].xyz, refBoxMaxArray[i].xyz, inRefPosArray[i].xyz);
+         vec3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refScaleArray[i].xyz, inRefPosArray[i].xyz);
 
          irradiance += textureLod(irradianceCubemapAR, vec4(dir, cubemapIdx), 0).xyz * contrib;
          specular += textureLod(specularCubemapAR, vec4(dir, cubemapIdx), lod).xyz * contrib;

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/prefilterP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/prefilterP.hlsl
@@ -126,5 +126,5 @@ float4 prefilterEnvMap(float3 R)
 float4 main(ConnectData IN) : TORQUE_TARGET0
 {
 	float3 N = getCubeDir(face, IN.uv);
-	return prefilterEnvMap(N);
+	return float4(prefilterEnvMap(N).rgb,1.0);
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
@@ -30,8 +30,7 @@ uniform float4 rtParams6;
 uniform float4    inProbePosArray[MAX_PROBES];
 uniform float4    inRefPosArray[MAX_PROBES];
 uniform float4x4  worldToObjArray[MAX_PROBES];
-uniform float4    refBoxMinArray[MAX_PROBES];
-uniform float4    refBoxMaxArray[MAX_PROBES];
+uniform float4    refScaleArray[MAX_PROBES];
 uniform float4    probeConfigData[MAX_PROBES];   //r,g,b/mode,radius,atten
 
 #if DEBUGVIZ_CONTRIB
@@ -172,7 +171,7 @@ float4 main(PFXVertToPix IN) : SV_TARGET
       if (contrib > 0.0f)
       {
          int cubemapIdx = probeConfigData[i].a;
-         float3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refBoxMinArray[i].xyz, refBoxMaxArray[i].xyz, inRefPosArray[i].xyz);
+         float3 dir = boxProject(surface.P, surface.R, worldToObjArray[i], refScaleArray[i].xyz, inRefPosArray[i].xyz);
 
          irradiance += TORQUE_TEXCUBEARRAYLOD(irradianceCubemapAR, dir, cubemapIdx, 0).xyz * contrib;
          specular += TORQUE_TEXCUBEARRAYLOD(specularCubemapAR, dir, cubemapIdx, lod).xyz * contrib;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/probeBake.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/probeBake.ed.cs
@@ -39,17 +39,11 @@ function ProbeBakeDlg_RunBake::onClick(%this)
       if(%iter != 0)
          $pref::ReflectionProbes::RenderWithProbes = true;
          
-      for(%i=0; %i < %probeCount; %i++)
-      {
-         %probe = getWord(%probeIds, %i);
-         
-         $pref::ReflectionProbes::CurrentLevelPath = filePath($Server::MissionFile) @ "/" @ fileBase($Server::MissionFile) @ "/probes/";
-         ProbeBin.bakeProbe(%probe);
-         
-         %currentProgressValue += %progressStep;
-         ProbeBakeDlg_Progress.setValue(%currentProgressValue);
-         Canvas.repaint();
-      }
+      $pref::ReflectionProbes::CurrentLevelPath = filePath($Server::MissionFile) @ "/" @ fileBase($Server::MissionFile) @ "/probes/";
+      ProbeBin.bakeProbes();
+      
+      %currentProgressValue += %progressStep;
+      ProbeBakeDlg_Progress.setValue(%currentProgressValue);
    }
    
    EWorldEditor.isDirty = true;


### PR DESCRIPTION
Overhauls the handling of probes to utilize an active probe list to improve performance and allow a greater total number of active probes in a scene, and also improves stability.

Also fixes handling of metal materials during bakes to render properly, and fixes a possible double-up return in findObjectByType, which could cause doubling when getting probes in the scene