### PR TITLE
adress gl spotlights disapearing for deferred

### DIFF
--- a/Engine/source/lighting/shadowMap/lightShadowMap.cpp
+++ b/Engine/source/lighting/shadowMap/lightShadowMap.cpp
@@ -470,7 +470,6 @@ void LightingShaderConstants::init(GFXShader* shader)
    }
 
    mLightParamsSC = shader->getShaderConstHandle("$lightParams");
-   mLightSpotParamsSC = shader->getShaderConstHandle("$lightSpotParams");
 
    // NOTE: These are the shader constants used for doing lighting 
    // during the forward pass.  Do not confuse these for the deferred
@@ -480,6 +479,7 @@ void LightingShaderConstants::init(GFXShader* shader)
    mLightAmbientSC = shader->getShaderConstHandle( ShaderGenVars::lightAmbient );
    mLightConfigDataSC = shader->getShaderConstHandle( ShaderGenVars::lightConfigData);
    mLightSpotDirSC = shader->getShaderConstHandle( ShaderGenVars::lightSpotDir );
+   mLightSpotParamsSC = shader->getShaderConstHandle(ShaderGenVars::lightSpotParams);
 
    mHasVectorLightSC = shader->getShaderConstHandle(ShaderGenVars::hasVectorLight);
    mVectorLightDirectionSC = shader->getShaderConstHandle(ShaderGenVars::vectorLightDirection);

--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -2189,7 +2189,7 @@ void RTLightingFeatGLSL::processPix(   Vector<ShaderComponent*> &componentList,
    inLightSpotDir->arraySize = 4;
    inLightSpotDir->constSortPos = cspPotentialPrimitive;
 
-   Var * lightSpotParams = new Var( "lightSpotParams", "vec2" );
+   Var * lightSpotParams = new Var( "inlightSpotParams", "vec2" );
    lightSpotParams->uniform = true;
    lightSpotParams->arraySize = 4;
    lightSpotParams->constSortPos = cspPotentialPrimitive;

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -2262,7 +2262,7 @@ void RTLightingFeatHLSL::processPix(   Vector<ShaderComponent*> &componentList,
    inLightSpotDir->arraySize = 4;
    inLightSpotDir->constSortPos = cspPotentialPrimitive;
 
-   Var * lightSpotParams = new Var( "lightSpotParams", "float2" );
+   Var * lightSpotParams = new Var( "inlightSpotParams", "float2" );
    lightSpotParams->uniform = true;
    lightSpotParams->arraySize = 4;
    lightSpotParams->constSortPos = cspPotentialPrimitive;

--- a/Engine/source/shaderGen/shaderGenVars.cpp
+++ b/Engine/source/shaderGen/shaderGenVars.cpp
@@ -66,7 +66,7 @@ const String ShaderGenVars::lightDiffuse("$inLightColor");
 const String ShaderGenVars::lightAmbient("$ambient");
 const String ShaderGenVars::lightConfigData("$inLightConfigData");
 const String ShaderGenVars::lightSpotDir("$inLightSpotDir");
-const String ShaderGenVars::lightSpotParams("$lightSpotParams");
+const String ShaderGenVars::lightSpotParams("$inlightSpotParams");
 
 const String ShaderGenVars::hasVectorLight("$hasVectorLight");
 const String ShaderGenVars::vectorLightDirection("$vectorLightDirection");


### PR DESCRIPTION
It was mixing vars up between it and forward. resolved by prefixing the forward vars with "in" as the rest are, as well as pointing the val at the const String ShaderGenVars::lightSpotParams("$inlightSpotParams");