### PR TITLE
Wraps material animation floats to sane values.

### DIFF
--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -593,8 +593,10 @@ void Material::updateTimeBasedParams()
       for (U32 i = 0; i < MAX_STAGES; i++)
       {
          mScrollOffset[i] += mScrollDir[i] * mScrollSpeed[i] * dt;
-         mRotPos[i] += mRotSpeed[i] * dt;
-         mWavePos[i] += mWaveFreq[i] * dt;
+         mScrollOffset[i].x = mWrapF(mScrollOffset[i].x, 0.0, 1.0);
+         mScrollOffset[i].y = mWrapF(mScrollOffset[i].y, 0.0, 1.0);
+         mRotPos[i] = mWrapF((mRotPos[i] + (mRotSpeed[i] * dt)), 0.0, 360.0);
+         mWavePos[i] = mWrapF((mWavePos[i] + (mWaveFreq[i] * dt)), 0.0, 1.0);
       }
       mLastUpdateTime = lastTime;
    }


### PR DESCRIPTION
Wraps material animation floats to sane values to prevent floating point drift.

Addresses #384 