### PR TITLE
Fixes for AA toggle and GFX Device reporting for options menu

### DIFF
--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -1364,6 +1364,17 @@ DefineEngineFunction( getDisplayDeviceInformation, const char*, (),,
    return adapter.getName();
 }
 
+DefineEngineFunction(getDisplayDeviceType, GFXAdapterType, (), ,
+   "Get the string describing the active GFX device type.\n"
+   "@ingroup GFX\n")
+{
+   if (!GFXDevice::devicePresent())
+      return NullDevice;
+
+   const GFXAdapter& adapter = GFX->getAdapter();
+   return adapter.mType;
+}
+
 DefineEngineFunction( getBestHDRFormat, GFXFormat, (),,
    "Returns the best texture format for storage of HDR data for the active device.\n"
    "@ingroup GFX\n" )

--- a/Templates/BaseGame/game/core/gui/scripts/canvas.cs
+++ b/Templates/BaseGame/game/core/gui/scripts/canvas.cs
@@ -37,7 +37,7 @@ function createCanvas(%windowTitle)
    // Set the window title
    if (isObject(Canvas)) 
    {
-      Canvas.setWindowTitle(%windowTitle @ " - " @ $pref::Video::displayDevice);
+      Canvas.setWindowTitle(%windowTitle @ " - " @ getDisplayDeviceType());
       configureCanvas();
    } 
    else 
@@ -107,7 +107,7 @@ function configureCanvas()
    %resY = $pref::Video::Resolution.y;
    %bpp  = $pref::Video::BitDepth;
    %rate = $pref::Video::RefreshRate;
-   %fsaa = $pref::Video::AA;
+   %aa = $pref::Video::AA;
    %fs = ($pref::Video::deviceMode == 2);
 
    echo("Accepted Mode: " NL
@@ -115,7 +115,7 @@ function configureCanvas()
       "--Screen Mode    : " @ %fsLabel NL
       "--Bits Per Pixel : " @ %bpp NL
       "--Refresh Rate   : " @ %rate NL
-      "--FSAA Level     : " @ %fsaa NL
+      "--FSAA Level     : " @ %aa NL
       "--------------");
 
    // Actually set the new video mode
@@ -132,8 +132,8 @@ function configureCanvas()
    // We need to parse the setting between AA modes, and then it's level
    // It's formatted as AATypexAALevel
    // So, FXAAx4 or MLAAx2
-   if ( isObject( FXAA_PostEffect ) )
-      FXAA_PostEffect.Enabled = ( %aa > 0 ) ? true : false;
+   if ( isObject( FXAAPostFX ) )
+      FXAAPostFX.Enabled = ( %aa > 0 ) ? true : false;
 }
 
 function GuiCanvas::modeStrToPrefs(%this, %modeStr)

--- a/Templates/BaseGame/game/data/ui/guis/optionsMenu.cs
+++ b/Templates/BaseGame/game/data/ui/guis/optionsMenu.cs
@@ -196,7 +196,32 @@ function OptionsMenu::populateDisplaySettingsList(%this)
    OptionName.setText("");
    OptionDescription.setText("");
    
-   OptionsMenuSettingsList.addOptionRow("Display API", "D3D11\tOpenGL", false, "", -1, -30, true, "The display API used for rendering.", $pref::Video::displayDevice);
+   //First, lets double-check the active device is accurate. Sometimes the default value in our prefs doesn't match the active one
+   %displayDevice = getDisplayDeviceType();
+   if($changingDisplayDevice !$= "")
+      %displayDevice = $changingDisplayDevice;
+      
+   %apiList = "";
+   %apiCount = GFXInit::getAdapterCount();
+   %apiIdx = 0;
+   for(%i=0; %i < %apiCount; %i++)
+   {
+      %api = GFXInit::getAdapterType(%i);
+      
+      if(%api !$= "NullDevice")
+      {
+         if(%apiIdx==0)
+            %apiList = %api;
+         else
+            %apiList = %apiList TAB %api;
+            
+         %apiIdx++;
+      }
+   }   
+   
+   trim(%apiList);
+   
+   OptionsMenuSettingsList.addOptionRow("Display API", %apiList, false, "", -1, -30, true, "The display API used for rendering.", %displayDevice);
    
    %numDevices = Canvas.getMonitorCount();
    %devicesList = "";
@@ -246,7 +271,7 @@ function OptionsMenu::populateDisplaySettingsList(%this)
 
 function OptionsMenu::applyDisplaySettings(%this)
 {
-	%newDevice     = OptionsMenuSettingsList.getCurrentOption(0);
+	%newDevice = OptionsMenuSettingsList.getCurrentOption(0);
 							
    // Change the device.
    if ( %newDevice !$= $pref::Video::displayDevice )
@@ -257,6 +282,8 @@ function OptionsMenu::applyDisplaySettings(%this)
       $pref::Video::displayDevice = %newDevice;
       if( %newAdapter !$= getDisplayDeviceInformation() )
          MessageBoxOK( "Change requires restart", "Please restart the game for a display device change to take effect." );
+         
+      $changingDisplayDevice = %newDevice;
    }
    
    updateDisplaySettings();


### PR DESCRIPTION
Adds function to better report active device type from GFXDevice
Ensures Window title and options menu correctly displays available and active render api
Fixes AA option so it correctly toggles FXAA