### PR TITLE
Window resolution options

### DIFF
--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -1760,7 +1760,9 @@ void GuiCanvas::renderFrame(bool preRenderOnly, bool bufferSwap /* = true */)
       const char *pref = Con::getVariable( "$pref::Video::mode" );
       mode.parseFromString( pref );
       mode.antialiasLevel = 0;
+      Point2I winPos = mPlatformWindow->getPosition(); // Save position so we can put window back.
       mPlatformWindow->setVideoMode(mode);
+      mPlatformWindow->setPosition(winPos);
 
       Con::printf( "AntiAliasing has been disabled; it is not compatible with AdvancedLighting." );
    }
@@ -1772,7 +1774,9 @@ void GuiCanvas::renderFrame(bool preRenderOnly, bool bufferSwap /* = true */)
       if ( prefAA != mode.antialiasLevel )
       {
          mode.parseFromString( pref );
+         Point2I winPos = mPlatformWindow->getPosition(); // Save position so we can put window back.
          mPlatformWindow->setVideoMode(mode);
+         mPlatformWindow->setPosition(winPos);
 
          Con::printf( "AntiAliasing has been enabled while running BasicLighting." );
       }

--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -1762,6 +1762,8 @@ void GuiCanvas::renderFrame(bool preRenderOnly, bool bufferSwap /* = true */)
       mode.antialiasLevel = 0;
       Point2I winPos = mPlatformWindow->getPosition(); // Save position so we can put window back.
       mPlatformWindow->setVideoMode(mode);
+      // setVideoMode (above) will center the window on the display device. If the window had been positioned
+      // by the user or from script, put it back where it was before the light manager change.
       mPlatformWindow->setPosition(winPos);
 
       Con::printf( "AntiAliasing has been disabled; it is not compatible with AdvancedLighting." );
@@ -1776,6 +1778,8 @@ void GuiCanvas::renderFrame(bool preRenderOnly, bool bufferSwap /* = true */)
          mode.parseFromString( pref );
          Point2I winPos = mPlatformWindow->getPosition(); // Save position so we can put window back.
          mPlatformWindow->setVideoMode(mode);
+         // setVideoMode (above) will center the window on the display device. If the window had been positioned
+         // by the user or from script, put it back where it was before the light manager change.
          mPlatformWindow->setPosition(winPos);
 
          Con::printf( "AntiAliasing has been enabled while running BasicLighting." );

--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -207,7 +207,6 @@ void PlatformWindowSDL::_setVideoMode( const GFXVideoMode &mode )
          SDL_MaximizeWindow(mWindowHandle);
    }
 
-   getScreenResChangeSignal().trigger(this, true);
    mSuppressReset = false;
 }
 

--- a/Templates/BaseGame/game/core/gui/scripts/canvas.tscript
+++ b/Templates/BaseGame/game/core/gui/scripts/canvas.tscript
@@ -184,6 +184,12 @@ function GuiCanvas::checkCanvasRes(%this, %mode, %deviceId, %deviceMode, %startu
 
       return true;
    }
+   else if (%deviceMode == $Video::ModeFullscreen)
+   {  // Fullscreen must match the aspect ratio of the monitor
+      %deviceRes = getWords(%this.getMonitorRect(%deviceId), 2);
+      if (mRoundColour(%resX / %resY, 2) != mRoundColour(%deviceRes.x / %deviceRes.y, 2))
+         return false;
+   }
 
    if (!%startup)
       return true;

--- a/Templates/BaseGame/game/core/gui/scripts/canvas.tscript
+++ b/Templates/BaseGame/game/core/gui/scripts/canvas.tscript
@@ -120,6 +120,13 @@ function configureCanvas()
 
    // Actually set the new video mode
    Canvas.setVideoMode(%resX, %resY, %fs, %bpp, %rate, %aa);
+
+   // For borderless on non-windows OS, move the window into position.
+   if (($pref::Video::deviceMode == $Video::ModeBorderless) && ($platform !$= "windows"))
+   {
+      %borderlessPos = getWords(Canvas.getMonitorUsableRect($pref::Video::deviceId), 0, 1);
+      Canvas.setWindowPosition(%borderlessPos);
+   }
    Canvas.setFocus();
 
    // Lock and unlock the mouse to force the position to sync with the platform window
@@ -242,6 +249,14 @@ function GuiCanvas::getBestCanvasRes(%this, %deviceId, %deviceMode)
          ((%resX == getWord(%bestRes, $WORD::RES_X)) && (%resY == getWord(%bestRes, $WORD::RES_Y)) &&
             (%rate > getWord(%bestRes, $WORD::REFRESH))))
          %bestRes = %testRes;
+   }
+
+   // Borderless on non-windows OS should be the usable screen area.
+   if ((%deviceMode == $Video::ModeBorderless) && ($platform !$= "windows"))
+   {
+      %deviceRect = getWords(%this.getMonitorUsableRect(%deviceId), 2);
+      %bestRes = setWord(%bestRes, $WORD::RES_X, %deviceRect.x);
+      %bestRes = setWord(%bestRes, $WORD::RES_Y, %deviceRect.y);
    }
 
    return %bestRes;

--- a/Templates/BaseGame/game/core/rendering/scripts/graphicsOptions.tscript
+++ b/Templates/BaseGame/game/core/rendering/scripts/graphicsOptions.tscript
@@ -845,6 +845,13 @@ function getScreenResolutionList(%deviceID, %deviceMode)
 {
    %returnsList = "";
 
+   // For borderless on non-windows OS only add the usable area.
+   if ((%deviceMode == $Video::ModeBorderless) && ($platform !$= "windows"))
+   {
+      %borderlessRes = getWords(Canvas.getMonitorUsableRect(%newDeviceID), 2);
+      return _makePrettyResString(%borderlessRes);
+   }
+
    %resCount = Canvas.getModeCount();
    for (%i = 0; %i < %resCount; %i++)
    {

--- a/Templates/BaseGame/game/data/ui/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/ui/guis/optionsMenu.tscript
@@ -634,9 +634,14 @@ function onDisplayModeChange(%val)
    }
    %resolutionList = getScreenResolutionList(%newDeviceID, %newDeviceMode);
 
-   // If we're switching to borderless, default to monitor res
    if (%newDeviceMode == $Video::ModeBorderless)
-      %newRes = getWords(Canvas.getMonitorRect(%newDeviceID), 2);
+   {  // If we're switching to borderless, default to monitor res on Windows OS,
+      // monitor usable area for other platforms.
+      if ($platform $= "windows")
+         %newRes = getWords(Canvas.getMonitorRect(%newDeviceID), 2);
+      else
+         %newRes = getWords(Canvas.getMonitorUsableRect(%newDeviceID), 2);
+   }
    else
    {  // Otherwise, if our old resolution is still in the list, attempt to reset it.
       %oldRes = getWord(OptionsMenuSettingsList.getCurrentOption(3), 0) SPC getWord(OptionsMenuSettingsList.getCurrentOption(3), 2);


### PR DESCRIPTION
Limits fullscreen windows to resolutions that match the monitor aspect ratio.
Adjusts borderless window default size to be the monitor usable area on Mac and Linux. This prevents the window from rendering behind the taskbar or titlebar on those platforms.