### PR TITLE
pad isFile search string buffer

### DIFF
--- a/Engine/source/platformWin32/winFileio.cpp
+++ b/Engine/source/platformWin32/winFileio.cpp
@@ -943,7 +943,7 @@ bool Platform::isFile(const char *pFilePath)
    if (!pFilePath || !*pFilePath)
       return false;
 
-   TempAlloc< TCHAR > buf( dStrlen( pFilePath ) + 1 );
+   TempAlloc< TCHAR > buf(dStrlen(getMainDotCsDir()) + dStrlen(pFilePath) + 1);
 
 #ifdef UNICODE
    convertUTF8toUTF16N( pFilePath, buf, buf.size );


### PR DESCRIPTION
we were hitting a few cases where the isfile comparison internal buffer was retrieving the raw file location when testing for the relative and going out of bounds. this ensures there's enough preallocated space