### PR TITLE
suppress deletion of temp material created by the editor

### DIFF
--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -47,7 +47,7 @@ function MaterialEditorGui::establishMaterials(%this)
    singleton CustomMaterial( materialEd_justAlphaMaterial )
    {
       mapTo = "matEd_mappedMatB";
-      texture[0] = materialEd_previewMaterial.diffuseMap[0];
+      texture[0] = materialEd_previewMaterial.getdiffuseMap(0);
    };
 
    //Custom shader to allow the display of just the alpha channel. 
@@ -176,7 +176,7 @@ function MaterialEditorGui::quit(%this)
    // Now we can delete the preview materials and shaders
    // knowing that there are no matinstances using them.
    matEdCubeMapPreviewMat.delete();
-   materialEd_previewMaterial.delete();
+   //materialEd_previewMaterial.delete();
    materialEd_justAlphaMaterial.delete();
    materialEd_justAlphaShader.delete();
 }


### PR DESCRIPTION
stops it from crashing out swapping back and forth into the mat editor
not a proper fix, just ensures we have *something* for the weekend if we don't do a better job.