### PR TITLE
mac compilation and standarization fixes

### DIFF
--- a/Engine/lib/convexDecomp/NvThreadConfig.cpp
+++ b/Engine/lib/convexDecomp/NvThreadConfig.cpp
@@ -129,17 +129,15 @@ void   tc_sleep(NxU32 ms)
 
 void tc_spinloop()
 {
-   #ifdef __linux__
-      asm ( "pause" );
-   #elif defined( _XBOX )
-      // Pause would do nothing on the Xbox. Threads are not scheduled.
-   #elif defined( _WIN64 )
-      YieldProcessor( );
-   #elif (defined( __arm64__ ) && defined( __APPLE__ )) || defined( __arch64__ )
-      pthread_yield_np();
-   #else
-      __asm { pause };
-   #endif
+#if defined( _XBOX )
+   // Pause would do nothing on the Xbox. Threads are not scheduled.
+#elif defined( _WIN64 )
+   YieldProcessor( );
+#elif defined( __APPLE__ )||(__linux__)
+   pthread_yield_np();
+#else
+   __asm { pause };
+#endif
 }
 
 void tc_interlockedExchange(void *dest, const int64_t exchange)

--- a/Engine/source/platformMac/macPlatform.mm
+++ b/Engine/source/platformMac/macPlatform.mm
@@ -97,7 +97,7 @@ const char* Platform::getUserDataDirectory()
 //-----------------------------------------------------------------------------
 const char* Platform::getUserHomeDirectory() 
 {
-   return StringTable->insert([[@"~/" stringByStandardizingPath] UTF8String]);
+   return StringTable->insert([[@"~/Documents" stringByStandardizingPath] UTF8String]);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
compresses void tc_spinloop() for both unix derivatives and apples to utilize pthread_yield_np();
mac only tweaks to Platform::getUserHomeDirectory() to return the ~/documents directory for parity with windows results