### PR TITLE
Consolidates and standardizes terrain creation between the editor, asset browser and creator panel

### DIFF
--- a/Engine/source/terrain/terrImport.cpp
+++ b/Engine/source/terrain/terrImport.cpp
@@ -117,7 +117,7 @@ DefineEngineStaticMethod( TerrainBlock, createNew, S32, (String terrainName, U32
    return terrain->getId();
 }
 
-DefineEngineStaticMethod( TerrainBlock, import, S32, (String terrainName, String heightMapFile, F32 metersPerPixel, F32 heightScale, String opacityLayerFiles, String materialsStr, bool flipYAxis), (true),
+DefineEngineStaticMethod( TerrainBlock, import, S32, (S32 terrainObjectId, String heightMapFile, F32 metersPerPixel, F32 heightScale, String opacityLayerFiles, String materialsStr, bool flipYAxis), (true),
    "" )
 {
    // First load the height map and validate it.
@@ -237,13 +237,12 @@ DefineEngineStaticMethod( TerrainBlock, import, S32, (String terrainName, String
    }
 
    // Do we have an existing terrain with that name... then update it!
-   TerrainBlock *terrain = dynamic_cast<TerrainBlock*>( Sim::findObject( terrainName.c_str() ) );
+   TerrainBlock *terrain = dynamic_cast<TerrainBlock*>( Sim::findObject( terrainObjectId ) );
    if ( terrain )
       terrain->import( (*heightmap), heightScale, metersPerPixel, layerMap, materials, flipYAxis );
    else
    {
       terrain = new TerrainBlock();
-      terrain->assignName( terrainName );
       terrain->import( (*heightmap), heightScale, metersPerPixel, layerMap, materials, flipYAxis );
       terrain->registerObject();
 

--- a/Templates/BaseGame/game/core/clientServer/scripts/client/client.cs
+++ b/Templates/BaseGame/game/core/clientServer/scripts/client/client.cs
@@ -22,8 +22,6 @@ function initClient()
       
    callOnModules("initClient");
 
-   loadMaterials();
-
    // Copy saved script prefs into C++ code.
    setDefaultFov( $pref::Player::defaultFov );
    setZoomSpeed( $pref::Player::zoomSpeed );

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.cs
@@ -1121,14 +1121,22 @@ function AssetBrowserPreviewButton::onRightClick(%this)
    }
    
    if(%assetType $= "LevelAsset")
+   {
       EditLevelAssetPopup.showPopup(Canvas);  
+   }
    else if(%assetType $= "Folder")
    {
       EditFolderPopup.dirPath = %this.moduleName @ "/" @ %this.assetName;
       EditFolderPopup.showPopup(Canvas);  
    }
+   else if(%assetType $= "TerrainAsset")
+   {
+      EditTerrainAssetPopup.showPopup(Canvas); 
+   }
    else
+   {
       EditAssetPopup.showPopup(Canvas);  
+   }
       
    if(%assetType $= "Folder")
    {

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/popupMenus.cs
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/popupMenus.cs
@@ -64,6 +64,27 @@ function AssetBrowser::buildPopupMenus(%this)
       };
    }
    
+   if( !isObject( EditTerrainAssetPopup ) )
+   {
+      new PopupMenu( EditTerrainAssetPopup )
+      {
+         superClass = "MenuBuilder";
+         class = "EditorWorldMenu";
+         //isPopup = true;
+
+         item[ 0 ] = "Export Terraform Data" TAB "" TAB "Heightfield::saveBitmap(\"\");";
+         item[ 1 ] = "Rename Asset" TAB "" TAB "AssetBrowser.renameAsset();";
+         item[ 2 ] = "Asset Properties" TAB "" TAB "AssetBrowser.editAssetInfo();";
+         item[ 3 ] = "-";
+         Item[ 4 ] = "Duplicate Asset" TAB "" TAB "AssetBrowser.duplicateAsset();";
+         item[ 5 ] = "-";
+         item[ 6 ] = "Delete Asset" TAB "" TAB "AssetBrowser.deleteAsset();";
+
+         jumpFileName = "";
+         jumpLineNumber = "";
+      };
+   }
+
    if( !isObject( AddNewComponentAssetPopup ) )
    {
       new PopupMenu( AddNewComponentAssetPopup )

--- a/Templates/BaseGame/game/tools/gui/profiles.ed.cs
+++ b/Templates/BaseGame/game/tools/gui/profiles.ed.cs
@@ -479,7 +479,7 @@ new GuiControlProfile( ToolsGuiScrollProfile )
 if( !isObject( ToolsGuiOverlayProfile ) )
 new GuiControlProfile( ToolsGuiOverlayProfile )
 {
-   opaque = true;
+   opaque = false;
    fillColor = EditorSettings.value("Theme/windowBackgroundColor");
    fontColor = EditorSettings.value("Theme/fieldTextColor");
    fontColorHL = EditorSettings.value("Theme/fieldTextGLColor");

--- a/Templates/BaseGame/game/tools/worldEditor/gui/guiTerrainImportGui.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/guiTerrainImportGui.gui
@@ -328,10 +328,10 @@
          canSave = "1";
          isDecoy = "0";
          Visible = "1";
-         Command = "TerrainImportGui.import();";
+         Command = "TerrainImportGui.acceptSettings();";
          tooltipprofile = "ToolsGuiToolTipProfile";
          hovertime = "1000";
-         text = "Import";
+         text = "Accept";
          groupNum = "-1";
          buttonType = "PushButton";
          useMouseEvents = "0";
@@ -414,60 +414,6 @@
          text = "Channels";
          maxLength = "1024";
       };
-      new GuiTextCtrl() {
-         canSaveDynamicFields = "0";
-         Enabled = "1";
-         isContainer = "0";
-         Profile = "ToolsGuiTextProfile";
-         HorizSizing = "right";
-         VertSizing = "bottom";
-         Position = "11 26";
-         Extent = "64 18";
-         MinExtent = "8 2";
-         canSave = "1";
-         isDecoy = "0";
-         Visible = "1";
-         tooltipprofile = "ToolsGuiToolTipProfile";
-         hovertime = "1000";
-         Margin = "0 0 0 0";
-         Padding = "0 0 0 0";
-         AnchorTop = "1";
-         AnchorBottom = "0";
-         AnchorLeft = "1";
-         AnchorRight = "0";
-         text = "Name:";
-         maxLength = "1024";
-      };
-      new GuiTextEditCtrl() {
-         canSaveDynamicFields = "0";
-         internalName = "TerrainName";
-         Enabled = "1";
-         isContainer = "0";
-         Profile = "ToolsGuiTextEditProfile";
-         HorizSizing = "width";
-         VertSizing = "bottom";
-         Position = "10 44";
-         Extent = "206 18";
-         MinExtent = "8 2";
-         canSave = "1";
-         isDecoy = "0";
-         Visible = "1";
-         tooltipprofile = "ToolsGuiToolTipProfile";
-         hovertime = "1000";
-         Margin = "0 0 0 0";
-         Padding = "0 0 0 0";
-         AnchorTop = "1";
-         AnchorBottom = "0";
-         AnchorLeft = "1";
-         AnchorRight = "0";
-         text = "theTerrain";
-         maxLength = "1024";
-         historySize = "0";
-         password = "0";
-         tabComplete = "0";
-         sinkAllKeyEvents = "0";
-         passwordMask = "*";
-      };
       new GuiButtonCtrl() {
          canSaveDynamicFields = "0";
          Enabled = "1";
@@ -502,7 +448,7 @@
          canSave = "1";
          isDecoy = "0";
          Visible = "1";
-         Command = "Canvas.popDialog( TerrainImportGui );";
+         Command = "TerrainImportGui.cancel();";
          tooltipprofile = "ToolsGuiToolTipProfile";
          hovertime = "1000";
          text = "Cancel";
@@ -544,28 +490,23 @@ function TerrainImportGui::onWake( %this )
       %this.channelsArray = new ArrayObject();
 }
 
-function TerrainImportGui::import( %this )
+function TerrainImportGui::acceptSettings( %this )
 {
    // Gather all the import settings.
-   
-   %heightMapPng = %this-->HeightfieldFilename.getText();
+   AssetBrowser.newAssetSettings.importingTerrain = true;
+   AssetBrowser.newAssetSettings.heightMapPng = %this-->HeightfieldFilename.getText();
      
-   %metersPerPixel = %this-->MetersPerPixel.getText();
-   %heightScale = %this-->HeightScale.getText();
+   AssetBrowser.newAssetSettings.metersPerPixel = %this-->MetersPerPixel.getText();
+   AssetBrowser.newAssetSettings.heightScale = %this-->HeightScale.getText();
    
-   %flipYAxis = %this-->FlipYAxis.isStateOn();
+   AssetBrowser.newAssetSettings.flipYAxis = %this-->FlipYAxis.isStateOn();
    
    // Grab and validate terrain object name.
    
-   %terrainName = %this-->TerrainName.getText();
-   if( !( isObject( %terrainName ) && %terrainName.isMemberOfClass( "TerrainBlock" ) ) &&
-       !Editor::validateObjectName( %terrainName ) )
-      return;
+   AssetBrowser.newAssetSettings.opacityNames = "";
+   AssetBrowser.newAssetSettings.materialNames = "";
    
-   %opacityNames = "";
-   %materialNames = "";
-   
-   %opacityList = %this-->OpacityLayerTextList;
+   AssetBrowser.newAssetSettings.opacityList = %this-->OpacityLayerTextList;
    
    for( %i = 0; %i < %opacityList.rowCount(); %i++ )
    {
@@ -577,53 +518,19 @@ function TerrainImportGui::import( %this )
       
       %materialName = getField( %itemText, 2 );
 
-      %opacityNames = %opacityNames @ %opacityName TAB %channel @ "\n";
-      %materialNames = %materialNames @ %materialName @ "\n";
+      AssetBrowser.newAssetSettings.opacityNames = AssetBrowser.newAssetSettings.opacityNames @ %opacityName TAB %channel @ "\n";
+      AssetBrowser.newAssetSettings.materialNames = AssetBrowser.newAssetSettings.materialNames @ %materialName @ "\n";
    }
 
-   %updated = nameToID( %terrainName );
-
-   // This will update an existing terrain with the name %terrainName,
-   // or create a new one if %terrainName isn't a TerrainBlock
-   %obj = TerrainBlock::import(   %terrainName, 
-                                  %heightMapPng, 
-                                  %metersPerPixel, 
-                                  %heightScale, 
-                                  %opacityNames, 
-                                  %materialNames,
-                                  %flipYAxis );
-
+   //AssetBrowser.newAssetSettings.updated = nameToID( %terrainName );
+   
    Canvas.popDialog( %this );
+}
 
-   if ( isObject( %obj ) )
-   {
-      if( %obj != %updated )
-      {
-         // created a new TerrainBlock
-         // Submit an undo action. 
-         MECreateUndoAction::submit(%obj);
-      }
-
-      assert( isObject( EWorldEditor ), 
-         "ObjectBuilderGui::processNewObject - EWorldEditor is missing!" );
-
-      // Select it in the editor.
-      EWorldEditor.clearSelection();
-      EWorldEditor.selectObject(%obj);
-
-      // When we drop the selection don't store undo
-      // state for it... the creation deals with it.
-      EWorldEditor.dropSelection( true );
-
-      ETerrainEditor.isDirty = true;
-      EPainter.updateLayers();
-   }
-   else
-   {
-      toolsMessageBox( "Import Terrain", 
-         "Terrain import failed! Check console for error messages.", 
-         "Ok", "Error" );
-   }
+function TerrainImportGui::cancel( %this )
+{
+   AssetBrowser.newAssetSettings.importingTerrain = false;
+   Canvas.popDialog( TerrainImportGui );
 }
 
 function TerrainImportGui::doOpenDialog( %this, %filter, %callback )

--- a/Templates/BaseGame/game/tools/worldEditor/gui/objectBuilderGui.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/objectBuilderGui.ed.gui
@@ -900,14 +900,16 @@ function ObjectBuilderGui::buildWaterPlane(%this)
 
 function ObjectBuilderGui::buildTerrainBlock(%this)
 {
-   %this.objectClassName = "TerrainBlock";
+   /*%this.objectClassName = "TerrainBlock";
    %this.createCallback = "ETerrainEditor.attachTerrain();";
 
    %this.addField("terrainFile", "TypeFile", "Terrain file", "", "*.ter");
    %this.addField("terrainAsset", "TypeTerrainAsset", "Terrain Asset", "", "");
    %this.addField("squareSize", "TypeInt", "Square size", "8");
 
-   %this.process();
+   %this.process();*/
+   
+   AssetBrowser.setupCreateNewAsset("TerrainAsset", AssetBrowser.selectedModule);
 }
 
 function ObjectBuilderGui::buildGroundCover( %this )


### PR DESCRIPTION
Also shifts terrain data importing into the new terrain asset window instead of separate in the File menu
Also removes redundant loadMaterials call that caused duplicates in the Terrain Painter material list