### PR TITLE
mac fixes

### DIFF
--- a/Engine/source/T3D/assets/MaterialAsset.h
+++ b/Engine/source/T3D/assets/MaterialAsset.h
@@ -198,7 +198,7 @@ static bool _set##name##Asset(void* obj, const char* index, const char* data)\
    if (stream->writeFlag(m##name##Asset.notNull()))\
    {\
       NetStringHandle assetIdStr = m##name##Asset.getAssetId();\
-      ##netconn##->packNetStringHandleU(stream, assetIdStr);\
+      netconn->packNetStringHandleU(stream, assetIdStr);\
    }\
    else\
       stream->writeString(m##name##Name);
@@ -206,7 +206,7 @@ static bool _set##name##Asset(void* obj, const char* index, const char* data)\
 #define unpackMaterialAsset(netconn, name)\
    if (stream->readFlag())\
    {\
-      m##name##AssetId = StringTable->insert(##netconn##->unpackNetStringHandleU(stream).getString());\
+      m##name##AssetId = StringTable->insert(netconn->unpackNetStringHandleU(stream).getString());\
       MaterialAsset::getAssetById(m##name##AssetId, &m##name##Asset);\
    }\
    else\

--- a/Engine/source/T3D/assets/ShapeAsset.h
+++ b/Engine/source/T3D/assets/ShapeAsset.h
@@ -269,14 +269,14 @@ static bool _set##name##Asset(void* obj, const char* index, const char* data)\
    }\
    return false;\
 }\
-void className::pack##name##Asset(BitStream *stream)\
+void pack##name##Asset(BitStream *stream)\
 {\
    if (stream->writeFlag(m##name##Asset.notNull()))\
       stream->writeString(m##name##Asset.getAssetId());\
    else\
       stream->writeString(m##name##Name);\
 }\
-void className::unpack##name##Asset(BitStream *stream)\
+void unpack##name##Asset(BitStream *stream)\
 {\
    if (stream->readFlag())\
    {\

--- a/Tools/CMake/Info.plist.in
+++ b/Tools/CMake/Info.plist.in
@@ -16,5 +16,7 @@
 	<string>APPL</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+    <key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>
+    <string>parent</string>
 </dict>
 </plist>


### PR DESCRIPTION
1) add sdl token for referencing the parent directory of the aplication bundle when determining the root dir
2) shape and mateiral asset macro corrections for a few stray ## redundencies (space, ->, . ect are all conidered token sperators in and of themselves)