### PR TITLE
* BugFix: Correct a Windows compilation error in the endian swap code

### DIFF
--- a/Engine/source/platform/types.visualc.h
+++ b/Engine/source/platform/types.visualc.h
@@ -23,6 +23,7 @@
 #ifndef INCLUDED_TYPES_VISUALC_H
 #define INCLUDED_TYPES_VISUALC_H
 
+#include <stdlib.h>
 
 // For more information on VisualC++ predefined macros
 // http://support.microsoft.com/default.aspx?scid=kb;EN-US;q65472


### PR DESCRIPTION
This is a follow up to #607 due to an oversight for MSVC compilation.