### PR TITLE
* [Shape Editor] BugFix: Correct a bad octahedron.dts reference when using the mount viewer.

### DIFF
--- a/Templates/BaseGame/game/tools/shapeEditor/scripts/shapeEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/shapeEditor/scripts/shapeEditor.ed.tscript
@@ -3367,7 +3367,7 @@ function ShapeEdMountWindow::mountShape( %this, %slot )
    %type = %this-->mountType.getText();
 
    if ( %model $= "Browse..." )
-      %model = "core/shapes/octahedron.dts";
+      %model = "core/gameObjects/shapes/octahedron.dts";
 
    if ( ShapeEdShapeView.mountShape( %model, %node, %type, %slot ) )
    {


### PR DESCRIPTION
This merge fixes a bad filepath for octahedron.dts whose real path is here: https://github.com/TorqueGameEngines/Torque3D/blob/Preview4_0/Templates/BaseGame/game/core/gameObjects/shapes/octahedron.dts