### PR TITLE
adress #501 - thread oversight.

### DIFF
--- a/Engine/lib/convexDecomp/NvThreadConfig.cpp
+++ b/Engine/lib/convexDecomp/NvThreadConfig.cpp
@@ -133,9 +133,15 @@ void tc_spinloop()
    // Pause would do nothing on the Xbox. Threads are not scheduled.
 #elif defined( _WIN64 )
    YieldProcessor( );
-#elif defined( __APPLE__ )||(__linux__)
+#elif defined( __APPLE__ )
    pthread_yield_np();
-#else
+#elif defined(__linux__)
+   #if defined(_POSIX_PRIORITY_SCHEDULING)
+      sched_yield();
+   #else
+      asm("pause");
+   #endif
+#elif
    __asm { pause };
 #endif
 }


### PR DESCRIPTION
as discussed in the followup conversation to #500, seems like there's been a bit of command-drift since the writeup we were referencing to attempt consistentcy, so back to treating mac and nix differently on this front, looks like