### PR TITLE
 Bugfix linux release builds for Clang

### DIFF
--- a/Engine/source/T3D/fx/particleEmitter.h
+++ b/Engine/source/T3D/fx/particleEmitter.h
@@ -278,7 +278,7 @@ class ParticleEmitter : public GameBase
    // code to expose the necessary members and methods.
    void update( U32 ms );
 protected:
-   inline void updateKeyData( Particle *part );
+    void updateKeyData( Particle *part );
  
 
   private:

--- a/Engine/source/console/consoleTypes.cpp
+++ b/Engine/source/console/consoleTypes.cpp
@@ -975,13 +975,16 @@ ConsoleSetType( TypePID )
       else
       {
          Torque::UUID uuid;
-         if( !uuid.fromString( argv[ 0 ] ) )
-         {
+
+        if( !uuid.fromString( argv[ 0 ] ) )
+        {
             Con::errorf( "Error parsing UUID in PID: '%s'", argv[ 0 ] );
             *pid = NULL;
-         }
-         else
-            *pid = SimPersistID::findOrCreate( uuid );
+        }
+        else
+        {
+            *pid = SimPersistID::findOrCreate(uuid);
+        }
       }
    }
    else

--- a/Engine/source/core/util/uuid.cpp
+++ b/Engine/source/core/util/uuid.cpp
@@ -68,31 +68,14 @@
 #include <ctype.h>
 
 #include "core/util/md5.h"
+#include "core/util/uuid.h"
 #include "console/enginePrimitives.h"
-
-#if defined (TORQUE_OS_MAC) && (defined(TORQUE_CPU_X64) || defined(TORQUE_CPU_ARM64))
-typedef unsigned int    unsigned32;
-#else
-typedef unsigned long   unsigned32;
-#endif
-typedef unsigned short  unsigned16;
-typedef unsigned char   unsigned8;
 
 typedef struct {
     char nodeID[6];
 } uuid_node_t;
 
 #undef xuuid_t
-
-typedef struct _uuid_t
-{
-    unsigned32	time_low;
-    unsigned16	time_mid;
-    unsigned16	time_hi_and_version;
-    unsigned8	clock_seq_hi_and_reserved;
-    unsigned8	clock_seq_low;
-    unsigned8	node[6];
-} xuuid_t;
 
 /* data type for UUID generator persistent state */
 	

--- a/Engine/source/core/util/uuid.h
+++ b/Engine/source/core/util/uuid.h
@@ -28,11 +28,31 @@
 #endif
 #include "console/engineTypeInfo.h"
 
+#if defined (TORQUE_OS_MAC) && (defined(TORQUE_CPU_X64) || defined(TORQUE_CPU_ARM64))
+typedef unsigned int    unsigned32;
+#else
+typedef unsigned long   unsigned32;
+#endif
+typedef unsigned short  unsigned16;
+typedef unsigned char   unsigned8;
+
+class xuuid_t
+{
+public:
+    unsigned32	time_low;
+    unsigned16	time_mid;
+    unsigned16	time_hi_and_version;
+    unsigned8	clock_seq_hi_and_reserved;
+    unsigned8	clock_seq_low;
+    unsigned8	node[6];
+};
 
 namespace Torque
 {
+
+
    /// A universally unique identifier.
-   class UUID
+   class UUID : public xuuid_t
    {
       friend class UUIDEngineExport;
       public:

--- a/Engine/source/core/util/uuid.h
+++ b/Engine/source/core/util/uuid.h
@@ -28,11 +28,7 @@
 #endif
 #include "console/engineTypeInfo.h"
 
-#if defined (TORQUE_OS_MAC) && (defined(TORQUE_CPU_X64) || defined(TORQUE_CPU_ARM64))
 typedef unsigned int    unsigned32;
-#else
-typedef unsigned long   unsigned32;
-#endif
 typedef unsigned short  unsigned16;
 typedef unsigned char   unsigned8;
 


### PR DESCRIPTION
This merge corrects issues with TORQUE_BUILD_TYPE=Release on Linux when building on Clang.

This partially resolves https://github.com/TorqueGameEngines/Torque3D/issues/503