### PR TITLE
add validation flagging for server objects

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -68,6 +68,7 @@
 #include "renderInstance/renderOcclusionMgr.h"
 #include "core/stream/fileStream.h"
 #include "T3D/accumulationVolume.h"
+#include "console/persistenceManager.h"
 
 IMPLEMENT_CO_DATABLOCK_V1(ShapeBaseData);
 
@@ -358,6 +359,12 @@ bool ShapeBaseData::preload(bool server, String &errorStr)
             delete pDummy;
          }
       }
+   }
+   PersistenceManager *persistMgr;
+   if (!Sim::findObject("ServerAssetValidator", persistMgr)) Con::errorf("ServerAssetValidator not found!");
+   if (server && persistMgr && shapeAssetId == StringTable->EmptyString())
+   {
+      persistMgr->setDirty(this);
    }
 
    //Legacy catch

--- a/Templates/BaseGame/game/core/clientServer/scripts/server/server.cs
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/server.cs
@@ -185,6 +185,7 @@ function createServer(%serverType, %levelAsset)
 
 function onServerCreated()
 {
+   new PersistenceManager( ServerAssetValidator );
    // Server::GameType is sent to the master server.
    // This variable should uniquely identify your game and/or mod.
    $Server::GameType = $appName;
@@ -208,6 +209,7 @@ function onServerCreated()
    
    // Keep track of when the game started
    $Game::StartTime = $Sim::Time;
+   ServerAssetValidator.saveDirty();
 }
 
 /// Shut down the server


### PR DESCRIPTION
sets up a generic `ServerAssetValidator` PersistenceManager onServerCreated and saves anything marked dirty after processing. demonstrates looking that up and setting something dirty via shapebase::preload asset tagging