### PR TITLE
shader preprocessor fixes

### DIFF
--- a/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
@@ -24,7 +24,7 @@
 #include "./brdf.glsl"
 
 #ifndef TORQUE_SHADERGEN
-#line 26
+#line 27
 // These are the uniforms used by most lighting shaders.
 
 uniform vec4 inLightPos[4];
@@ -51,6 +51,18 @@ uniform vec4 albedo;
 #define MAX_FORWARD_PROBES 4
 
 #define MAX_FORWARD_LIGHT 4
+
+#ifndef CAPTURING
+#define CAPTURING 0
+#endif
+
+#ifndef DEBUGVIZ_ATTENUATION
+#define DEBUGVIZ_ATTENUATION 0
+#endif
+
+#ifndef DEBUGVIZ_CONTRIB
+#define DEBUGVIZ_CONTRIB 0
+#endif
 
 vec3 getDistanceVectorToPlane( vec3 origin, vec3 direction, vec4 plane )
 {
@@ -219,7 +231,7 @@ vec3 evaluateStandardBRDF(Surface surface, SurfaceToLight surfaceToLight)
    float D = D_GGX(surfaceToLight.NdotH, surface.linearRoughnessSq);
    vec3 Fr = D * F * Vis;
 
-#if CAPTURING == true
+#if (CAPTURING == 1)
    return mix(Fd + Fr,surface.f0,surface.metalness);
 #else
    return Fd + Fr;
@@ -416,7 +428,7 @@ vec4 computeForwardProbes(Surface surface,
       }
    }
 
-#if DEBUGVIZ_ATTENUATION == 1
+#if (DEBUGVIZ_ATTENUATION == 1)
       float contribAlpha = 1;
       for (i = 0; i < numProbes; ++i)
       {
@@ -426,7 +438,7 @@ vec4 computeForwardProbes(Surface surface,
       return vec4(1 - contribAlpha, 1 - contribAlpha, 1 - contribAlpha, 1);
 #endif
 
-#if DEBUGVIZ_CONTRIB == 1
+#if (DEBUGVIZ_CONTRIB == 1)
    vec3 probeContribColors[4];
    probeContribColors[0] = vec3(1,0,0);
    probeContribColors[1] = vec3(0,1,0);

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
@@ -53,6 +53,18 @@ uniform float4 albedo;
 
 #define MAX_FORWARD_LIGHT 4
 
+#ifndef CAPTURING
+#define CAPTURING 0
+#endif
+
+#ifndef DEBUGVIZ_ATTENUATION
+#define DEBUGVIZ_ATTENUATION 0
+#endif
+
+#ifndef DEBUGVIZ_CONTRIB
+#define DEBUGVIZ_CONTRIB 0
+#endif
+
 inline float3 getDistanceVectorToPlane( float3 origin, float3 direction, float4 plane )
 {
    float denum = dot( plane.xyz, direction.xyz );


### PR DESCRIPTION
some hardware/apis do not evalueate 'not defined' as '0', so always ensure there's *some* value when doing macro value comparisons