### PR TITLE
Misc fixes to ensure that the default postFX save, load and editing process is valid

### DIFF
--- a/Engine/source/assets/assetBase_ScriptBinding.h
+++ b/Engine/source/assets/assetBase_ScriptBinding.h
@@ -41,29 +41,33 @@ DefineEngineMethod(AssetBase, getAssetId, String, (), ,
 }
 
 DefineEngineMethod(AssetBase, getAssetDependencyFieldCount, S32, (const char* pFieldName), (""),
-   "Gets the assets' Asset Id.  This is only available if the asset was acquired from the asset manager.\n"
-   "@return The assets' Asset Id.\n")
+   "Gets the number of asset dependencies of a given field name.\n"
+   "eg. Would return '2' if you searched for 'myDependencyField'\n"
+   "and the asset had myDependencyField0 and myDependencyField1\n"
+   "@param fieldName The name of the field to get a count of\n"
+   "@return The number of dependency fields matching the search name.\n")
 {
    return object->getAssetDependencyFieldCount(pFieldName);
 }
 
 DefineEngineMethod(AssetBase, clearAssetDependencyFields, void, (const char* pFieldName), (""),
-   "Gets the assets' Asset Id.  This is only available if the asset was acquired from the asset manager.\n"
-   "@return The assets' Asset Id.\n")
+   "Clears any asset dependency fields matching the name provided.\n"
+   "@param fieldName The name of the fields to be cleared")
 {
    object->clearAssetDependencyFields(pFieldName);
 }
 
 DefineEngineMethod(AssetBase, addAssetDependencyField, void, (const char* pFieldName, const char* pAssetId), ("", ""),
-   "Gets the assets' Asset Id.  This is only available if the asset was acquired from the asset manager.\n"
-   "@return The assets' Asset Id.\n")
+   "Adds an asset dependency field to the asset definition.\n"
+   "@param fieldName The name of the field. Will automatically increment the tailing number if the field is used multiple times\n"
+   "@param assetId The assetId to be marked as a dependency")
 {
    object->addAssetDependencyField(pFieldName, pAssetId);
 }
 
 DefineEngineMethod(AssetBase, saveAsset, bool, (), ,
-   "Gets the assets' Asset Id.  This is only available if the asset was acquired from the asset manager.\n"
-   "@return The assets' Asset Id.\n")
+   "Saves the asset definition.\n"
+   "@return Whether the save was successful.\n")
 {
    return object->saveAsset();
 }

--- a/Templates/BaseGame/game/core/postFX/Core_PostFX.cs
+++ b/Templates/BaseGame/game/core/postFX/Core_PostFX.cs
@@ -5,28 +5,8 @@ function Core_PostFX::onCreate(%this)
    exec("./scripts/postFxManager.cs");
    exec("./scripts/postFx.cs");
    
-   /*exec("./scripts/postFxManager.gui.settings.cs");
-   exec("./scripts/postFxManager.persistance.cs");
-   
-   exec("./scripts/default.postfxpreset.cs");
-   
-   exec("./scripts/caustics.cs");
-   exec("./scripts/chromaticLens.cs");
-   exec("./scripts/dof.cs");
-   exec("./scripts/edgeAA.cs");
-   exec("./scripts/flash.cs");
-   exec("./scripts/fog.cs");
-   exec("./scripts/fxaa.cs");
-   exec("./scripts/GammaPostFX.cs");
-   exec("./scripts/glow.cs");
-   exec("./scripts/hdr.cs");
-   exec("./scripts/lightRay.cs");
-   exec("./scripts/MLAA.cs");
-   exec("./scripts/MotionBlurFx.cs");
-   exec("./scripts/ovrBarrelDistortion.cs");
-   exec("./scripts/ssao.cs");
-   exec("./scripts/turbulence.cs");
-   exec("./scripts/vignette.cs");*/
+   //Load the default config
+   loadPresetHandler("./scripts/default.postfxpreset.cs");
 }
 
 function Core_PostFX::onDestroy(%this)

