### PR TITLE
BugFix: Correct the inability to spawn assorted objects

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/creator.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/creator.tscript
@@ -174,7 +174,7 @@ function AssetBrowser::addCreatorClass(%this, %class, %name, %buildfunc)
          %method = "build" @ %class;
 
       if( !ObjectBuilderGui.isMethod( %method ) )
-         %cmd = "return new " @ %class @ "();";
+         %cmd = "new " @ %class @ "();";
       else
          %cmd = "ObjectBuilderGui." @ %method @ "();";
 


### PR DESCRIPTION
This PR corrects an error where things like SkyBoxes cannot be spawned from the asset browser.