### PR TITLE
* Adjustment: Utilize native compiler intrinsics for endian swapping when available

### DIFF
--- a/Engine/source/core/util/endian.h
+++ b/Engine/source/core/util/endian.h
@@ -48,8 +48,12 @@ Convert the byte ordering on the U16 to and from big/little endian format.
 
 inline U16 endianSwap(const U16 in_swap)
 {
+#ifdef TORQUE_U16_ENDIANSWAP_BUILTIN
+    return TORQUE_U16_ENDIANSWAP_BUILTIN(in_swap);
+#else
    return U16(((in_swap >> 8) & 0x00ff) |
       ((in_swap << 8) & 0xff00));
+#endif
 }
 
 inline S16 endianSwap(const S16 in_swap)
@@ -64,10 +68,14 @@ Convert the byte ordering on the U32 to and from big/little endian format.
 */
 inline U32 endianSwap(const U32 in_swap)
 {
+#ifdef TORQUE_U32_ENDIANSWAP_BUILTIN
+    return TORQUE_U32_ENDIANSWAP_BUILTIN(in_swap);
+#else
    return U32(((in_swap >> 24) & 0x000000ff) |
       ((in_swap >>  8) & 0x0000ff00) |
       ((in_swap <<  8) & 0x00ff0000) |
       ((in_swap << 24) & 0xff000000));
+#endif
 }
 
 inline S32 endianSwap(const S32 in_swap)
@@ -77,12 +85,16 @@ inline S32 endianSwap(const S32 in_swap)
 
 inline U64 endianSwap(const U64 in_swap)
 {
+#ifdef TORQUE_U64_ENDIANSWAP_BUILTIN
+    return TORQUE_U64_ENDIANSWAP_BUILTIN(in_swap);
+#else
    U32 *inp = (U32 *) &in_swap;
    U64 ret;
    U32 *outp = (U32 *) &ret;
    outp[0] = endianSwap(inp[1]);
    outp[1] = endianSwap(inp[0]);
    return ret;
+#endif
 }
 
 inline S64 endianSwap(const S64 in_swap)
@@ -138,4 +150,3 @@ TORQUE_DECLARE_TEMPLATIZED_ENDIAN_CONV(F32)
 TORQUE_DECLARE_TEMPLATIZED_ENDIAN_CONV(F64)
 
 #endif
-

--- a/Engine/source/platform/types.gcc.h
+++ b/Engine/source/platform/types.gcc.h
@@ -107,7 +107,7 @@ typedef unsigned long  U64;
 // This could be reconfigured for static builds, though minimal impact
 //#     define TORQUE_SUPPORTS_NASM
 #  endif
-#else 
+#else
 #  error "GCC: Unsupported Operating System"
 #endif
 
@@ -169,5 +169,8 @@ typedef unsigned long  U64;
 #endif
 #endif
 
-#endif // INCLUDED_TYPES_GCC_H
+#define TORQUE_U16_ENDIANSWAP_BUILTIN __builtin_bswap16
+#define TORQUE_U32_ENDIANSWAP_BUILTIN __builtin_bswap32
+#define TORQUE_U64_ENDIANSWAP_BUILTIN __builtin_bswap64
 
+#endif // INCLUDED_TYPES_GCC_H

--- a/Engine/source/platform/types.visualc.h
+++ b/Engine/source/platform/types.visualc.h
@@ -69,7 +69,7 @@ typedef unsigned _int64 U64;
 #  define TORQUE_OS_WIN
 #  define TORQUE_OS_WIN64
 #  include "platform/types.win.h"
-#else 
+#else
 #  error "VC: Unsupported Operating System"
 #endif
 
@@ -115,5 +115,8 @@ typedef unsigned _int64 U64;
 #define TORQUE_UNLIKELY
 #endif
 
-#endif // INCLUDED_TYPES_VISUALC_H
+#define TORQUE_U16_ENDIANSWAP_BUILTIN _byteswap_ushort
+#define TORQUE_U32_ENDIANSWAP_BUILTIN _byteswap_ulong
+#define TORQUE_U64_ENDIANSWAP_BUILTIN _byteswap_uint64
 
+#endif // INCLUDED_TYPES_VISUALC_H


### PR DESCRIPTION
This is a simple change that ensures that the best available routines are utilized for endian swapping.