### PR TITLE
BugFix: Correct a case where creator categories may get populated Incorrectly

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -628,7 +628,8 @@ function AssetBrowser::loadDirectories( %this )
    
    %this.loadTags();
    
-   %this.loadCreatorClasses();
+   if (!%this.selectMode)
+      %this.loadCreatorClasses();
    
    //If set to, show core
    if(EditorSettings.value("Assets/Browser/showCoreModule", false) == 1)


### PR DESCRIPTION
This corrects a potential error in populating the Creator tree in the asset browser when entering asset select mode (Ie. clicking the "..." next to an asset field in the inspector). It is caused by the Creator tree root initializing being gated by !%this.selectMode but the actual population function, %this.loadCreatorClasses, not being gated by anything.

Note the original intent seems to have been to exclude the creator tree entirely when entering select mode given the presence of that check on the initialization here: https://github.com/TorqueGameEngines/Torque3D/blob/Preview4_0/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript#L622

![treeWhat](https://user-images.githubusercontent.com/4891495/137647055-bfaafbba-bb12-4361-b108-fa7e5fbe4998.PNG)
