### PR TITLE
Pause Menu toggle fix

### DIFF
--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -819,11 +819,11 @@ bool GuiGameListMenuCtrl::onInputEvent(const InputEventInfo& event)
 {
    if (mCallbackOnInputs)
    {
-      char deviceString[32];
-      if (!ActionMap::getDeviceName(event.deviceType, event.deviceInst, deviceString))
+      char deviceStr[32];
+      if (!ActionMap::getDeviceName(event.deviceType, event.deviceInst, deviceStr))
          return false;
 
-      StringTableEntry deviceStringEntry = StringTable->insert(deviceString);
+      String deviceString = deviceStr;
 
       if (event.action == SI_MAKE || event.action == SI_BREAK)
       {
@@ -850,23 +850,22 @@ bool GuiGameListMenuCtrl::onInputEvent(const InputEventInfo& event)
             if (!ActionMap::getKeyString(event.objInst, keyString))
                return false;
 
-            onInputEvent_callback(deviceStringEntry, keyString, state);
+            onInputEvent_callback(deviceString.c_str(), keyString, state);
 
             if (mConsumeKeyInputEvents)
             {
-               if(deviceStringEntry == StringTable->insert("keyboard"))
+               if(deviceString.startsWith("keyboard"))
                   return true;
             }
-
          }
          else
          {
             const char* actionString = ActionMap::buildActionString(&event);
-            onInputEvent_callback(deviceStringEntry, actionString, state);
+            onInputEvent_callback(deviceString.c_str(), actionString, state);
 
             if (mConsumeKeyInputEvents)
             {
-               if (deviceStringEntry == StringTable->insert("keyboard"))
+               if (deviceString.startsWith("keyboard") || deviceString.startsWith("gamepad"))
                   return true;
             }
          }
@@ -877,12 +876,12 @@ bool GuiGameListMenuCtrl::onInputEvent(const InputEventInfo& event)
          if (event.objType == SI_INT)
             fValue = (F32)event.iValue;
 
-         if (!ActionMap::getDeviceName(event.deviceType, event.deviceInst, deviceString))
+         if (!ActionMap::getDeviceName(event.deviceType, event.deviceInst, deviceStr))
             return false;
 
          const char* actionString = ActionMap::buildActionString(&event);
 
-         onAxisEvent_callback(deviceString, actionString, fValue);
+         onAxisEvent_callback(deviceStr, actionString, fValue);
       }
    }
 

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -37,7 +37,8 @@ GuiGameListMenuCtrl::GuiGameListMenuCtrl()
  : mSelected(NO_ROW),
    mDebugRender(false),
    mHighlighted(NO_ROW),
-   mCallbackOnInputs(false)
+   mCallbackOnInputs(false),
+   mConsumeKeyInputEvents(false)
 {
    VECTOR_SET_ASSOCIATION(mRows);
 
@@ -822,6 +823,8 @@ bool GuiGameListMenuCtrl::onInputEvent(const InputEventInfo& event)
       if (!ActionMap::getDeviceName(event.deviceType, event.deviceInst, deviceString))
          return false;
 
+      StringTableEntry deviceStringEntry = StringTable->insert(deviceString);
+
       if (event.action == SI_MAKE || event.action == SI_BREAK)
       {
          bool isModifier = false;
@@ -847,12 +850,25 @@ bool GuiGameListMenuCtrl::onInputEvent(const InputEventInfo& event)
             if (!ActionMap::getKeyString(event.objInst, keyString))
                return false;
 
-            onInputEvent_callback(deviceString, keyString, state);
+            onInputEvent_callback(deviceStringEntry, keyString, state);
+
+            if (mConsumeKeyInputEvents)
+            {
+               if(deviceStringEntry == StringTable->insert("keyboard"))
+                  return true;
+            }
+
          }
          else
          {
             const char* actionString = ActionMap::buildActionString(&event);
-            onInputEvent_callback(deviceString, actionString, state);
+            onInputEvent_callback(deviceStringEntry, actionString, state);
+
+            if (mConsumeKeyInputEvents)
+            {
+               if (deviceStringEntry == StringTable->insert("keyboard"))
+                  return true;
+            }
          }
       }
       else if (event.objType == SI_AXIS || event.objType == SI_INT || event.objType == SI_FLOAT)
@@ -1400,6 +1416,10 @@ void GuiGameListMenuCtrl::initPersistFields()
 
    addField("callbackOnInputs", TypeBool, Offset(mCallbackOnInputs, GuiGameListMenuCtrl),
       "Script callback when any inputs are detected, even if they aren't the regular 4 face buttons. Useful for secondary/speciality handling of menu navigation.");
+
+   addField("consumeKeyInputEvents", TypeBool, Offset(mConsumeKeyInputEvents, GuiGameListMenuCtrl),
+      "When callbackOnInputs is active, this indicates if the input event should be consumed, or allowed 'through' to let other things respond to the event as well.");
+   
 
    Parent::initPersistFields();
 }

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.h
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.h
@@ -428,6 +428,7 @@ private:
    S32      mHighlighted;  ///< index of the currently highlighted row
 
    bool     mCallbackOnInputs;
+   bool     mConsumeKeyInputEvents;
 };
 
 /// \class GuiGameListMenuProfile

--- a/Templates/BaseGame/game/data/ui/guis/pauseMenu.gui
+++ b/Templates/BaseGame/game/data/ui/guis/pauseMenu.gui
@@ -53,6 +53,7 @@
       new GuiGameListMenuCtrl(PauseMenuList) {
          debugRender = "0";
          callbackOnInputs = "1";
+         consumeKeyInputEvents = "1";
          position = "0 0";
          extent = "700 320";
          minExtent = "8 2";


### PR DESCRIPTION
Adds a flag to the guiGameListMenuCtrl to allow consuming of key input events. This allows for overriding other active keybinds that may be in play when a menu is active.