### PR TITLE
Fixes display of internal names on objects shown in guiTreeViewCtrl

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -560,7 +560,7 @@ void GuiTreeViewCtrl::Item::getDisplayText(U32 bufLen, char *buf)
                if (mState.test(Item::Marked))
                   dSprintf(ptr, len, " *[%s]", pInternalName);
                else
-                  dSprintf(ptr, len, " [%s]", pObjName);
+                  dSprintf(ptr, len, " [%s]", pInternalName);
             }
          }
       }


### PR DESCRIPTION
Test case:
Add internal name to an object that can be viewed in a guiTreeViewCtrl and then ensure that the display shows as the proper objectname[internalName]