### PR TITLE
Misc. minor AB fixes

### DIFF
--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -2877,11 +2877,12 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
    StringTableEntry assetName = StringTable->insert(assetItem->assetName.c_str());
 
    String shapeFileName = assetItem->filePath.getFileName() + "." + assetItem->filePath.getExtension();
+   String constructorFileName = assetItem->filePath.getFileName() + "." TORQUE_SCRIPT_EXTENSION;
    String assetPath = targetPath + "/" + shapeFileName;
-   String constructorPath = targetPath + "/" + assetItem->filePath.getFileName() + "." TORQUE_SCRIPT_EXTENSION;
+   String constructorPath = targetPath + "/" + constructorFileName;
    String tamlPath = targetPath + "/" + assetName + ".asset.taml";
    String originalPath = assetItem->filePath.getFullPath().c_str();
-   String originalConstructorPath = assetItem->filePath.getPath() + "/" + assetItem->filePath.getFileName() + "." TORQUE_SCRIPT_EXTENSION;
+   String originalConstructorPath = assetItem->filePath.getPath() + "/" + constructorFileName;
 
    char qualifiedFromFile[2048];
    char qualifiedToFile[2048];
@@ -2896,6 +2897,7 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
 
    newAsset->setAssetName(assetName);
    newAsset->setShapeFile(shapeFileName.c_str());
+   newAsset->setShapeConstructorFile(constructorFileName.c_str());
 
    AssetImportConfig* cachedConfig = new AssetImportConfig();;
    cachedConfig->registerObject();

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -256,7 +256,7 @@ function AssetBrowser::selectAsset( %this, %asset )
       %this.changeAsset();
    }
    
-   EWInspectorWindow.refresh();
+   Inspector.refresh();
    
    AssetBrowser.hideDialog();
 }
@@ -270,6 +270,7 @@ function AssetBrowser::showDialog( %this, %AssetTypeFilter, %selectCallback, %ta
    AssetBrowser.fieldTargetObject = %targetObj;
    AssetBrowser.fieldTargetName = %fieldName;
 
+   Canvas.popDialog(AssetBrowser);
    Canvas.pushDialog(AssetBrowser);
    AssetBrowser.setVisible(1);
    AssetBrowserWindow.setVisible(1);
@@ -1701,6 +1702,30 @@ function AssetBrowser::doRebuildAssetArray(%this)
       %tscriptPattern = %breadcrumbPath @ "/" @ "*.tscript";
       for (%fullScriptPath = findFirstFile(%tscriptPattern); %fullScriptPath !$= ""; %fullScriptPath = findNextFile(%tscriptPattern))
       {
+         //If it's associated to an asset, we'll want to do extra checks
+         %assetQuery = new AssetQuery();
+         %foundAssets = AssetDatabase.findAssetLooseFile(%assetQuery, %fullScriptPath);
+         
+         if(%foundAssets != 0)
+         {
+            %doSkip = false;
+            %count = %assetQuery.getCount();
+            for(%i=0; %i < %count; %i++)
+            {
+               %assetId = %assetQuery.getAsset(%i);
+               %foundAssetType = AssetDatabase.getAssetType(%assetId);
+
+               if(%foundAssetType !$= "ScriptAsset" && %foundAssetType !$= "GUIAsset")
+               {
+                  %doSkip = true;
+                  break;
+               }
+            }  
+            
+            if(%doSkip)
+               continue;
+         }
+         
          %tscriptPath = filePath(%fullScriptPath);
          %tscriptName = fileName(%fullScriptPath);
          


### PR DESCRIPTION
Fixes script presentation logic in the AB so it only shows scripts that isn't an asset file for an asset.

Also fixes a reference to the Inspector for refreshing purposes.
Adds a pop call to ensure AB is in focus when shown

Test case:
When opening a folder with assets that have script files associated, such as a shape having a constructor script, ensure script file doesn't appear as it's own item