### PR TITLE
%guiContent importer compliance fix

### DIFF
--- a/Templates/BaseGame/game/tools/projectImporter/scripts/pre40/T3Dpre4ProjectImporter.tscript
+++ b/Templates/BaseGame/game/tools/projectImporter/scripts/pre40/T3Dpre4ProjectImporter.tscript
@@ -470,6 +470,12 @@ function T3Dpre4ProjectImporter::beginCodeFilesImport(%this)
                
                %objectName = findObjectName(%line, "new");
                
+               if(strIsMatchExpr("*%guiContent*=*new*", %line))
+               {
+                  %line = strReplace(%line, "%guiContent", "$guiContent");
+                  %fileWasChanged = true;
+               }
+               
                if(%objectName !$= "")
                {
                   %sanitizedName = sanitizeString(%objectName);


### PR DESCRIPTION
Adds handling to project importer so if incoming gui files have the %guiContent declaration at the start, it's converted to a global to comply with the script interpreter