### PR TITLE
MacOS fixes

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -52,7 +52,7 @@
 
 //-----------------------------------------------------------------------------
 
-StringTableEntry ImageAsset::smNoImageAssetFallback(StringTable->insert(Con::getVariable("$Core::NoImageAssetFallback")));
+StringTableEntry ImageAsset::smNoImageAssetFallback = NULL;
 
 //-----------------------------------------------------------------------------
 
@@ -147,6 +147,8 @@ void ImageAsset::consoleInit()
    Con::addVariable("$Core::NoImageAssetFallback", TypeString, &smNoImageAssetFallback,
       "The assetId of the texture to display when the requested image asset is missing.\n"
       "@ingroup GFX\n");
+   
+   smNoImageAssetFallback = StringTable->insert(Con::getVariable("$Core::NoImageAssetFallback"));
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -43,7 +43,7 @@
 
 #include "T3D/assets/assetImporter.h"
 
-StringTableEntry MaterialAsset::smNoMaterialAssetFallback(StringTable->insert(Con::getVariable("$Core::NoMaterialAssetFallback")));
+StringTableEntry MaterialAsset::smNoMaterialAssetFallback = NULL;
 
 //-----------------------------------------------------------------------------
 
@@ -145,6 +145,8 @@ void MaterialAsset::consoleInit()
    Con::addVariable("$Core::NoMaterialAssetFallback", TypeString, &smNoMaterialAssetFallback,
       "The assetId of the material to display when the requested material asset is missing.\n"
       "@ingroup GFX\n");
+   
+   smNoMaterialAssetFallback = StringTable->insert(Con::getVariable("$Core::NoMaterialAssetFallback"));
 }
 
 void MaterialAsset::initPersistFields()

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -50,7 +50,7 @@
 #include "ts/tsLastDetail.h"
 #endif
 
-StringTableEntry ShapeAsset::smNoShapeAssetFallback(StringTable->insert(Con::getVariable("$Core::NoShapeAssetFallback")));
+StringTableEntry ShapeAsset::smNoShapeAssetFallback = NULL;
 
 //-----------------------------------------------------------------------------
 
@@ -146,6 +146,8 @@ void ShapeAsset::consoleInit()
    Con::addVariable("$Core::NoShapeAssetFallback", TypeString, &smNoShapeAssetFallback,
       "The assetId of the shape to display when the requested shape asset is missing.\n"
       "@ingroup GFX\n");
+   
+   smNoShapeAssetFallback = StringTable->insert(Con::getVariable("$Core::NoShapeAssetFallback"));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes an issue where Con::getVariable can't be used in the global scope before the console system is initialized. I'm honestly surprised this error didn't happen on any other platform.