### PR TITLE
Misc. BaseGame UI fixes

### DIFF
--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -391,7 +391,7 @@ void GuiGameListMenuCtrl::onRenderKeybindOption(Row* row, Point2I currentOffset)
    //drawer->drawBitmap(row->mBitmap, )
 
    Point2I button;
-   button.x = currentOffset.x + columnSplit + (columnSplit / 2)/* + (optionWidth / 2)*/;
+   button.x = currentOffset.x + columnSplit + (columnSplit / 2.5)/* + (optionWidth / 2)*/;
    button.y = currentOffset.y + (rowHeight / 4);
 
    Point2I buttonSize;
@@ -883,6 +883,14 @@ bool GuiGameListMenuCtrl::onKeyDown(const GuiEvent &event)
 
       case KEY_DOWN:
          changeRow(1);
+         return true;
+
+      case KEY_LEFT:
+         changeOption(-1);
+         return true;
+
+      case KEY_RIGHT:
+         changeOption(1);
          return true;
 
       case KEY_A:

--- a/Templates/BaseGame/game/data/ui/guis/optionsMenu.gui
+++ b/Templates/BaseGame/game/data/ui/guis/optionsMenu.gui
@@ -206,7 +206,7 @@
          willFirstRespond = "1";
          hScrollBar = "alwaysOff";
          vScrollBar = "dynamic";
-         lockHorizScroll = "0";
+         lockHorizScroll = "1";
          lockVertScroll = "0";
          constantThumbHeight = "0";
          childMargin = "0 0";

--- a/Templates/BaseGame/game/data/ui/guis/pauseMenu.cs
+++ b/Templates/BaseGame/game/data/ui/guis/pauseMenu.cs
@@ -9,6 +9,7 @@ function PauseMenu::onWake(%this)
 {
    $timescale = 0;
    
+   sfxSetChannelVolume( $SimAudioType, $pref::SFX::channelVolume[ 0 ] );
    PauseMenuList.hidden = false;
    PauseMenuList.setFirstResponder();
    PauseButtonHolder.setActive();
@@ -18,6 +19,7 @@ function PauseMenu::onWake(%this)
 function PauseMenu::onSleep(%this)
 {
    $timescale = 1;
+   sfxSetChannelVolume( $SimAudioType, $pref::SFX::channelVolume[ $SimAudioType ] );
 }
 
 function PauseMenu::onReturnTo(%this)

--- a/Templates/BaseGame/game/data/ui/guis/pauseMenu.cs
+++ b/Templates/BaseGame/game/data/ui/guis/pauseMenu.cs
@@ -7,9 +7,13 @@ function PauseMenuList::onAdd(%this)
 
 function PauseMenu::onWake(%this)
 {
-   $timescale = 0;
+   if($Server::ServerType $= "SinglePlayer")
+   {
+      $timescale = 0;
+      
+      sfxSetChannelVolume( $SimAudioType, $pref::SFX::channelVolume[ 0 ] );
+   }
    
-   sfxSetChannelVolume( $SimAudioType, $pref::SFX::channelVolume[ 0 ] );
    PauseMenuList.hidden = false;
    PauseMenuList.setFirstResponder();
    PauseButtonHolder.setActive();
@@ -18,8 +22,11 @@ function PauseMenu::onWake(%this)
 
 function PauseMenu::onSleep(%this)
 {
-   $timescale = 1;
-   sfxSetChannelVolume( $SimAudioType, $pref::SFX::channelVolume[ $SimAudioType ] );
+   if($Server::ServerType $= "SinglePlayer")
+   {
+      $timescale = 1;
+      sfxSetChannelVolume( $SimAudioType, $pref::SFX::channelVolume[ $SimAudioType ] );
+   }
 }
 
 function PauseMenu::onReturnTo(%this)


### PR DESCRIPTION
Adjusts guiGameListMenuCtrl.cpp to handle Left and Right keys to adjust options, which simultaneously fixes the 'jiggle' issue on the options menu of the BaseGame base UI
Per Steve's suggestion, put a pause on gameplay sounds alongside the game sim being paused when the pause menu is opened.
Nudges the keybind preview image for guiGameListMenuCtrl to be better centered