### PR TITLE
Misc Fixes and QOL improvements

### DIFF
--- a/Engine/source/gui/controls/guiPopUpCtrl.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrl.cpp
@@ -881,6 +881,12 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
       // Do we render a bitmap border or lines?
       if ( mProfile->getChildrenProfile() && mProfile->mBitmapArrayRects.size() )
       {
+         if (mProfile->mBitmapArrayRects[0].extent.y < baseRect.extent.y)
+         {
+            //if our bitmap is smaller than the height of our ctrl, we'll nudge it towards the center
+            U32 nudge = (baseRect.extent.y - mProfile->mBitmapArrayRects[0].extent.y) / 2;
+            baseRect.point.y += nudge;
+         }
          // Render the fixed, filled in border
          renderFixedBitmapBordersFilled(baseRect, 3, mProfile );
 
@@ -926,6 +932,12 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
          // Do we render a bitmap border or lines?
          if ( mProfile->getChildrenProfile() && mProfile->mBitmapArrayRects.size() )
          {
+            if (mProfile->mBitmapArrayRects[0].extent.y < baseRect.extent.y)
+            {
+               //if our bitmap is smaller than the height of our ctrl, we'll nudge it towards the center
+               U32 nudge = (baseRect.extent.y - mProfile->mBitmapArrayRects[0].extent.y) / 2;
+               baseRect.point.y += nudge;
+            }
             // Render the fixed, filled in border
             renderFixedBitmapBordersFilled(baseRect, 2, mProfile );
 
@@ -957,6 +969,12 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
          // Do we render a bitmap border or lines?
          if ( mProfile->getChildrenProfile() && mProfile->mBitmapArrayRects.size() )
          {
+            if (mProfile->mBitmapArrayRects[0].extent.y < baseRect.extent.y)
+            {
+               //if our bitmap is smaller than the height of our ctrl, we'll nudge it towards the center
+               U32 nudge = (baseRect.extent.y - mProfile->mBitmapArrayRects[0].extent.y) / 2;
+               baseRect.point.y += nudge;
+            }
             // Render the fixed, filled in border
             renderFixedBitmapBordersFilled(baseRect, 1, mProfile );
          } 
@@ -976,6 +994,12 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
          // Do we render a bitmap border or lines?
          if ( !( mProfile->getChildrenProfile() && mProfile->mBitmapArrayRects.size() ) )
          {
+            if (mProfile->mBitmapArrayRects[0].extent.y < baseRect.extent.y)
+            {
+               //if our bitmap is smaller than the height of our ctrl, we'll nudge it towards the center
+               U32 nudge = (baseRect.extent.y - mProfile->mBitmapArrayRects[0].extent.y) / 2;
+               baseRect.point.y += nudge;
+            }
             drawUtil->drawRect( baseRect, mProfile->mBorderColorNA );
          }
       }
@@ -1095,6 +1119,13 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
       // If we're rendering a bitmap border, then it will take care of the arrow.
       if ( !(mProfile->getChildrenProfile() && mProfile->mBitmapArrayRects.size()) )
       {
+         if (mProfile->mBitmapArrayRects[0].extent.y < baseRect.extent.y)
+         {
+            //if our bitmap is smaller than the height of our ctrl, we'll nudge it towards the center
+            U32 nudge = (baseRect.extent.y - mProfile->mBitmapArrayRects[0].extent.y) / 2;
+            baseRect.point.y += nudge;
+         }
+
          //  Draw a triangle (down arrow)
          S32 left = baseRect.point.x + baseRect.extent.x - 12;
          S32 right = left + 8;

--- a/Templates/BaseGame/game/tools/VPathEditor/Scripts/Plugin.tscript
+++ b/Templates/BaseGame/game/tools/VPathEditor/Scripts/Plugin.tscript
@@ -61,7 +61,8 @@ function VPathEditorPlugin::onWorldEditorStartup( %this )
     }
     
     // Add Toolbar.
-    EditorGuiToolbar.add( VPathEditorToolbar );
+    //EditorGuiToolbar.add( VPathEditorToolbar );
+
     
     // Populate Type Menu.
     VPathEditorToolbarPathTypeMenu.clear();
@@ -119,7 +120,9 @@ function VPathEditorPlugin::onActivated( %this )
     EVPathEditor.setVisible( true );
     EVPathEditor.makeFirstResponder( true );
     EditorGui.bringToFront( EVPathEditor );
-    VPathEditorToolbar.setVisible( true );
+    EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+    EditorGuiToolbarStack.add( VPathEditorToolbar );
+
     VPathTreeView.open( GetServerPathSet(), true );
     
     // Sync Gizmo.
@@ -147,7 +150,9 @@ function VPathEditorPlugin::onDeactivated( %this )
 {
     // Hide Editor.
     EVPathEditor.setVisible( false );
-    VPathEditorToolbar.setVisible( false );
+
+    EditorGuiToolbarStack.add( EWorldEditorToolbar );
+    EditorGuiToolbarStack.remove( VPathEditorToolbar );
     
     // Disable Map.
     %this.EditorMap.pop();

--- a/Templates/BaseGame/game/tools/assetBrowser/main.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/main.tscript
@@ -156,14 +156,11 @@ function initializeAssetBrowser()
    AssetBrowser.buildPopupMenus();
    
    //Force everything to initialize if other things need to reference it's behavior before we're displayed(usually other tools)
-   AssetBrowser.showDialog();
-   AssetBrowser.hideDialog();
+   AssetBrowser.initialize();
 }
 
 function AssetBrowserPlugin::onWorldEditorStartup( %this )
 { 
-   // Add ourselves to the toolbar.
-   AssetBrowser.addToolbarButton();
 }
 
 function AssetBrowserPlugin::initSettings( %this )

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -1,5 +1,3 @@
-new SimGroup(AssetBrowserPreviewCache);
-
 //AssetBrowser.addToolbarButton
 function AssetBrowser::addToolbarButton(%this)
 {
@@ -30,11 +28,8 @@ function AssetBrowser::addToolbarButton(%this)
 	EWToolsToolbar.setExtent((25 + 8) * (ToolsToolbarArray.getCount()) + 12 SPC "33");
 }
 //
-function AssetBrowser::onAdd(%this)
-{
-}
 
-function AssetBrowser::onWake(%this)
+function AssetBrowser::initialize(%this)
 {
    // manage preview array
    if(!isObject(AssetPreviewArray))
@@ -63,6 +58,30 @@ function AssetBrowser::onWake(%this)
    AssetBrowser-->previewSlider.setValue(EditorSettings.value("Assets/Browser/previewTileSize", "1.0"));
    
    AssetBrowser-->filterAssetsButton.setActive(true); 
+}
+
+function AssetBrowser::onAdd(%this)
+{
+}
+
+function AssetBrowser::onWake(%this)
+{
+   %this.initialize();
+}
+
+function AssetBrowser::onDialogPop(%this)
+{
+   %lastPosExt = AssetBrowserWindow.position SPC AssetBrowserWindow.extent;
+   EditorSettings.setValue("Assets/Browser/LastPosExt", %lastPosExt); 
+}
+
+function AssetBrowser::restoreLastPosExt(%this)
+{
+   %lastPosExt = EditorSettings.value("Assets/Browser/LastPosExt", ""); 
+   if(%lastPosExt !$= "")
+   {
+      AssetBrowserWindow.resize(getWord(%lastPosExt, 0), getWord(%lastPosExt, 1), getWord(%lastPosExt, 2), getWord(%lastPosExt, 3));
+   }    
 }
 
 function contentTreeTabBook::onTabSelected(%this, %tabText, %tabIndex)
@@ -271,6 +290,7 @@ function AssetBrowser::showDialog( %this, %AssetTypeFilter, %selectCallback, %ta
 
    Canvas.popDialog(AssetBrowser);
    Canvas.pushDialog(AssetBrowser);
+   
    AssetBrowser.setVisible(1);
    AssetBrowserWindow.setVisible(1);
    AssetBrowserWindow.selectWindow();
@@ -299,6 +319,8 @@ function AssetBrowser::showDialog( %this, %AssetTypeFilter, %selectCallback, %ta
    }
 
    AssetBrowser.loadDirectories();
+   
+   AssetBrowser.restoreLastPosExt();
 }
 
 function AssetBrowser::hideDialog( %this )
@@ -309,6 +331,18 @@ function AssetBrowser::hideDialog( %this )
    Canvas.popDialog(ImportAssetWindow);
    
    Canvas.popDialog(AssetBrowser);
+}
+
+function AssetBrowser::toggleDialog( %this )
+{
+   if(AssetBrowser.isAwake())
+   {
+      AssetBrowser.hideDialog();
+   }
+   else
+   {
+      AssetBrowser.showDialog();
+   }
 }
 
 function AssetBrowser::buildAssetPreview( %this, %asset, %moduleName )
