### PR TITLE
BugFix: Correct a crash caused by sfxProfile

### DIFF
--- a/Engine/source/sfx/sfxProfile.h
+++ b/Engine/source/sfx/sfxProfile.h
@@ -154,7 +154,7 @@ class SFXProfile : public SFXTrack
       void unpackData( BitStream* stream );
 
       /// Returns the sound filename.
-      const String& getSoundFileName() const { return mFilename; }
+      const String getSoundFileName() const { return mFilename; }
       void setSoundFileName(StringTableEntry filename) { mFilename = filename; }
 
       bool getPreload() const { return mPreload; }


### PR DESCRIPTION
This corrects a crash (usually when a sound file failed to load) caused by returning an address to temporary in sfxProfile.