### PR TITLE
kill off glowchan leftovers

### DIFF
--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -2443,7 +2443,6 @@ function MaterialEditorGui::saveCompositeMap(%this)
     %roughMap = %material.getRoughMap(%layer);
     %aoMap = %material.getAOMap(%layer);
     %metalMap = %material.getMetalMap(%layer);
-    %glowMap = %material.getGlowMap(%layer);
     
     %roughness = %material.RoughnessChan[%layer];
     %ao = %material.AOChan[%layer];

--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -1059,7 +1059,6 @@ function MaterialEditorGui::guiSync( %this, %material )
    %this.getRoughChan((%material).RoughnessChan[%layer]);
    %this.getAOChan((%material).AOChan[%layer]);
    %this.getMetalChan((%material).metalChan[%layer]);
-   %this.getGlowChan((%material).glowChan[%layer]);
    %this.preventUndo = false;
 }
 
@@ -1081,11 +1080,7 @@ function MaterialEditorGui::getMetalChan(%this, %channel)
 	%guiElement = metalChanBtn @ %channel;
 	%guiElement.setStateOn(true);
 }
-function MaterialEditorGui::getGlowChan(%this, %channel)
-{
-	%guiElement = glowChanBtn @ %channel;
-	%guiElement.setStateOn(true);
-}
+
 //=======================================
 // Material Update Functionality
 
@@ -2417,12 +2412,6 @@ function MaterialEditorGui::setAOChan(%this, %value)
 function MaterialEditorGui::setMetalChan(%this, %value)
 {
    MaterialEditorGui.updateActiveMaterial("metalChan[" @ MaterialEditorGui.currentLayer @ "]", %value);   
-   MaterialEditorGui.guiSync( materialEd_previewMaterial );
-}
-
-function MaterialEditorGui::setGlowChan(%this, %value)
-{
-   MaterialEditorGui.updateActiveMaterial("glowChan[" @ MaterialEditorGui.currentLayer @ "]", %value);   
    MaterialEditorGui.guiSync( materialEd_previewMaterial );
 }
 


### PR DESCRIPTION
at one point we were eyeballing embedding a single-channel glow multiplier mask in the orm map. this gets rid of the last leftover bits