### PR TITLE
* BugFix: Fix a crash that sometimes occurs when groups of of objects are deleted

### DIFF
--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -1993,12 +1993,12 @@ void WorldEditor::on3DMouseMove(const Gui3DMouseEvent & event)
    if ( !mHitObject )
    {
       SceneObject *hitObj = NULL;
-      if ( collide(event, &hitObj) && hitObj->isSelectionEnabled() && !objClassIgnored(hitObj) )
+      if ( collide(event, &hitObj) && !hitObj->isDeleted() && hitObj->isSelectionEnabled() && !objClassIgnored(hitObj) )
       {
          mHitObject = hitObj;
       }
    }
-   
+
    mLastMouseEvent = event;
 }
 


### PR DESCRIPTION
This fixes a bug that causes the engine to crash when using the world editor to delete groups of objects. This error didn't always occur but occurred frequently enough in A/B testing that it appears to be corrected with this change.