### PR TITLE
Fix buffer overflow issue in StringUnit::getWords

### DIFF
--- a/Engine/source/core/strings/stringUnit.cpp
+++ b/Engine/source/core/strings/stringUnit.cpp
@@ -42,7 +42,7 @@ namespace StringUnit
          
       buffer[0] = 0;
       
-      U32 sz;
+      dsize_t sz;
       while(index--)
       {
          if(!*string)
@@ -71,7 +71,7 @@ namespace StringUnit
       if( startIndex > endIndex )
          return "";
 
-      S32 sz;
+      dsize_t sz;
       S32 index = startIndex;
       while(index--)
       {
@@ -89,7 +89,7 @@ namespace StringUnit
          sz = dStrcspn(string, set);
          string += sz;
 
-         if( i < endIndex )
+         if( i < endIndex && *string )
             string ++;
       }
       


### PR DESCRIPTION
getWords("a b c d", 2); // "c d"

that turns into this inside the engine:

getWords("a b c d", 2, 1000000);

that code after parsing d goes string++ which passes over the null character. This now enforces that check. Found this with the new script interpreter...how this wasn't blowing up before is beyond me.