### PR TITLE
sdl usage standards proposal 3

### DIFF
--- a/Engine/source/platformMac/macPlatform.mm
+++ b/Engine/source/platformMac/macPlatform.mm
@@ -132,6 +132,7 @@ void Platform::outputDebugString( const char *string, ... )
    fflush(stderr);
 #endif
 }
+#ifndef TORQUE_SDL
 //-----------------------------------------------------------------------------
 bool Platform::openWebBrowser( const char* webAddress )
 {
@@ -142,7 +143,7 @@ bool Platform::openWebBrowser( const char* webAddress )
    
    return(err==noErr);
 }
-
+#endif
 #pragma mark ---- Administrator ----
 //-----------------------------------------------------------------------------
 bool Platform::getUserIsAdministrator()

--- a/Engine/source/platformSDL/sdlPlatform.cpp
+++ b/Engine/source/platformSDL/sdlPlatform.cpp
@@ -1,0 +1,30 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2012 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+#include "platform/platform.h"
+/// Spawn the User default web browser with a URL
+/// @param webAddress URL to pass to browser
+/// @return true if browser successfully spawned
+bool Platform::openWebBrowser(const char* webAddress)
+{
+   return !SDL_OpenURL(webAddress);
+}

--- a/Engine/source/platformWin32/winWindow.cpp
+++ b/Engine/source/platformWin32/winWindow.cpp
@@ -511,6 +511,7 @@ F32 Platform::getRandom()
    return sgPlatRandom.randF();
 }
 
+#ifndef TORQUE_SDL
 ////--------------------------------------
 /// Spawn the default Operating System web browser with a URL
 /// @param webAddress URL to pass to browser
@@ -585,6 +586,7 @@ bool Platform::openWebBrowser( const char* webAddress )
 
    return( true );
 }
+#endif
 
 //--------------------------------------
 // Login password routines:

--- a/Engine/source/platformX86UNIX/x86UNIXPlatform.cpp
+++ b/Engine/source/platformX86UNIX/x86UNIXPlatform.cpp
@@ -1,5 +1,5 @@
 #include "platform/platform.h"
-
+#ifndef TORQUE_SDL
 bool Platform::openWebBrowser(const char* webAddress)
 {
    String startingURL(webAddress);
@@ -23,7 +23,7 @@ bool Platform::openWebBrowser(const char* webAddress)
 
    return false;
 }
-
+#endif
 #ifdef TORQUE_DEDICATED
 // XA: New class for the unix unicode font
 class PlatformFont;

--- a/Tools/CMake/torqueConfig.h.in
+++ b/Tools/CMake/torqueConfig.h.in
@@ -197,3 +197,8 @@
 #else
 #  define TORQUE_INSTANCE_EXCLUSION   "TorqueTest"
 #endif
+
+//use sdl backend?
+#if defined(TORQUE_SDL)
+#include <SDL.h>
+#endif


### PR DESCRIPTION
again maintains fallbacks for folks that just don't want to use the lib (though if we do want to go that route, we'll likely want to re-review a few commits and put fallbacks, well, *back* at some point)
includes sdl in torqueconfig.h if in use to kill duplication.
adds a generic sdlPlatform.cpp for general methods, oneliners, and the like