### PR TITLE
* Workaround: GCC Release mode Runtime Errors

### DIFF
--- a/Engine/source/core/util/str.cpp
+++ b/Engine/source/core/util/str.cpp
@@ -284,8 +284,8 @@ class String::StringData : protected StringDataImpl
             delete [] mUTF16;
       }
 
-      void* operator new(size_t size, U32 len);
-      void* operator new( size_t size, U32 len, DataChunker& chunker );
+      void* TORQUE_NOINLINE operator new(size_t size, U32 len);
+      void* TORQUE_NOINLINE operator new( size_t size, U32 len, DataChunker& chunker );
       void operator delete(void *);
 
       bool isShared() const

--- a/Engine/source/platform/types.gcc.h
+++ b/Engine/source/platform/types.gcc.h
@@ -165,5 +165,8 @@ typedef unsigned long  U64;
 #endif
 #endif
 
+// Set GCC noinline
+#define TORQUE_NOINLINE __attribute__ ((noinline))
+
 #endif // INCLUDED_TYPES_GCC_H
 

--- a/Engine/source/platform/types.visualc.h
+++ b/Engine/source/platform/types.visualc.h
@@ -104,6 +104,8 @@ typedef unsigned _int64 U64;
 // see msdn.microsoft.com "Compiler Warning (level 1) C4291" for more details
 #pragma warning(disable: 4291) 
 
+// Set MSVC noline attribute
+#define TORQUE_NOINLINE __declspec(noinline)
 
 #endif // INCLUDED_TYPES_VISUALC_H
 


### PR DESCRIPTION
This merge works around apparent compiler bugs in GCC causing an application crash right at startup. 