### PR TITLE
moar asset errorhandling

### DIFF
--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -274,7 +274,7 @@ bool ShapeAsset::loadShape()
 
    if (!mShape)
    {
-      Con::errorf("ShapeAsset::loadShape : failed to load shape file!");
+      Con::errorf("ShapeAsset::loadShape : failed to load shape file %s!", mFilePath);
       mLoadedState = BadFileReference;
       return false; //if it failed to load, bail out
    }
@@ -437,12 +437,16 @@ U32 ShapeAsset::getAssetById(StringTableEntry assetId, AssetPtr<ShapeAsset>* sha
    if ((*shapeAsset))
       return (*shapeAsset)->mLoadedState;
 
-   //Didn't work, so have us fall back to a placeholder asset
-   StringTableEntry noShapeId = StringTable->insert("Core_Rendering:noshape");
-   shapeAsset->setAssetId(noShapeId);
-
    if (shapeAsset->notNull())
    {
+      //Didn't work, so have us fall back to a placeholder asset
+      StringTableEntry noShapeId = StringTable->insert("Core_Rendering:noshape");
+      shapeAsset->setAssetId(noShapeId);
+
+      //handle noshape not being loaded itself
+      if ((*shapeAsset)->mLoadedState == BadFileReference)
+         return AssetErrCode::Failed;
+
       (*shapeAsset)->mLoadedState = AssetErrCode::UsingFallback;
       return AssetErrCode::UsingFallback;
    }

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -274,7 +274,7 @@ bool ShapeAsset::loadShape()
 
    if (!mShape)
    {
-      Con::errorf("ShapeAsset::loadShape : failed to load shape file %s!", mFilePath);
+      Con::errorf("ShapeAsset::loadShape : failed to load shape file %s (%s)!", getAssetName(), mFilePath);
       mLoadedState = BadFileReference;
       return false; //if it failed to load, bail out
    }


### PR DESCRIPTION
report shape file location that failed to load, set loaded status to badfilereference if getAssetById can't even find noshape
(also fixes a subtle crash bug)