--- a/Templates/BaseGame/game/core/postFX/scripts/HDR/HDRPostFX.cs
+++ b/Templates/BaseGame/game/core/postFX/scripts/HDR/HDRPostFX.cs
@@ -341,9 +341,6 @@ function HDRPostFX::onAdd( %this )
 {
    PostFXManager.registerPostEffect(%this);
    
-   //HDR should really be on at all times
-   //%this.enable();
-   
    $PostFX::HDRPostFX::enableToneMapping = 1;
 }
 
@@ -356,7 +353,6 @@ function HDRPostFX::populatePostFXSettings(%this)
    PostEffectEditorInspector.addCallbackField("$PostFX::HDRPostFX::Enabled", "Enabled", "bool", "", $PostFX::HDRPostFX::Enabled, "", "toggleHDRPostFX");
    PostEffectEditorInspector.addField("$PostFX::HDRPostFX::minLuminace", "Minimum Luminance", "range", "", $PostFX::HDRPostFX::minLuminace, "0 1 100");
    PostEffectEditorInspector.addField("$PostFX::HDRPostFX::whiteCutoff", "White Cutoff", "range", "", $PostFX::HDRPostFX::whiteCutoff, "0 10 20");
-   PostEffectEditorInspector.addField("$PostFX::HDRPostFX::adaptRate", "Brightness Adapt Rate", "range", "", $PostFX::HDRPostFX::adaptRate, "0 1 10");
    PostEffectEditorInspector.endGroup();
    
    PostEffectEditorInspector.startGroup("HDR - Tonemapping");
@@ -373,6 +369,7 @@ function HDRPostFX::populatePostFXSettings(%this)
    
    PostEffectEditorInspector.startGroup("HDR - Adaptation");
    PostEffectEditorInspector.addField("$PostFX::HDRPostFX::enableAutoExposure", "Enable Auto Exposure", "bool", "", $PostFX::HDRPostFX::enableAutoExposure, "");
+   PostEffectEditorInspector.addField("$PostFX::HDRPostFX::adaptRate", "Brightness Adapt Rate", "range", "", $PostFX::HDRPostFX::adaptRate, "0 1 10");
    PostEffectEditorInspector.addField("$PostFX::HDRPostFX::keyValue", "Key Value", "range", "", $PostFX::HDRPostFX::keyValue, "0 1 10");
    PostEffectEditorInspector.addField("$PostFX::HDRPostFX::enableBlueShift", "Enable Blue Shift", "bool", "", $PostFX::HDRPostFX::enableBlueShift, "");
    PostEffectEditorInspector.addField("$PostFX::HDRPostFX::blueShiftColor", "Blue Shift Color", "colorF", "", $PostFX::HDRPostFX::blueShiftColor, "");

