### PR TITLE
BugFix: Allow the asset browser tree view to use a horizontal scroll bar

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/guis/assetBrowser.gui
+++ b/Templates/BaseGame/game/tools/assetBrowser/guis/assetBrowser.gui
@@ -518,9 +518,9 @@ $guiContent = new GuiControl(AssetBrowser) {
 
                new GuiScrollCtrl() {
                   willFirstRespond = "1";
-                  hScrollBar = "alwaysOff";
+                  hScrollBar = "dynamic";
                   vScrollBar = "dynamic";
-                  lockHorizScroll = "1";
+                  lockHorizScroll = "0";
                   lockVertScroll = "0";
                   constantThumbHeight = "0";
                   childMargin = "0 0";


### PR DESCRIPTION
This PR slightly improves the usability of the asset browser by allowing the tree view to use a horizontal scroll bar when necessary.