### PR TITLE
* BugFix: Correct function call Error that causes the engine to crash

### DIFF
--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -734,7 +734,7 @@ ConsoleValue CodeBlock::exec(U32 ip, const char* functionName, Namespace* thisNa
    SimObject* curObject = NULL;
    SimObject* saveObject = NULL;
    Namespace::Entry* nsEntry;
-   Namespace* ns;
+   Namespace* ns = NULL;
    const char* curFNDocBlock = NULL;
    const char* curNSDocBlock = NULL;
    const S32 nsDocLength = 128;


### PR DESCRIPTION
This corrects an error that causes the engine to crash when calling non-namespaced engine functions incorrectly (Ie. You do not meet the minimum argument count).