### PR TITLE
dedicated gfx device suppression

### DIFF
--- a/Engine/source/gfx/gfxInit.cpp
+++ b/Engine/source/gfx/gfxInit.cpp
@@ -290,7 +290,7 @@ GFXAdapter *GFXInit::getBestAdapterChoice()
    {
      S32 adapterIdx = dAtoi(adapterDevice.c_str());
      if (adapterIdx == -1)
-        adapter = chooseAdapter(adapterType, outputDevice.c_str());
+        adapter = chooseAdapter(NullDevice, outputDevice.c_str());
      else
         adapter = chooseAdapter(adapterType, adapterIdx);
    }

--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -258,17 +258,19 @@ bool GuiCanvas::onAdd()
    // Make sure we're able to render.
    newDevice->setAllowRender( true );
 
-   if(mDisplayWindow)
+   // NULL device returns a nullptr for getPlatformWindow
+   PlatformWindow* window = getPlatformWindow();
+   if (mDisplayWindow && window)
    {
-      getPlatformWindow()->show();
+      window->show();
       WindowManager->setDisplayWindow(true);
-      getPlatformWindow()->setDisplayWindow(true);
+      window->setDisplayWindow(true);
    }
-   else
+   else if (window)
    {
-      getPlatformWindow()->hide();
+      window->hide();
       WindowManager->setDisplayWindow(false);
-      getPlatformWindow()->setDisplayWindow(false);
+      window->setDisplayWindow(false);
    }
 
    // Propagate add to parents.

--- a/Templates/BaseGame/game/main.tscript.in
+++ b/Templates/BaseGame/game/main.tscript.in
@@ -1,10 +1,6 @@
 $Core::windowIcon = "data/icon.png";
 $Core::splashWindowImage = "data/splash.png";
 
-// Display a splash window immediately to improve app responsiveness before
-// engine is initialized and main window created.
-displaySplashWindow($Core::splashWindowImage);
-
 // Console does something.
 setLogMode(6);
 
@@ -20,6 +16,13 @@ ModuleDatabase.setModuleExtension("module");
 ModuleDatabase.scanModules( "core", false );
 ModuleDatabase.LoadExplicit( "CoreModule" );
 
+// Display a splash window immediately to improve app responsiveness before
+// engine is initialized and main window created.
+if ($Server::Dedicated == false)
+    displaySplashWindow($Core::splashWindowImage);
+else
+    $Video::forceDisplayAdapter = -1;
+    
 //-----------------------------------------------------------------------------
 // Load any gameplay modules
 ModuleDatabase.scanModules( "data", false );
@@ -42,6 +45,7 @@ else
    }
 }
 
-closeSplashWindow();
+if ($Server::Dedicated == false)
+    closeSplashWindow();
 
 echo("Engine initialized...");


### PR DESCRIPTION
augments $Video::forceDisplayAdapter = -1; to force usage of GFXAdapterType::NullDevice
skips trying to open a splash window for dedicated servers
bypasses guicanvas window display if window does not exist