### PR TITLE
Fixes a few bugs/issues on Linux

### DIFF
--- a/Engine/source/cinterface/c_controlInterface.cpp
+++ b/Engine/source/cinterface/c_controlInterface.cpp
@@ -35,6 +35,9 @@ extern void createFontInit(void);
 extern void createFontShutdown(void);
 #endif
 
+#if defined(TORQUE_SDL)
+#include "SDL.h"
+#endif
 
 #if defined( TORQUE_MINIDUMP ) && defined( TORQUE_RELEASE )
 extern S32 CreateMiniDump(LPEXCEPTION_POINTERS ExceptionInfo);
@@ -227,7 +230,11 @@ extern "C" {
 
    const char* torque_getexecutablepath()
    {
+#if defined(TORQUE_SDL)
+      return gExecutablePath ? gExecutablePath : SDL_GetBasePath();
+#elif
       return gExecutablePath;
+#endif
    }
 
    void torque_setexecutablepath(const char* directory)

--- a/Engine/source/platformX86UNIX/x86UNIXFileio.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXFileio.cpp
@@ -332,7 +332,7 @@ bool dPathCopy(const char *fromName, const char *toName, bool nooverwrite)
  }
 
  //-----------------------------------------------------------------------------
- static bool RecurseDumpPath(const char *path, const char* relativePath, const char *pattern, Vector<Platform::FileInfo> &fileVector)
+ static bool RecurseDumpPath(const char *path, const char* relativePath, const char *pattern, Vector<Platform::FileInfo> &fileVector, S32 currentDepth = 0, S32 recurseDepth = -1)
  {
     char search[1024];
 
@@ -382,7 +382,8 @@ bool dPathCopy(const char *fromName, const char *toName, bool nooverwrite)
                 relativePath, fEntry->d_name);
              childRelative = childRelativeBuf;
           }
-          RecurseDumpPath(child, childRelative, pattern, fileVector);
+          if (currentDepth < recurseDepth || recurseDepth == -1 )
+            RecurseDumpPath(child, childRelative, pattern, fileVector, currentDepth+1, recurseDepth);
        }
        else
        {
@@ -908,7 +909,7 @@ bool dPathCopy(const char *fromName, const char *toName, bool nooverwrite)
     {
        char prefPathName[MaxPath];
        MungePath(prefPathName, MaxPath, path, GetPrefDir());
-       RecurseDumpPath(prefPathName, path, pattern, fileVector);
+       RecurseDumpPath(prefPathName, path, pattern, fileVector, 0, depth);
     }
 
     // munge the requested path and dump it
@@ -916,7 +917,7 @@ bool dPathCopy(const char *fromName, const char *toName, bool nooverwrite)
     char cwd[MaxPath];
     getcwd(cwd, MaxPath);
     MungePath(mungedPath, MaxPath, path, cwd);
-    return RecurseDumpPath(mungedPath, path, pattern, fileVector);
+    return RecurseDumpPath(mungedPath, path, pattern, fileVector, 0, depth);
  }
 
  //-----------------------------------------------------------------------------


### PR DESCRIPTION
Corrects recursive path dump so it can actually recurse correctly on linux. This fixes module/asset scan lookups

Also added logic to more correctly get the base path of executable, making it easier for certain debuggers, like on linux, to find the main.cs.