### PR TITLE
Tweaks the MaterialAsset loading logic

### DIFF
--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -167,6 +167,12 @@ void MaterialAsset::initializeAsset()
 
    mScriptPath = getOwned() ? expandAssetFilePath(mScriptFile) : mScriptPath;
 
+   if (mMatDefinitionName == StringTable->EmptyString())
+   {
+      mLoadedState = Failed;
+      return;
+   }
+
    if (Torque::FS::IsScriptFile(mScriptPath))
    {
       if (!Sim::findObject(mMatDefinitionName))
@@ -180,6 +186,10 @@ void MaterialAsset::initializeAsset()
               mLoadedState = Failed;
           }
       }
+      else
+      {
+         mLoadedState = DefinitionAlreadyExists;
+      }
    }
 
    loadMaterial();
@@ -188,6 +198,12 @@ void MaterialAsset::initializeAsset()
 void MaterialAsset::onAssetRefresh()
 {
    mScriptPath = getOwned() ? expandAssetFilePath(mScriptFile) : mScriptPath;
+
+   if (mMatDefinitionName == StringTable->EmptyString())
+   {
+      mLoadedState = Failed;
+      return;
+   }
 
    if (Torque::FS::IsScriptFile(mScriptPath))
    {
@@ -204,7 +220,6 @@ void MaterialAsset::onAssetRefresh()
 
       //And now that we've executed, switch back to the prior behavior
       Con::setVariable("$Con::redefineBehavior", redefineBehaviorPrev.c_str());
-      
    }
 
    loadMaterial();
@@ -232,7 +247,7 @@ void MaterialAsset::loadMaterial()
    if (mMaterialDefinition)
       SAFE_DELETE(mMaterialDefinition);
 
-   if (mLoadedState == ScriptLoaded && mMatDefinitionName != StringTable->EmptyString())
+   if ((mLoadedState == ScriptLoaded || mLoadedState == DefinitionAlreadyExists) && mMatDefinitionName != StringTable->EmptyString())
    {
       Material* matDef;
       if (!Sim::findObject(mMatDefinitionName, matDef))

--- a/Engine/source/T3D/assets/MaterialAsset.h
+++ b/Engine/source/T3D/assets/MaterialAsset.h
@@ -73,6 +73,7 @@ public:
    enum MaterialAssetErrCode
    {
       ScriptLoaded = AssetErrCode::Extended,
+      DefinitionAlreadyExists,
       Extended
    };
 


### PR DESCRIPTION
Tweaks the MaterialAsset loading logic to continue to see if the matD…efinition already points to an existing object(to avoid needlessly re-executing files over and over), but also validate other cases, and ensures that if we DO have an existing definition, we still process and load it in the asset itself properly.