### PR TITLE
Fix for transparency in splash images

### DIFF
--- a/Engine/source/windowManager/sdl/sdlSplashScreen.cpp
+++ b/Engine/source/windowManager/sdl/sdlSplashScreen.cpp
@@ -81,13 +81,30 @@ bool Platform::displaySplashWindow( String path )
       }
 
       gSplashImage = SDL_CreateRGBSurfaceFrom(img->getAddress(0, 0), img->getWidth(), img->getHeight(), depth, pitch, rmask, gmask, bmask, amask);
+      gSplashImage = SDL_ConvertSurfaceFormat(gSplashImage, SDL_PIXELFORMAT_RGBA8888, NULL);
    }
 
    //now the pop-up window
    if (gSplashImage)
    {
-      gSplashWindow = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-         gSplashImage->w, gSplashImage->h, SDL_WINDOW_BORDERLESS | SDL_WINDOW_SHOWN);
+      gSplashWindow = SDL_CreateShapedWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+         gSplashImage->w, gSplashImage->h, SDL_WINDOW_BORDERLESS);
+
+      SDL_WindowShapeMode mode;
+      SDL_Color black = { 0,0,0,0xff };
+      SDL_PixelFormat* format = gSplashImage->format;
+      if (SDL_ISPIXELFORMAT_ALPHA(format->format))
+      {
+         mode.mode = ShapeModeBinarizeAlpha;
+         mode.parameters.binarizationCutoff = 255;
+      }
+      else
+      {
+         mode.mode = ShapeModeColorKey;
+         mode.parameters.colorKey = black;
+      }
+
+      SDL_SetWindowShape(gSplashWindow, gSplashImage, &mode);
 
       gSplashRenderer = SDL_CreateRenderer(gSplashWindow, -1, SDL_RENDERER_ACCELERATED);
 


### PR DESCRIPTION
This comes from a conversation back in October 2020 source from this section of the discord#coding channel https://discord.com/channels/358091480004558848/416629987936829451/765339207878836224 

This is the simplified version that just works automagically based on the image, there was more work done using variables and such from marauder2k9 here https://discord.com/channels/358091480004558848/416629987936829451/765345319478624306 that I just thought was a little too much extra for what i personally think should be just a simple "it works". 

**This has NOT been tested AFAIK on Mac or Linux** *I also don't know if it has to be or not, idk how much voodoo sdl does