@@ -2402,6 +2436,11 @@ function EWorldEditor::onControlDropped( %this, %payload, %position )
          %buildCommand = AssetBrowser @ ".on" @ %assetType @ "EditorDropped(" @ %assetDef @ ",\"" @ %position @ "\");";
       }
       eval(%buildCommand);
+      
+      if(EditorSettings.value("AssetManagement/Assets/closeBrowserOnDragAction", false))
+      {
+         AssetBrowser.hideDialog();  
+      }
    }
    
    EWorldEditor.isDirty = true;

--- a/Templates/BaseGame/game/tools/convexEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/convexEditor/main.tscript
@@ -34,13 +34,12 @@ function initializeConvexEditor()
    ConvexEditorGui.setVisible( false );  
    ConvexEditorOptionsWindow.setVisible( false );  
    ConvexEditorTreeWindow.setVisible( false ); 
-   ConvexEditorToolbar.setVisible( false );
+   
    ConvexEditorOptionsWindow.setVisible( false );
    
    EditorGui.add( ConvexEditorGui );
    EditorGui.add( ConvexEditorOptionsWindow );
    EditorGui.add( ConvexEditorTreeWindow );
-   EditorGui.add( ConvexEditorToolbar );
    EditorGui.add( ConvexEditorOptionsWindow );
       
    new ScriptObject( ConvexEditorPlugin )
@@ -103,7 +102,10 @@ function ConvexEditorPlugin::onActivated( %this )
    
    EditorGui.bringToFront( ConvexEditorGui );
    ConvexEditorGui.setVisible( true );
-   ConvexEditorToolbar.setVisible( true );
+   
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   EditorGuiToolbarStack.add( ConvexEditorToolbar );
+   
    ConvexEditorOptionsWindow.setVisible( true );
    ConvexEditorGui.makeFirstResponder( true ); 
    %this.map.push();   
@@ -137,7 +139,10 @@ function ConvexEditorPlugin::onDeactivated( %this )
    %this.writeSettings();
    
    ConvexEditorGui.setVisible( false );
-   ConvexEditorOptionsWindow.setVisible( false );
+   
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   EditorGuiToolbarStack.remove( ConvexEditorToolbar );
+
    ConvexEditorTreeWindow.setVisible( false );
    ConvexEditorOptionsWindow.setVisible( false );
    ConvexEditorToolbar.setVisible( false );

--- a/Templates/BaseGame/game/tools/forestEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/forestEditor/main.tscript
@@ -34,12 +34,10 @@ function initializeForestEditor()
    ForestEditorGui.setVisible( false );   
    ForestEditorPalleteWindow.setVisible( false );
    ForestEditorPropertiesWindow.setVisible( false );
-   ForestEditToolbar.setVisible( false );
    
    EditorGui.add( ForestEditorGui );
    EditorGui.add( ForestEditorPalleteWindow );
    EditorGui.add( ForestEditorPropertiesWindow );