--- a/Templates/BaseGame/game/core/postFX/scripts/default.postfxpreset.cs
+++ b/Templates/BaseGame/game/core/postFX/scripts/default.postfxpreset.cs
@@ -1,72 +1,14 @@
-//-----------------------------------------------------------------------------
-// Copyright (c) 2012 GarageGames, LLC
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal in the Software without restriction, including without limitation the
-// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-// sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
-//-----------------------------------------------------------------------------
-$PostFXManager::Settings::EnableVignette = "1";
-$PostFXManager::Settings::EnableDOF = "1";
-$PostFXManager::Settings::EnabledSSAO = "1";
-$PostFXManager::Settings::EnableHDR = "1";
-$PostFXManager::Settings::EnableLightRays = "1";
-$PostFXManager::Settings::EnablePostFX = "1";
-$PostFXManager::Settings::Vignette::VMax = "0.6";
-$PostFXManager::Settings::DOF::BlurCurveFar = "";
-$PostFXManager::Settings::DOF::BlurCurveNear = "";
-$PostFXManager::Settings::DOF::BlurMax = "";
-$PostFXManager::Settings::DOF::BlurMin = "";
-$PostFXManager::Settings::DOF::EnableAutoFocus = "";
-$PostFXManager::Settings::DOF::EnableDOF = "";
-$PostFXManager::Settings::DOF::FocusRangeMax = "";
-$PostFXManager::Settings::DOF::FocusRangeMin = "";
-$PostFXManager::Settings::HDR::adaptRate = "2";
-$PostFXManager::Settings::HDR::blueShiftColor = "1.05 0.97 1.27";
-$PostFXManager::Settings::HDR::brightPassThreshold = "1";
-$PostFXManager::Settings::HDR::enableBloom = "1";
-$PostFXManager::Settings::HDR::enableBlueShift = "0";
-$PostFXManager::Settings::HDR::enableToneMapping = "0.5";
-$PostFXManager::Settings::HDR::gaussMean = "0";
-$PostFXManager::Settings::HDR::gaussMultiplier = "0.3";
-$PostFXManager::Settings::HDR::gaussStdDev = "0.8";
-$PostFXManager::Settings::HDR::keyValue = "0.18";
-$PostFXManager::Settings::HDR::minLuminace = "0.001";
-$PostFXManager::Settings::HDR::whiteCutoff = "1";
-$PostFXManager::Settings::LightRays::brightScalar = "0.75";
-$PostFXManager::Settings::LightRays::decay = "1.0";
-$PostFXManager::Settings::LightRays::density = "0.94";
-$PostFXManager::Settings::LightRays::numSamples = "40";
-$PostFXManager::Settings::LightRays::weight = "5.65";
-$PostFXManager::Settings::SSAO::blurDepthTol = "0.001";
-$PostFXManager::Settings::SSAO::blurNormalTol = "0.95";
-$PostFXManager::Settings::SSAO::lDepthMax = "2";
-$PostFXManager::Settings::SSAO::lDepthMin = "0.2";
-$PostFXManager::Settings::SSAO::lDepthPow = "0.2";
-$PostFXManager::Settings::SSAO::lNormalPow = "2";
-$PostFXManager::Settings::SSAO::lNormalTol = "-0.5";
-$PostFXManager::Settings::SSAO::lRadius = "1";
-$PostFXManager::Settings::SSAO::lStrength = "10";
-$PostFXManager::Settings::SSAO::overallStrength = "2";
-$PostFXManager::Settings::SSAO::quality = "0";
-$PostFXManager::Settings::SSAO::sDepthMax = "1";
-$PostFXManager::Settings::SSAO::sDepthMin = "0.1";
-$PostFXManager::Settings::SSAO::sDepthPow = "1";
-$PostFXManager::Settings::SSAO::sNormalPow = "1";
-$PostFXManager::Settings::SSAO::sNormalTol = "0";
-$PostFXManager::Settings::SSAO::sRadius = "0.1";
-$PostFXManager::Settings::SSAO::sStrength = "6";
-$PostFXManager::Settings::ColorCorrectionRamp = "core/postFX/images/null_color_ramp.png";
+$PostFX::HDRPostFX::Enabled = 1;
+$PostFX::HDRPostFX::minLuminace = 0.001;
+$PostFX::HDRPostFX::whiteCutoff = 1;
+$PostFX::HDRPostFX::adaptRate = 2;
+$PostFX::HDRPostFX::tonemapMode = "ACES";
+$PostFX::HDRPostFX::enableBloom = 1;
+$PostFX::HDRPostFX::brightPassThreshold = 1;
+$PostFX::HDRPostFX::gaussMultiplier = 0.3;
+$PostFX::HDRPostFX::gaussMean = 0;
+$PostFX::HDRPostFX::gaussStdDev = 0.8;
+$PostFX::HDRPostFX::enableAutoExposure = "0";
+$PostFX::HDRPostFX::keyValue = 0.18;
+$PostFX::HDRPostFX::enableBlueShift = 0;
+$PostFX::HDRPostFX::blueShiftColor = "1.05 0.97 1.27";

--- a/Templates/BaseGame/game/core/postFX/scripts/postFxManager.cs
+++ b/Templates/BaseGame/game/core/postFX/scripts/postFxManager.cs
@@ -103,13 +103,26 @@ function PostFXManager::savePresetHandler( %filename )
       
    $PostFXManager::currentPresetFile = %filename;
    $PostFXManager::startedPresetFileSave = false;
