### PR TITLE
Fix ORM maps in terrain textures

### DIFF
--- a/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
+++ b/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
@@ -1260,7 +1260,7 @@ void TerrainORMMapFeatGLSL::processPix(Vector<ShaderComponent*> &componentList,
 
 	// search for material var
 	Var * ormConfig;
-	OutputTarget targ = RenderTarget1;
+	OutputTarget targ = DefaultTarget;
 	if (fd.features[MFT_isDeferred])
 	{
 		targ = RenderTarget2;
@@ -1283,22 +1283,19 @@ void TerrainORMMapFeatGLSL::processPix(Vector<ShaderComponent*> &componentList,
 	String matinfoName(String::ToString("matinfoCol%d", compositeIndex));
 	Var *matinfoCol = new Var(matinfoName, "vec3");
 
-	Var *priorComp = (Var*)LangElement::find(String::ToString("matinfoCol%d", compositeIndex - 1));
-	if (priorComp)
-	{
-		meta->addStatement(new GenOp("   @ = @.rgb*@;\r\n", new DecOp(matinfoCol), texOp, detailBlend));
-		meta->addStatement(new GenOp("   @.gba += @;\r\n", ormConfig, matinfoCol));
-	}
-	else
-	{
-		meta->addStatement(new GenOp("   @ = lerp(vec3(1.0,1.0,0.0),@.rgb,@);\r\n", new DecOp(matinfoCol), texOp, detailBlend));
-		meta->addStatement(new GenOp("   @ = vec4(0.0,@);\r\n", ormConfig, matinfoCol));
-	}
-
-   if (fd.features[MFT_InvertRoughness])
+   if (compositeIndex == 0)
    {
-      meta->addStatement(new GenOp("   @.b = 1.0-@.b;\r\n", ormConfig, ormConfig));
+      meta->addStatement(new GenOp("   @ = vec4(0.0, 0.0, 0.0, 0.0);\r\n", ormConfig));
    }
+
+   meta->addStatement(new GenOp("   @ = @.rgb;\r\n", new DecOp(matinfoCol), texOp));
+
+   if (fd.features.hasFeature(MFT_InvertRoughness, compositeIndex))
+   {
+      meta->addStatement(new GenOp("   @.b = 1.0 - @.b;\r\n", matinfoCol, matinfoCol));
+   }
+
+   meta->addStatement(new GenOp("   @.gba += @ * @;\r\n", ormConfig, matinfoCol, detailBlend));
 
 	output = meta;
 }
@@ -1321,9 +1318,11 @@ U32 TerrainBlankInfoMapFeatGLSL::getOutputTargets(const MaterialFeatureData &fd)
 void TerrainBlankInfoMapFeatGLSL::processPix(Vector<ShaderComponent*> &componentList,
    const MaterialFeatureData &fd)
 {
+   S32 compositeIndex = getProcessIndex();
+
    // search for material var
    Var *material;
-   OutputTarget targ = RenderTarget1;
+   OutputTarget targ = DefaultTarget;
    if (fd.features[MFT_isDeferred])
    {
       targ = RenderTarget2;
@@ -1340,7 +1339,17 @@ void TerrainBlankInfoMapFeatGLSL::processPix(Vector<ShaderComponent*> &component
       material->setStructName("OUT");
    }
 
-   meta->addStatement(new GenOp("   @ = vec4(0.0,1.0,1.0,0.0);\r\n", material));
+   if (compositeIndex == 0)
+   {
+      meta->addStatement(new GenOp("   @ = vec4(0.0, 0.0, 0.0, 0.0);\r\n", material));
+   }
+
+   Var* detailBlend = (Var*)LangElement::find(String::ToString("detailBlend%d", compositeIndex));
+   AssertFatal(detailBlend, "The detail blend is missing!");
+
+   String matinfoName(String::ToString("matinfoCol%d", compositeIndex));
+
+   meta->addStatement(new GenOp("   @.gba += vec3(@, @, 0.0);\r\n", material, detailBlend, detailBlend));
 
    output = meta;
 }

--- a/Engine/source/terrain/terrCellMaterial.cpp
+++ b/Engine/source/terrain/terrCellMaterial.cpp
@@ -390,7 +390,6 @@ bool TerrainCellMaterial::_createPass( Vector<MaterialInfo*> *materials,
          // if HDR is not enabled in the engine.
          features.addFeature( MFT_HDROut );
       }
-      features.addFeature(MFT_DeferredTerrainBlankInfoMap);
 
       // Enable lightmaps and fogging if we're in BL.
       if ( reflectMat || useBLM )
@@ -444,10 +443,13 @@ bool TerrainCellMaterial::_createPass( Vector<MaterialInfo*> *materials,
             if (deferredMat)
                features.addFeature(MFT_isDeferred, featureIndex);
             features.addFeature(MFT_TerrainORMMap, featureIndex);
-            features.removeFeature(MFT_DeferredTerrainBlankInfoMap);
+         }
+         else
+         {
+            features.addFeature(MFT_DeferredTerrainBlankInfoMap, featureIndex);
          }
          if (mat->getInvertRoughness())
-            features.addFeature(MFT_InvertRoughness);
+            features.addFeature(MFT_InvertRoughness, featureIndex);
 
          pass->materials.push_back( (*materials)[i] );
          normalMaps.increment();


### PR DESCRIPTION
This fixes some bad maths in terrain texture's ORM map.

Worth noting that edges between textures still seem pretty pronounced, but these fixes at least makes it somewhat passable.

![image](https://user-images.githubusercontent.com/2369614/103153060-eaca0100-478d-11eb-9c35-7e256c2e1690.png)


Fixes #422 