### PR TITLE
during preload, autoreplace direct file refs with assetIDs

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -68,6 +68,7 @@
 #include "renderInstance/renderOcclusionMgr.h"
 #include "core/stream/fileStream.h"
 #include "T3D/accumulationVolume.h"
+#include "console/persistenceManager.h"
 
 IMPLEMENT_CO_DATABLOCK_V1(ShapeBaseData);
 
@@ -359,6 +360,13 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
          }
       }
    }
+   PersistenceManager persistMgr;
+   bool unsavedShapeAsset = false;
+   if (shapeAssetId == StringTable->EmptyString())
+   {
+      unsavedShapeAsset = true;
+      persistMgr.setDirty(this);
+   }
 
    //Legacy catch
    if (shapeName != StringTable->EmptyString())
@@ -550,6 +558,9 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
    {
       Sim::findObject( cubeDescId, reflectorDesc );
    }
+
+   if (unsavedShapeAsset)
+      persistMgr.saveDirty();
 
    return !shapeError;
 }

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -362,7 +362,7 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
    }
    PersistenceManager persistMgr;
    bool unsavedShapeAsset = false;
-   if (shapeAssetId == StringTable->EmptyString())
+   if (server && shapeAssetId == StringTable->EmptyString())
    {
       unsavedShapeAsset = true;
       persistMgr.setDirty(this);


### PR DESCRIPTION
riffing off of updateMaterialsScript, during shapebasedata preload, spools up a PersistenceManager instance, if shapeAssetId is unset, sets the object dirty, and saves it off once processing is completed