### PR TITLE
Fixes the constructor path compare logic in the shape editor so the lists can populate correctly.

### DIFF
--- a/Templates/BaseGame/game/tools/shapeEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/shapeEditor/main.tscript
@@ -148,7 +148,7 @@ function ShapeEditorPlugin::onWorldEditorStartup(%this)
 function ShapeEditorPlugin::openShapeAsset(%this, %assetDef)
 {
    %this.selectedAssetDef = %assetDef;
-   %this.open(%this.selectedAssetDef.getShapeFile());
+   %this.open(makeRelativePath(%this.selectedAssetDef.getShapeFile()));
 }
 
 function ShapeEditorPlugin::openShapeAssetId(%this, %assetId)


### PR DESCRIPTION
Testing steps
Open shape in shape editor and confirm that material, node, etc lists populate correctly