### PR TITLE
Adds a sanity check so asset names cannot start with a number

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/newAsset.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/newAsset.cs
@@ -167,6 +167,13 @@ function CreateNewAsset()
 		return;
 	}
 	
+	%firstChar = getSubStr(%assetName, 0, 1);
+	if(isInt(%firstChar))
+	{
+	    toolsMessageBoxOK( "Error", "Names cannot start with a number!");
+		return;
+	}
+	
 	//get the selected module data
    %moduleName = NewAssetTargetModule.getText();
    


### PR DESCRIPTION
Adds a sanity check so asset names cannot start with a number, which would be an invalid object name,