### PR TITLE
Misc. probe bake/load fixups

### DIFF
--- a/Engine/source/T3D/lighting/reflectionProbe.cpp
+++ b/Engine/source/T3D/lighting/reflectionProbe.cpp
@@ -296,7 +296,7 @@ bool ReflectionProbe::onAdd()
    // Refresh this object's material (if any)
    if (isClientObject())
    {
-      if (!createClientResources())
+      if (!mResourcesCreated && !createClientResources())
          return false;
 
       updateProbeParams();
@@ -496,6 +496,12 @@ void ReflectionProbe::unpackUpdate(NetConnection *conn, BitStream *stream)
 //-----------------------------------------------------------------------------
 void ReflectionProbe::updateProbeParams()
 {
+   if (!mResourcesCreated)
+   {
+      if (!createClientResources())
+         return;
+   }
+
    mProbeInfo.mIsEnabled = mEnabled;
 
    mProbeInfo.mProbeShapeType = mProbeShapeType;
@@ -624,7 +630,7 @@ void ReflectionProbe::processStaticCubemap()
    String path = Con::getVariable("$pref::ReflectionProbes::CurrentLevelPath", "levels/");
 
    char irradFileName[256];
-   dSprintf(irradFileName, 256, "%s_Irradiance.dds", path.c_str(), mCubemapName.c_str());
+   dSprintf(irradFileName, 256, "%s%s_Irradiance.dds", path.c_str(), mCubemapName.c_str());
 
    if (Platform::isFile(irradFileName))
    {

--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -203,7 +203,8 @@ RenderProbeMgr::RenderProbeMgr()
    mHasSkylight(false),
    mSkylightCubemapIdx(-1),
    mCubeMapCount(0),
-   mDefaultSkyLight(nullptr)
+   mDefaultSkyLight(nullptr),
+   mUseHDRCaptures(true)
 {
    mEffectiveProbeCount = 0;
    mMipCount = 0;


### PR DESCRIPTION
Ensures that baking is consistently set to use HDR formats or not which avoids an occasional mismatch crash

Also corrected a string formatting issue with loading static cubemaps on probes that could lead to a crash
Fixed the resources loaded handling so it would correctly initialize the probe's cubemaps even if the initial ghost network packet assigned a cubemap before we fully init'd the client object