-               
+   
+   //First, clear the existing file
+   %fileObj = new FileObject();
+   if (!%fileObj.openForWrite($PostFXManager::currentPresetFile))
+   {
+      %fileObj.delete();
+   }
+   else
+   {
+      %fileObj.writeLine("");
+      %fileObj.close();
+      %fileObj.delete();
+   }
+   
    %count = PostFXManager.Count();
    for(%i=0; %i < %count; %i++)
    {
       %postEffect = PostFXManager.getKey(%i);  
       
-      if(isObject(%postEffect) && %postEffect.isMethod("savePresetSettings"))
+      if(isObject(%postEffect) && %postEffect.isEnabled && %postEffect.isMethod("savePresetSettings"))
       {     
          %postEffect.savePresetSettings();
       }

--- a/Templates/BaseGame/game/tools/gui/postFxEditor.cs
+++ b/Templates/BaseGame/game/tools/gui/postFxEditor.cs
@@ -134,6 +134,7 @@ function editScenePostEffects(%scene)
 function PostFXEditorNewPFXWindow::showDialog(%this)
 {
    %this.setHidden(false);
+   PostFXEditorNewPFXWindow.selectWindow();
    
    PostFXEditorNewPFXList.clear();
    

--- a/Templates/BaseGame/game/tools/gui/postFxEditor.gui
+++ b/Templates/BaseGame/game/tools/gui/postFxEditor.gui
@@ -115,10 +115,9 @@
                active = "1";
                command = "PostFXEditorNewPFXWindow.showDialog();";
                tooltipProfile = "GuiToolTipProfile";
-               tooltip = "Add a new Import Config";
+               tooltip = "Add a new PostFX";
                hovertime = "1000";
                isContainer = "0";
-               internalName = "newImportConfig";
                canSave = "1";
                canSaveDynamicFields = "0";
             };
@@ -142,10 +141,9 @@
                active = "1";
                command = "PostFXEditor.removePostFX();";
                tooltipProfile = "GuiToolTipProfile";
-               tooltip = "Delets the currently selected import config";
+               tooltip = "Delets the currently selected PostFX";
                hovertime = "1000";
                isContainer = "0";
-               internalName = "deleteImportConfig";
                canSave = "1";
                canSaveDynamicFields = "0";
             };

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.cs
@@ -332,8 +332,22 @@ function EditorSaveMission()
          %obj.onSaveMission( $Server::MissionFile );      
    } 
    
+   //We'll sanity check that we have a valid file association to our level asset first
+   %presetFile = $Server::LevelAsset.getPostFXPresetPath();
+   
+   if(!isFile(%presetFile))
+   {
+      //if it isn't valid, we'll fabricate a new one just to be sure
+      $Server::LevelAsset.PostFXPresetFile = fileBase($Server::LevelAsset.getLevelPath()) @ $PostFXManager::fileExtension;
+    
+      $Server::LevelAsset.saveAsset();
+      $Server::LevelAsset.refresh(); 
+      
+      %presetFile = $Server::LevelAsset.getPostFXPresetPath();
+   }
+   
    //Save out the PostFX config
-   PostFXManager::savePresetHandler( $Server::LevelAsset.getPostFXPresetPath() );
+   PostFXManager::savePresetHandler( %presetFile );
    
    EditorClearDirty();
    

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menus.ed.cs
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menus.ed.cs
@@ -208,7 +208,7 @@ function EditorGui::buildMenus(%this)
       item[14] = "Snap Options..." TAB "" TAB "ESnapOptions.ToggleVisibility();";
       item[15] = "-";
       item[16] = "Game Options..." TAB "" TAB "Canvas.pushDialog(optionsDlg);";
-      item[17] = "PostEffect Manager" TAB "" TAB "Canvas.pushDialog(PostFXEditor);";
+      item[17] = "Edit Default PostFX Config" TAB "" TAB "PostFXEditor.editDefaultPostFXSettings();";
    };
    %this.menuBar.insert(%editMenu);
       


### PR DESCRIPTION
Misc fixes to ensure that the default postFX save, load and editing process is valid

Also fixes it so if a level asset doesn't point to a valid postfx preset file, it'll generate a clean one on save