### PR TITLE
Allow local variables to be used in eval.

### DIFF
--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -693,7 +693,8 @@ ConsoleValue CodeBlock::exec(U32 ip, const char* functionName, Namespace* thisNa
       // Do we want this code to execute using a new stack frame?
       if (setFrame < 0)
       {
-         gEvalState.pushFrame(NULL, NULL, 0);
+         // argc is the local count for eval
+         gEvalState.pushFrame(NULL, NULL, argc);
          gCallStack.pushFrame(0);
          popFrame = true;
       }

--- a/Engine/source/console/compiler.h
+++ b/Engine/source/console/compiler.h
@@ -276,6 +276,35 @@ namespace Compiler
    void consoleAllocReset();
 
    extern bool gSyntaxError;
+   extern bool gIsEvalCompile;
+};
+
+class FuncVars
+{
+   struct Var
+   {
+      S32 reg;
+      TypeReq currentType;
+      StringTableEntry name;
+      bool isConstant;
+   };
+
+public:
+   S32 assign(StringTableEntry var, TypeReq currentType, S32 lineNumber, bool isConstant = false);
+
+   S32 lookup(StringTableEntry var, S32 lineNumber);
+
+   TypeReq lookupType(StringTableEntry var, S32 lineNumber);
+   
+   inline S32 count() { return counter; }
+
+   std::unordered_map<S32, StringTableEntry> variableNameMap;
+
+   void clear();
+   
+private:
+   std::unordered_map<StringTableEntry, Var> vars;
+   S32 counter = 0;
 };
 
 /// Utility class to emit and patch bytecode


### PR DESCRIPTION
For small editor scripts or evaling a script and needing a loop is another example. Note that locals stay within the eval scope and are not allowed to be referenced outside of it.