### PR TITLE
Updates the masterserver domain referenced in the default scripts, pointing it to the new torque3d master server

### DIFF
--- a/Templates/BaseGame/game/core/clientServer/scripts/server/defaults.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/defaults.tscript
@@ -25,7 +25,7 @@
 // List of master servers to query, each one is tried in order
 // until one responds
 $Pref::Server::RegionMask = 2;
-$pref::Master[0] = "2:master.garagegames.com:28002";
+$pref::Master[0] = "2:master.torque3d.org:5664";
 
 // Information about the server
 $Pref::Server::Name = "Torque 3D Server";

--- a/Templates/BaseGame/game/data/defaults.tscript
+++ b/Templates/BaseGame/game/data/defaults.tscript
@@ -5,6 +5,8 @@ $pref::Player::zoomSpeed = 0;
 $pref::Net::LagThreshold = 400;
 $pref::Net::Port = 28000;
 
+$pref::Master[0] = "2:master.torque3d.org:5664";
+
 $pref::HudMessageLogSize = 40;
 $pref::ChatHudLength = 1;
 


### PR DESCRIPTION
Test: Affirm that querying the internet on the join menu polls the master server successfully.