### PR TITLE
* [Text Pad] BugFix: Correct a local variable reference

### DIFF
--- a/Templates/BaseGame/game/tools/gui/scriptEditorDlg.ed.gui
+++ b/Templates/BaseGame/game/tools/gui/scriptEditorDlg.ed.gui
@@ -204,8 +204,8 @@ function _TextPadOnOk()
 {
    if(ScriptEditorDlg.callback !$= "")
    {
-      %text = ScriptEditorDlg-->textpad.getText();
-      %command  = ScriptEditorDlg.callback @ "(\"" @ expandEscape(%text) @ "\");";
+      $textpadText = ScriptEditorDlg-->textpad.getText();
+      %command  = ScriptEditorDlg.callback @ "(\"" @ expandEscape($textpadText) @ "\");";
       eval(%command);
    }
    ScriptEditorDlg.callback = "";


### PR DESCRIPTION
This corrects a local variable reference causing the GUI Editor (and other editors using the Text Pad) to crash.