-   EditorGui.add( ForestEditToolbar );
             
    new ScriptObject( ForestEditorPlugin )
    {
@@ -141,7 +139,9 @@ function ForestEditorPlugin::onActivated( %this )
    ForestEditorPalleteWindow.setVisible( true );
    ForestEditorPropertiesWindow.setVisible( true );
    ForestEditorGui.makeFirstResponder( true );
-   //ForestEditToolbar.setVisible( true );
+   
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   EditorGuiToolbarStack.add( ForestEditToolbar );
 
    //Get our existing forest object in our current mission if we have one
    %forestObject = trim(parseMissionGroupForIds("Forest", ""));
@@ -210,7 +210,11 @@ function ForestEditorPlugin::onActivated( %this )
 
 function ForestEditorPlugin::onDeactivated( %this )
 {  
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   EditorGuiToolbarStack.remove( ForestEditToolbar );
+   
    ForestEditorGui.setVisible( false );
+   
    ForestEditorPalleteWindow.setVisible( false );
    ForestEditorPropertiesWindow.setVisible( false );
    

--- a/Templates/BaseGame/game/tools/gui/editorSettingsWindow.ed.tscript
+++ b/Templates/BaseGame/game/tools/gui/editorSettingsWindow.ed.tscript
@@ -516,6 +516,8 @@ function ESettingsWindow::getAssetEditingSettings(%this)
    SettingsInspector.addSettingsField("Assets/Browser/showEmptyFolders", "Show Empty Folders in Tiles view in Asset Browser", "bool", "");
    SettingsInspector.addSettingsField("Assets/Browser/showLooseFiles", "Show Loose Files when viewing in Asset Browser", "bool", "");
    SettingsInspector.addSettingsField("AssetManagement/Assets/promptOnRename", "Prompt on Rename", "bool", "");
+   
+   SettingsInspector.addSettingsField("AssetManagement/Assets/closeBrowserOnDragAction", "Close Browser on Drag Action", "bool", "If on, the Asset Browser will automatically close after dragging an asset from it to the editor interface.");
    SettingsInspector.endGroup();
 }
 

--- a/Templates/BaseGame/game/tools/guiEditor/gui/guiEditor.ed.gui
+++ b/Templates/BaseGame/game/tools/guiEditor/gui/guiEditor.ed.gui
@@ -22,8 +22,8 @@
       Profile = "ToolsGuiFrameSetProfile";
       HorizSizing = "width";
       VertSizing = "height";
-      Position = "0 0";
-      Extent = "800 583";
+      Position = "-1 -1";
+      Extent = "801 584";
       MinExtent = "8 2";
       canSave = "1";
       Visible = "1";
@@ -50,24 +50,28 @@
          Visible = "1";
          hovertime = "1000";
 
-         new GuiContainer(GHToolBar) {
-            margin = "0 0 0 0";
-            padding = "0 0 0 0";
-            anchorTop = "1";
-            anchorBottom = "0";
-            anchorLeft = "1";
-            anchorRight = "0";
-            isContainer = "1";
-            profile = "ToolsMenubarProfile";
+         new GuiStackControl(GuiEditorToolbarStack) {
+            stackingType = "Horizontal";
+            horizStacking = "Left to Right";
+            vertStacking = "Top to Bottom";
+            padding = "0";
+            dynamicSize = "1";
+            dynamicNonStackExtent = "0";
+            dynamicPos = "0";
+            changeChildSizeToFit = "0";
+            changeChildPosition = "1";
+            position = "0 0";
+            extent = "885 32";
+            minExtent = "16 16";
             horizSizing = "right";
             vertSizing = "bottom";
-            position = "0 0";
-            extent = "16000 32";
-            minExtent = "8 2";
-            canSave = "1";
+            profile = "ToolsGuiDefaultProfile";
             visible = "1";
-            tooltipProfile = "ToolsGuiToolTipProfile";
+            active = "1";
+            tooltipProfile = "GuiToolTipProfile";
             hovertime = "1000";
+            isContainer = "1";
+            canSave = "1";
             canSaveDynamicFields = "0";
 
             new GuiBitmapButtonCtrl(GHWorldEditor) {
@@ -136,27 +140,31 @@
                canSaveDynamicFields = "0";
             };
             new GuiBitmapButtonCtrl() {
-               canSaveDynamicFields = "0";
-               internalName = AssetBrowserBtn;
-               Enabled = "1";
-               isContainer = "0";
-               Profile = "ToolsGuiButtonProfile";
-               HorizSizing = "right";
-               VertSizing = "bottom";
-               position = "98 3";
-               Extent = "29 27";
-               MinExtent = "8 2";
-               canSave = "1";
-               Visible = "1";
-               Command = "AssetBrowser.ShowDialog();";
-               tooltipprofile = "ToolsGuiToolTipProfile";
-               ToolTip = "Asset Browser";
-               hovertime = "750";
-               bitmapAsset = "ToolsModule:menuGrid_image";
+               BitmapAsset = "ToolsModule:settings_n_image";
                bitmapMode = "Stretched";
+               autoFitExtents = "0";
+               useModifiers = "0";
+               useStates = "1";
+               masked = "0";
+               groupNum = "-1";
                buttonType = "PushButton";
-               groupNum = "0";
                useMouseEvents = "0";
+               position = "150 0";
+               extent = "29 27";
+               minExtent = "8 8";
+               horizSizing = "right";
+               vertSizing = "bottom";
+               profile = "ToolsGuiButtonProfile";
+               visible = "1";
+               active = "1";
+               command = "ESettingsWindow.toggleEditorSettings();";
+               tooltipProfile = "ToolsGuiToolTipProfile";
+               tooltip = "Open Editor Settings";
+               hovertime = "1000";
+               isContainer = "0";
+               internalName = "editorSettingsBtn";
+               canSave = "1";
+               canSaveDynamicFields = "0";
             };
             new GuiBitmapCtrl() {
                bitmapAsset = "ToolsModule:separator_h_image";
@@ -174,21 +182,37 @@
                hovertime = "1000";
                canSaveDynamicFields = "0";
             };
-         };
-         new GuiControl() {
-            isContainer = "1";
-            profile = "ToolsGuiDefaultProfile";
-            horizSizing = "width";
-            vertSizing = "bottom";
-            position = "131 0";
-            extent = "723 32";
-            minExtent = "8 2";
-            canSave = "1";
-            visible = "1";
-            tooltipProfile = "ToolsGuiToolTipProfile";
-            hovertime = "1000";
-            canSaveDynamicFields = "0";
-
+            new GuiBitmapButtonCtrl() {
+               canSaveDynamicFields = "0";
+               internalName = AssetBrowserBtn;
+               Enabled = "1";
+               isContainer = "0";
+               Profile = "ToolsGuiButtonProfile";
+               HorizSizing = "right";
+               VertSizing = "bottom";
+               position = "98 3";
+               Extent = "29 27";
+               MinExtent = "8 2";
+               canSave = "1";
+               Visible = "1";
+               Command = "AssetBrowser.toggleDialog();";
+               tooltipprofile = "ToolsGuiToolTipProfile";
+               ToolTip = "Asset Browser";
+               hovertime = "750";
+               bitmapAsset = "ToolsModule:menuGrid_image";
+               bitmapMode = "Stretched";
+               buttonType = "PushButton";
+               groupNum = "0";
+               useMouseEvents = "0";
+            };
+            new GuiBitmapCtrl() {
+               Enabled = "1";
+               Profile = "ToolsGuiDefaultProfile";
+               position = "160 3";
+               Extent = "2 26";
+               MinExtent = "1 1";
+               bitmapAsset = "ToolsModule:separator_h_image";
+            };
             new GuiPopUpMenuCtrl(GuiEditorContentList) {
                maxPopupHeight = "200";
                sbUsesNAColor = "0";
@@ -205,9 +229,9 @@
                isContainer = "0";
                profile = "ToolsGuiPopUpMenuProfile";
                horizSizing = "right";
-               vertSizing = "bottom";
-               position = "8 7";
-               extent = "145 18";
+               vertSizing = "center";
+               position = "8 0";
+               extent = "145 27";
                minExtent = "8 2";
                canSave = "1";
                visible = "1";
@@ -231,9 +255,9 @@
                isContainer = "0";
                profile = "ToolsGuiPopUpMenuProfile";
                horizSizing = "right";
-               vertSizing = "bottom";
-               position = "161 7";
-               extent = "136 18";
+               vertSizing = "center";
+               position = "161 0";
+               extent = "136 27";
                minExtent = "8 2";
                canSave = "1";
                visible = "1";
@@ -247,7 +271,7 @@
                isContainer = "0";
                profile = "ToolsGuiDefaultProfile";
                horizSizing = "right";
-               vertSizing = "bottom";
+               vertSizing = "center";
                position = "307 3";
                extent = "2 26";
                minExtent = "1 1";
@@ -257,20 +281,6 @@
                hovertime = "1000";
                canSaveDynamicFields = "0";
             };
-            new GuiControl() {
-               isContainer = "1";
-               profile = "ToolsGuiDefaultProfile";
-               horizSizing = "right";
-               vertSizing = "bottom";
-               position = "312 3";
-               extent = "95 27";
-               minExtent = "8 2";
-               canSave = "1";
-               visible = "1";
-               tooltipProfile = "ToolsGuiToolTipProfile";
-               hovertime = "1000";
-               canSaveDynamicFields = "0";
-
                new GuiBitmapButtonCtrl(GuiEditorSnapCheckBox) {
                   bitmapAsset = "ToolsModule:snap_grid_n_image";
                   bitmapMode = "Stretched";
@@ -302,10 +312,10 @@
                   isContainer = "0";
                   profile = "ToolsGuiButtonProfile";
                   horizSizing = "right";
-                  vertSizing = "bottom";
+               vertSizing = "center";
                   position = "31 0";
                   extent = "29 27";
-                  minExtent = "120 21";
+               minExtent = "21 21";
                   canSave = "1";
                   visible = "1";
                   command = "GuiEditor.toggleEdgeSnap();";
@@ -324,10 +334,10 @@
                   isContainer = "0";
                   profile = "ToolsGuiButtonProfile";
                   horizSizing = "right";
-                  vertSizing = "bottom";
+               vertSizing = "center";
                   position = "62 0";
                   extent = "29 27";
-                  minExtent = "120 21";
+               minExtent = "21 21";
                   canSave = "1";
                   visible = "1";
                   command = "GuiEditor.toggleCenterSnap();";
@@ -336,7 +346,6 @@
                   hovertime = "1000";
                   canSaveDynamicFields = "0";
                };
-            };
             new GuiBitmapCtrl() {
                bitmapAsset = "ToolsModule:separator_h_image";
                wrap = "0";
@@ -353,20 +362,6 @@
                hovertime = "1000";
                canSaveDynamicFields = "0";
             };
-            new GuiControl() {
-               isContainer = "1";
-               profile = "ToolsGuiDefaultProfile";
-               horizSizing = "right";
-               vertSizing = "bottom";
-               position = "422 3";
-               extent = "95 27";
-               minExtent = "8 2";
-               canSave = "1";
-               visible = "1";
-               tooltipProfile = "ToolsGuiToolTipProfile";
-               hovertime = "1000";
-               canSaveDynamicFields = "0";
-
                new GuiBitmapButtonCtrl() {
                   bitmapAsset = "ToolsModule:align_left_n_image";
                   bitmapMode = "Stretched";
@@ -380,7 +375,7 @@
                   vertSizing = "bottom";
                   position = "0 0";
                   extent = "29 27";
-                  minExtent = "120 21";
+               minExtent = "21 21";
                   canSave = "1";
                   visible = "1";
                   command = "GuiEditor.Justify(0);";
@@ -433,21 +428,6 @@
                   hovertime = "1000";
                   canSaveDynamicFields = "0";
                };
-            };
-            new GuiControl() {
-               isContainer = "1";
-               profile = "ToolsGuiDefaultProfile";
-               horizSizing = "right";
-               vertSizing = "bottom";
-               position = "498 3";
-               extent = "95 27";
-               minExtent = "8 2";
-               canSave = "1";
-               visible = "1";
-               tooltipProfile = "ToolsGuiToolTipProfile";
-               hovertime = "1000";
-               canSaveDynamicFields = "0";
-
                new GuiBitmapButtonCtrl() {
                   bitmapAsset = "ToolsModule:align_top_n_image";
                   bitmapMode = "Stretched";
@@ -461,7 +441,7 @@
                   vertSizing = "bottom";
                   position = "0 0";
                   extent = "29 27";
-                  minExtent = "120 21";
+               minExtent = "21 21";
                   canSave = "1";
                   visible = "1";
                   command = "GuiEditor.Justify(3);";
@@ -514,7 +494,6 @@
                   hovertime = "1000";
                   canSaveDynamicFields = "0";
                };
-            };
             new GuiBitmapCtrl() {
                bitmapAsset = "ToolsModule:separator_h_image";
                wrap = "0";
@@ -547,20 +526,6 @@
                hovertime = "1000";
                canSaveDynamicFields = "0";
             };
-            new GuiControl() {
-               isContainer = "1";
-               profile = "ToolsGuiDefaultProfile";
-               horizSizing = "right";
-               vertSizing = "bottom";
-               position = "615 3";
-               extent = "117 27";
-               minExtent = "8 2";
-               canSave = "1";
-               visible = "1";
-               tooltipProfile = "ToolsGuiToolTipProfile";
-               hovertime = "1000";
-               canSaveDynamicFields = "0";
-
                new GuiBitmapButtonCtrl() {
                   bitmapAsset = "ToolsModule:send_to_back_n_image";
                   bitmapMode = "Stretched";
@@ -605,21 +570,6 @@
                   hovertime = "1000";
                   canSaveDynamicFields = "0";
                };
-            };
-            new GuiControl() {
-               isContainer = "1";
-               profile = "ToolsGuiDefaultProfile";
-               horizSizing = "right";
-               vertSizing = "bottom";
-               position = "583 3";
-               extent = "60 27";
-               minExtent = "8 2";
-               canSave = "1";
-               visible = "1";
-               tooltipProfile = "ToolsGuiToolTipProfile";
-               hovertime = "1000";
-               canSaveDynamicFields = "0";
-
                new GuiBitmapButtonCtrl() {
                   bitmapAsset = "ToolsModule:distribute_horizontal_n_image";
                   bitmapMode = "Stretched";
@@ -663,7 +613,6 @@
                   ToolTip = "Distribute Vertically";
                   hovertime = "1000";
                   canSaveDynamicFields = "0";
-               };
             };
          };
          //---------------------

--- a/Templates/BaseGame/game/tools/meshRoadEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/meshRoadEditor/main.tscript
@@ -31,12 +31,10 @@ function initializeMeshRoadEditor()
    
    MeshRoadEditorGui.setVisible( false );  
    MeshRoadEditorOptionsWindow.setVisible( false );  
-   MeshRoadEditorToolbar.setVisible( false ); 
    MeshRoadEditorTreeWindow.setVisible( false ); 
    
    EditorGui.add( MeshRoadEditorGui );
    EditorGui.add( MeshRoadEditorOptionsWindow );
-   EditorGui.add( MeshRoadEditorToolbar );
    EditorGui.add( MeshRoadEditorTreeWindow );
       
    new ScriptObject( MeshRoadEditorPlugin )
@@ -95,7 +93,10 @@ function MeshRoadEditorPlugin::onActivated( %this )
    MeshRoadEditorGui.setVisible( true );
    MeshRoadEditorGui.makeFirstResponder( true );
    MeshRoadEditorOptionsWindow.setVisible( true );
-   MeshRoadEditorToolbar.setVisible( true );  
+   
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   EditorGuiToolbarStack.add( MeshRoadEditorToolbar );
+
    MeshRoadEditorTreeWindow.setVisible( true );
    MeshRoadTreeView.open(ServerMeshRoadSet,true);
    %this.map.push();
@@ -121,7 +122,10 @@ function MeshRoadEditorPlugin::onDeactivated( %this )
    
    MeshRoadEditorGui.setVisible( false );
    MeshRoadEditorOptionsWindow.setVisible( false );
-   MeshRoadEditorToolbar.setVisible( false );  
+   
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   EditorGuiToolbarStack.remove( MeshRoadEditorToolbar );
+     
    MeshRoadEditorTreeWindow.setVisible( false );
    %this.map.pop();
    

--- a/Templates/BaseGame/game/tools/meshRoadEditor/meshRoadEditorToolbar.gui
+++ b/Templates/BaseGame/game/tools/meshRoadEditor/meshRoadEditorToolbar.gui
@@ -10,7 +10,7 @@
    Extent = "800 32";
    MinExtent = "8 2";
    canSave = "1";
-   Visible = "0";
+   Visible = "1";
    hovertime = "1000";
    
    new GuiTextCtrl() {

--- a/Templates/BaseGame/game/tools/navEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/navEditor/main.tscript
@@ -42,13 +42,11 @@ function initializeNavEditor()
 
    // Add ourselves to EditorGui, where all the other tools reside
    NavEditorGui.setVisible(false);  
-   NavEditorToolbar.setVisible(false); 
    NavEditorOptionsWindow.setVisible(false);
    NavEditorTreeWindow.setVisible(false);
    NavEditorConsoleDlg.setVisible(false);
 
    EditorGui.add(NavEditorGui);
-   EditorGui.add(NavEditorToolbar);
    EditorGui.add(NavEditorOptionsWindow);
    EditorGui.add(NavEditorTreeWindow);
    EditorGui.add(NavEditorConsoleDlg);
@@ -123,7 +121,8 @@ function NavEditorPlugin::onActivated(%this)
 
    NavEditorGui.setVisible(true);
    NavEditorGui.makeFirstResponder(true);
-   NavEditorToolbar.setVisible(true);
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   EditorGuiToolbarStack.add( NavEditorToolbar );
 
    NavEditorOptionsWindow.setVisible(true);
    NavEditorTreeWindow.setVisible(true);
@@ -167,7 +166,10 @@ function NavEditorPlugin::onDeactivated(%this)
    $Nav::EditorOpen = false;   
 
    NavEditorGui.setVisible(false);
-   NavEditorToolbar.setVisible(false);
+
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   EditorGuiToolbarStack.remove( NavEditorToolbar );
+
    NavEditorOptionsWindow.setVisible(false);
    NavEditorTreeWindow.setVisible(false);
    %this.map.pop();

--- a/Templates/BaseGame/game/tools/riverEditor/RiverEditorToolbar.gui
+++ b/Templates/BaseGame/game/tools/riverEditor/RiverEditorToolbar.gui
@@ -10,7 +10,7 @@
    Extent = "800 32";
    MinExtent = "8 2";
    canSave = "1";
-   Visible = "0";
+   Visible = "1";
    hovertime = "1000";
    
    new GuiTextCtrl() {

--- a/Templates/BaseGame/game/tools/riverEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/riverEditor/main.tscript
@@ -31,12 +31,10 @@ function initializeRiverEditor()
    
    // Add ourselves to EditorGui, where all the other tools reside
    RiverEditorGui.setVisible( false );  
-   RiverEditorToolbar.setVisible(false); 
    RiverEditorOptionsWindow.setVisible( false );
    RiverEditorTreeWindow.setVisible( false );
    
    EditorGui.add( RiverEditorGui );
-   EditorGui.add( RiverEditorToolbar );
    EditorGui.add( RiverEditorOptionsWindow );
    EditorGui.add( RiverEditorTreeWindow );
    
@@ -97,7 +95,9 @@ function RiverEditorPlugin::onActivated( %this )
    
    RiverEditorGui.setVisible(true);
    RiverEditorGui.makeFirstResponder( true );
-   RiverEditorToolbar.setVisible(true);
+   
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   EditorGuiToolbarStack.add( RiverEditorToolbar );
    
    RiverEditorOptionsWindow.setVisible( true );
    RiverEditorTreeWindow.setVisible( true );
@@ -130,7 +130,10 @@ function RiverEditorPlugin::onDeactivated( %this )
    $River::EditorOpen = false;   
    
    RiverEditorGui.setVisible(false);
-   RiverEditorToolbar.setVisible(false);
+   
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   EditorGuiToolbarStack.remove( RiverEditorToolbar );
+
    RiverEditorOptionsWindow.setVisible( false );
    RiverEditorTreeWindow.setVisible( false );
    %this.map.pop();

--- a/Templates/BaseGame/game/tools/roadEditor/RoadEditorToolbar.gui
+++ b/Templates/BaseGame/game/tools/roadEditor/RoadEditorToolbar.gui
@@ -10,7 +10,7 @@
    Extent = "800 32";
    MinExtent = "8 2";
    canSave = "1";
-   Visible = "0";
+   Visible = "1";
    hovertime = "1000";
    
    new GuiTextCtrl() {

--- a/Templates/BaseGame/game/tools/roadEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/roadEditor/main.tscript
@@ -31,12 +31,10 @@ function initializeRoadEditor()
    
    // Add ourselves to EditorGui, where all the other tools reside
    RoadEditorGui.setVisible( false ); 
-   RoadEditorToolbar.setVisible( false );
    RoadEditorOptionsWindow.setVisible( false );
    RoadEditorTreeWindow.setVisible( false );
    
    EditorGui.add( RoadEditorGui );
-   EditorGui.add( RoadEditorToolbar );
    EditorGui.add( RoadEditorOptionsWindow );
    EditorGui.add( RoadEditorTreeWindow );
    
@@ -94,7 +92,8 @@ function RoadEditorPlugin::onActivated( %this )
    
    RoadEditorGui.setVisible( true );
    RoadEditorGui.makeFirstResponder( true );
-   RoadEditorToolbar.setVisible( true );   
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   EditorGuiToolbarStack.add( RoadEditorToolbar );
    
    RoadEditorOptionsWindow.setVisible( true );
    RoadEditorTreeWindow.setVisible( true );
@@ -115,7 +114,10 @@ function RoadEditorPlugin::onDeactivated( %this )
    %this.writeSettings();
    
    RoadEditorGui.setVisible( false );
-   RoadEditorToolbar.setVisible( false );   
+   
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   EditorGuiToolbarStack.remove( RoadEditorToolbar );
+
    RoadEditorOptionsWindow.setVisible( false );
    RoadEditorTreeWindow.setVisible( false );
    %this.map.pop();

--- a/Templates/BaseGame/game/tools/shapeEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/shapeEditor/main.tscript
@@ -51,7 +51,6 @@ function initializeShapeEditor()
    EditorGui.add(ShapeEdAnimWindow);
    EditorGui.add(ShapeEdAdvancedWindow);
 
-   EditorGui.add(ShapeEditorToolbar);
    EditorGui.add(ShapeEdSelectWindow);
    EditorGui.add(ShapeEdPropWindow);
 
@@ -187,7 +186,6 @@ function ShapeEditorPlugin::open(%this, %shapeAsset)
       ShapeEdPropWindow.setVisible(true);
       ShapeEdAnimWindow.setVisible(true);
       ShapeEdAdvancedWindow.setVisible(ShapeEditorToolbar-->showAdvanced.getValue());
-      ShapeEditorToolbar.setVisible(true);
       EditorGui.bringToFront(ShapeEdPreviewGui);
 
       ToolsPaletteArray->WorldEditorMove.performClick();

--- a/Templates/BaseGame/game/tools/shapeEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/shapeEditor/main.tscript
@@ -44,8 +44,6 @@ function initializeShapeEditor()
    // Add windows to editor gui
    ShapeEdPreviewGui.setVisible(false);
    ShapeEdAnimWindow.setVisible(false);
-
-   ShapeEditorToolbar.setVisible(false);
    ShapeEdSelectWindow.setVisible(false);
    ShapeEdPropWindow.setVisible(false);
 
@@ -256,6 +254,9 @@ function ShapeEditorPlugin::onActivated(%this)
          %this.openShapeAssetId(%shapeFile);
       }
    }
+   
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   EditorGuiToolbarStack.add( ShapeEditorToolbar );
 }
 
 function ShapeEditorPlugin::initStatusBar(%this)
@@ -275,7 +276,9 @@ function ShapeEditorPlugin::onDeactivated(%this)
    $gfx::wireframe = $wasInWireFrameMode;
 
    ShapeEdMaterials.updateSelectedMaterial(false);
-   ShapeEditorToolbar.setVisible(false);
+   
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   EditorGuiToolbarStack.remove( ShapeEditorToolbar );
 
    ShapeEdPreviewGui.setVisible(false);
    ShapeEdSelectWindow.setVisible(false);

--- a/Templates/BaseGame/game/tools/worldEditor/gui/EditorGui.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/EditorGui.ed.gui
@@ -33,6 +33,29 @@
       Visible = "1";
       hovertime = "1000";
       
+      new GuiStackControl(EditorGuiToolbarStack) {
+         stackingType = "Horizontal";
+         horizStacking = "Left to Right";
+         vertStacking = "Top to Bottom";
+         padding = "0";
+         dynamicSize = "1";
+         dynamicNonStackExtent = "0";
+         dynamicPos = "0";
+         changeChildSizeToFit = "0";
+         changeChildPosition = "1";
+         position = "0 0";
+         extent = "885 32";
+         minExtent = "16 16";
+         horizSizing = "right";
+         vertSizing = "bottom";
+         profile = "GuiDefaultProfile";
+         visible = "1";
+         active = "1";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "1";
+         canSave = "1";
+         canSaveDynamicFields = "0";
         
       new GuiBitmapButtonCtrl(EHWorldEditor) {
          canSaveDynamicFields = "0";
@@ -107,6 +130,76 @@
       bitmapAsset = "ToolsModule:separator_h_image";
       };
       
+         new GuiBitmapButtonCtrl() {
+            BitmapAsset = "ToolsModule:settings_n_image";
+            bitmapMode = "Stretched";
+            autoFitExtents = "0";
+            useModifiers = "0";
+            useStates = "1";
+            masked = "0";
+            groupNum = "-1";
+            buttonType = "PushButton";
+            useMouseEvents = "0";
+            position = "572 0";
+            extent = "29 27";
+            minExtent = "8 8";
+            horizSizing = "right";
+            vertSizing = "bottom";
+            profile = "ToolsGuiButtonProfile";
+            visible = "1";
+            active = "1";
+            command = "ESettingsWindow.toggleEditorSettings();";
+            tooltipProfile = "ToolsGuiToolTipProfile";
+            tooltip = "Open Editor Settings";
+            hovertime = "1000";
+            isContainer = "0";
+            internalName = "editorSettingsBtn";
+            canSave = "1";
+            canSaveDynamicFields = "0";
+         };
+         
+         new GuiBitmapCtrl() {
+            Enabled = "1";
+            Profile = "ToolsGuiDefaultProfile";
+            position = "98 3";
+            Extent = "2 26";
+            MinExtent = "1 1";
+            bitmapAsset = "ToolsModule:separator_h_image";
+         };
+         
+         new GuiBitmapButtonCtrl() {
+            canSaveDynamicFields = "0";
+            internalName = AssetBrowserBtn;
+            Enabled = "1";
+            isContainer = "0";
+            Profile = "ToolsGuiButtonProfile";
+            HorizSizing = "right";
+            VertSizing = "bottom";
+            position = "180 0";
+            Extent = "29 27";
+            MinExtent = "8 2";
+            canSave = "1";
+            Visible = "1";
+            Command = "AssetBrowser.toggleDialog();";
+            tooltipprofile = "ToolsGuiToolTipProfile";
+            ToolTip = "Asset Browser";
+            hovertime = "750";
+            bitmapAsset = "ToolsModule:menuGrid_n_image";
+            bitmapMode = "Stretched";
+            buttonType = "PushButton";
+            groupNum = "0";
+            useMouseEvents = "0";
+         };
+         
+         new GuiBitmapCtrl() {
+            Enabled = "1";
+            Profile = "ToolsGuiDefaultProfile";
+            position = "98 3";
+            Extent = "2 26";
+            MinExtent = "1 1";
+            bitmapAsset = "ToolsModule:separator_h_image";
+         };
+         
       new GuiBitmapButtonCtrl(EWorldEditorToggleCamera) {
          canSaveDynamicFields = "0";
          Enabled = "1";
@@ -306,6 +399,7 @@
          sbUsesNAColor = "0";
          reverseTextList = "0";
          bitmapBounds = "16 16";
+         };
       };
    };
    

--- a/Templates/BaseGame/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/WorldEditorToolbar.ed.gui
@@ -520,31 +520,6 @@
          useMouseEvents = "0";
       };
       
