### PR TITLE
Added date/timestamp option to console log

### DIFF
--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -621,7 +621,7 @@ static void _printf(ConsoleLogEntry::Level level, ConsoleLogEntry::Type type, co
    {
       Platform::LocalTime lt;
       Platform::getLocalTime(lt);
-      offset += dSprintf(buffer + offset, sizeof(buffer) - offset, "[%d/%d/%d %02d:%02d:%02d]", lt.year + 1900, lt.month + 1, lt.monthday, lt.hour, lt.min, lt.sec);
+      offset += dSprintf(buffer + offset, sizeof(buffer) - offset, "[%d-%d-%d %02d:%02d:%02d]", lt.year + 1900, lt.month + 1, lt.monthday, lt.hour, lt.min, lt.sec);
    }
 
    if (useTimestamp)
@@ -630,6 +630,12 @@ static void _printf(ConsoleLogEntry::Level level, ConsoleLogEntry::Type type, co
       U32 curTime = Platform::getRealMilliseconds() - startTime;
       offset += dSprintf(buffer + offset, sizeof(buffer) - offset, "[+%4d.%03d]", U32(curTime * 0.001), curTime % 1000);
    }
+
+   if (useTimestamp || useRealTimestamp) {
+      offset += dSprintf(buffer + offset, sizeof(buffer) - offset, " ");
+   }
+
+
    dVsprintf(buffer + offset, sizeof(buffer) - offset, fmt, argptr);
 
    for(S32 i = 0; i < gConsumers.size(); i++)

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -621,7 +621,7 @@ static void _printf(ConsoleLogEntry::Level level, ConsoleLogEntry::Type type, co
    {
       Platform::LocalTime lt;
       Platform::getLocalTime(lt);
-      offset += dSprintf(buffer + offset, sizeof(buffer) - offset, "[%d/%d/%d %02d:%02d:%02d]", lt.monthday, lt.month + 1, lt.year + 1900, lt.hour, lt.min, lt.sec);
+      offset += dSprintf(buffer + offset, sizeof(buffer) - offset, "[%d/%d/%d %02d:%02d:%02d]", lt.year + 1900, lt.month + 1, lt.monthday, lt.hour, lt.min, lt.sec);
    }
 
    if (useTimestamp)

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -275,6 +275,7 @@ S32 gObjectCopyFailures = -1;
 
 bool alwaysUseDebugOutput = true;
 bool useTimestamp = false;
+bool useRealTimestamp = false;
 
 ConsoleFunctionGroupBegin( Clipboard, "Miscellaneous functions to control the clipboard and clear the console.");
 
@@ -372,6 +373,10 @@ void init()
 
    // controls whether a timestamp is prepended to every console message
    addVariable("Con::useTimestamp", TypeBool, &useTimestamp, "If true a timestamp is prepended to every console message.\n"
+      "@ingroup Console\n");
+
+   // controls whether a real date and time is prepended to every console message
+   addVariable("Con::useRealTimestamp", TypeBool, &useRealTimestamp, "If true a date and time will be prepended to every console message.\n"
       "@ingroup Console\n");
 
    // Plug us into the journaled console input signal.
@@ -610,6 +615,13 @@ static void _printf(ConsoleLogEntry::Level level, ConsoleLogEntry::Type type, co
       offset = gEvalState.getStackDepth() * 3;
       for(U32 i = 0; i < offset; i++)
          buffer[i] = ' ';
+   }
+
+   if (useRealTimestamp)
+   {
+      Platform::LocalTime lt;
+      Platform::getLocalTime(lt);
+      offset += dSprintf(buffer + offset, sizeof(buffer) - offset, "[%d/%d/%d %02d:%02d:%02d]", lt.monthday, lt.month + 1, lt.year + 1900, lt.hour, lt.min, lt.sec);
    }
 
    if (useTimestamp)


### PR DESCRIPTION
Added support for prepending a fairly popular timestamp style Example: `[24/10/2020 05:38:39]Console message`
to use: `Con::useRealTimestamp = true;` 
Open to different name suggestions for the variable if it's not liked.
Also if it's requested could make date and/or time options but I see that getting to be a little messy in code. Also plays nice with `Con::useTimestamp`