### PR TITLE
Makes the DB creation process better jive with modules

### DIFF
--- a/Templates/BaseGame/game/tools/datablockEditor/DatablockEditorTreeWindow.ed.gui
+++ b/Templates/BaseGame/game/tools/datablockEditor/DatablockEditorTreeWindow.ed.gui
@@ -299,7 +299,7 @@
          MinExtent = "8 2";
          canSave = "1";
          Visible = "0";
-         Command = "DatablockEditorPlugin.createDatablock();";
+         Command = "DatablockEditorPlugin.pickDatablockPath();";
          tooltipprofile = "ToolsGuiToolTipProfile";
          tooltip = "Create New Datablock";
          hovertime = "1000";

--- a/Templates/BaseGame/game/tools/datablockEditor/datablockEditor.tscript
+++ b/Templates/BaseGame/game/tools/datablockEditor/datablockEditor.tscript
@@ -674,8 +674,19 @@ function DatablockEditorPlugin::createDatablock(%this)
 }
 
 //---------------------------------------------------------------------------------------------
+function DatablockEditorPlugin::pickDatablockPath(%this)
+{
+   SelectAssetPath.showDialog(AssetBrowser.dirHandler.currentAddress, "DatablockEditorPlugin.pickedNewDBPath", "Select New Datablock Path");
+   SelectAssetPathWindow.selectWindow();   
+}
 
-function DatablockEditorPlugin::createPromptNameCheck(%this)
+function DatablockEditorPlugin::pickedNewDBPath(%this, %path)
+{
+   $DATABLOCK_EDITOR_DEFAULT_FILENAME = %path @ "/managedDatablocks." @ $TorqueScriptFileExtension;
+   DatablockEditorPlugin.createDatablock();
+}
+
+function DatablockEditorPlugin::createPromptNameCheck(%this, %path)
 {
    %name = DatablockEditorCreatePrompt-->CreateDatablockName.getText();
    if( !Editor::validateObjectName( %name, true ) )


### PR DESCRIPTION
Makes the DB creation process better jive with modules by having you select the destination folder for the managed datablock script file to be saved off into

Test case:
Create new datablock and ensure can correctly select destination path