### PR TITLE
Fix return value conversion when using SimObject::call() method

### DIFF
--- a/Engine/source/console/consoleInternal.cpp
+++ b/Engine/source/console/consoleInternal.cpp
@@ -1451,9 +1451,9 @@ ConsoleValueRef Namespace::Entry::execute(S32 argc, ConsoleValueRef *argv, ExprE
       case StringCallbackType:
          return ConsoleValueRef::fromValue(CSTK.pushStackString(cb.mStringCallbackFunc(state->thisObject, argc, argv)));
       case IntCallbackType:
-         return ConsoleValueRef::fromValue(CSTK.pushUINT((U32)cb.mBoolCallbackFunc(state->thisObject, argc, argv)));
+         return ConsoleValueRef::fromValue(CSTK.pushUINT((U32)cb.mIntCallbackFunc(state->thisObject, argc, argv)));
       case FloatCallbackType:
-         return ConsoleValueRef::fromValue(CSTK.pushFLT((U32)cb.mBoolCallbackFunc(state->thisObject, argc, argv)));
+         return ConsoleValueRef::fromValue(CSTK.pushFLT((U32)cb.mFloatCallbackFunc(state->thisObject, argc, argv)));
       case VoidCallbackType:
          cb.mVoidCallbackFunc(state->thisObject, argc, argv);
          return ConsoleValueRef();


### PR DESCRIPTION
Fix copy-paste in `ConsoleValueRef Namespace::Entry::execute(S32 argc, ConsoleValueRef *argv, ExprEvalState *state)` method to use proper callbacks (Int and Float).

This fixes return value conversion when using SimObject::call() method from scripts.

Use 
```cs
function xzTest(%obj)
{
   %a = "getId";
   %r = %obj.call(%a);
   echo("%r ==" SPC %r SPC "==" SPC %obj.getId());
}
```
to test.  
Stock engine:
```
% xzTest(GhostAlwaysSet);
%r == 43 == 16452
```
This PR:
```
% xzTest(GhostAlwaysSet);
%r == 16452 == 16452
```