-      new GuiBitmapButtonCtrl() {
-         canSaveDynamicFields = "0";
-         internalName = "editorSettingsBtn";
-         Enabled = "1";
-         isContainer = "0";
-         Profile = "ToolsGuiButtonProfile";
-         HorizSizing = "right";
-         VertSizing = "bottom";
-         Position = "484 3";
-         Extent = "29 27";
-         MinExtent = "8 8";
-         canSave = "1";
-         Visible = "1";
-         Variable = "";
-         Command = "ESettingsWindow.toggleEditorSettings();";
-         tooltipprofile = "ToolsGuiToolTipProfile";
-         ToolTip = "Open Editor Settings";
-         hovertime = "1000";
-         bitmapAsset = "ToolsModule:settings_n_image";
-         text = "";
-         groupNum = "-1";
-         buttonType = "PushButton";
-         useMouseEvents = "0";
-      };
-
       new GuiContainer(objectCenterDropdown){
          Profile = "IconDropdownProfile";
          Position = getWord(EWorldEditorToolbar.position, 0)+getWord(ToggleButtonBar.Position, 0)+getWord(EWorldEditorToolbar-->centerObject.position, 0)-5 SPC getWord(EditorGuiToolbar.extent, 1)-1;

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
@@ -91,10 +91,10 @@ function EditorGui::init(%this)
    {
       // Load Creator/Inspector GUI
       exec("~/worldEditor/gui/WorldEditorToolbar.ed.gui");
-      if( isObject( EWorldEditorToolbar ) )
+      if( isObject( EditorGuiToolbarStack ) )
       {
-         %this.add( EWorldEditorToolbar );
-         EWorldEditorToolbar.setVisible( false );
+         EditorGuiToolbarStack.add( EWorldEditorToolbar );
+         //EWorldEditorToolbar.setVisible( false );
       }
    }  
    
@@ -102,11 +102,11 @@ function EditorGui::init(%this)
    {
       // Load Terrain Edit GUI
       exec("~/worldEditor/gui/TerrainEditToolbar.ed.gui");
-      if( isObject( EWTerrainEditToolbar ) )
+      /*if( isObject( EWTerrainEditToolbar ) )
       {
          %this.add( EWTerrainEditToolbar );
          EWTerrainEditToolbar.setVisible( false );
-      }
+      }*/
    }
    
    if( !isObject( %this-->TerrainPainter ) )
@@ -126,11 +126,11 @@ function EditorGui::init(%this)
    {
       // Load Terrain Edit GUI
       exec("~/worldEditor/gui/TerrainPainterToolbar.ed.gui");
-      if( isObject( EWTerrainPainterToolbar ) )
+      /*if( isObject( EWTerrainPainterToolbar ) )
       {
          %this.add( EWTerrainPainterToolbar );
          EWTerrainPainterToolbar.setVisible( false );
-      }
+      }*/
    }
 
    if( !isObject( %this-->ToolsToolbar ) )
@@ -1082,7 +1082,9 @@ function TerrainEditorPlugin::onActivated( %this )
    ETerrainEditor.attachTerrain();
    ETerrainEditor.makeFirstResponder( true );
         
-   EWTerrainEditToolbar.setVisible( true );
+   EditorGuiToolbarStack.add(EWTerrainEditToolbar);
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   //EWTerrainEditToolbar.setVisible( true );
    ETerrainEditor.onBrushChanged();
    ETerrainEditor.setup();
    TerrainEditorPlugin.syncBrushInfo();
@@ -1098,7 +1100,9 @@ function TerrainEditorPlugin::onDeactivated( %this )
    endToolTime("TerrainEditor");
    EditorGui.writeTerrainEditorSettings();
 
-   EWTerrainEditToolbar.setVisible( false );
+   EditorGuiToolbarStack.remove(EWTerrainEditToolbar);
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   //EWTerrainEditToolbar.setVisible( false );
    ETerrainEditor.setVisible( false );
 
    EditorGui.menuBar.remove( %this.terrainMenu );
@@ -1216,7 +1220,10 @@ function TerrainPainterPlugin::onActivated( %this )
 
    EditorGui-->TerrainPainter.setVisible(true);
    EditorGui-->TerrainPainterPreview.setVisible(true);
-   EWTerrainPainterToolbar.setVisible(true);
+   
+   EditorGuiToolbarStack.add(EWTerrainPainterToolbar);
+   EditorGuiToolbarStack.remove( EWorldEditorToolbar );
+   //EWTerrainPainterToolbar.setVisible(true);
    ETerrainEditor.onBrushChanged();
    EPainter.setup();
    TerrainPainterPlugin.syncBrushInfo();
@@ -1233,7 +1240,9 @@ function TerrainPainterPlugin::onDeactivated( %this )
    %this.map.pop();
    EditorGui-->TerrainPainter.setVisible(false);
    EditorGui-->TerrainPainterPreview.setVisible(false);
-   EWTerrainPainterToolbar.setVisible(false);
+   EditorGuiToolbarStack.remove(EWTerrainPainterToolbar);
+   EditorGuiToolbarStack.add( EWorldEditorToolbar );
+   //EWTerrainPainterToolbar.setVisible(false);
    ETerrainEditor.setVisible( false );
 }
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editor.keybinds.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editor.keybinds.tscript
@@ -78,3 +78,5 @@ GlobalActionMap.bind(keyboard, "ctrl F3", doProfile);
 GlobalActionMap.bind(keyboard, "tilde", toggleConsole);
 
 EditorMap.bind( mouse, "alt zaxis", editorWheelFadeScroll );
+
+EditorMap.bindCmd( keyboard, space, "", "AssetBrowser.toggleDialog();" );


### PR DESCRIPTION
Improves handling of rendering guiPopupCtrls where if the height extent is taller than the bitmap array height, it'll adjust the height to recenter the displayed bitmap elements.
Streamlined the toolbar for the gui and world editors to utilize a stack, making the behavior and manipulation of toolbar elements significantly more consistent.
Added Settings and Asset Browser buttons to both gui and world editor toolbars for easier access.
Moved all tool toolbars over to work with the stack system to make them more consistent and better formatting
Added saving of asset browser's last position and extent so it remembers it on load.
Added editor setting to close the asset browser after completing a drag-n-drop action.
Added keybind to editor keybind list, making space toggle the asset browser