### PR TITLE
* BugFix: Correct tags in the asset browser not filtering correctly

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -1802,7 +1802,7 @@ function matchesSearch(%assetName, %assetType)
          }
          else
          {
-            if(%assetName.tags !$= %word)
+            if(strstr(strlwr(%assetName.tags), strlwr(%word)) != -1)
                %matchTags = true;
          }
       }


### PR DESCRIPTION
This corrects an error in the asset browser filter logic causing all assets to be shown when a tag query is used.