### PR TITLE
BugFix: Correct the inability to use function keys F1-F10

### DIFF
--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
@@ -359,8 +359,9 @@ function EditorGui::addToEditorsMenu( %this, %displayName, %accel, %newPlugin )
          
    if(!%alreadyExists)
    {
-      EditorsMenuList.add(%displayName TAB %accel TAB %newPlugin);
-      %windowMenu.addItem( %count, %displayName TAB %accel TAB %newPlugin );
+      %pluginCommand = "EditorGui.setEditor(" @ %newPlugin @ ");";
+      EditorsMenuList.add(%displayName TAB %accel TAB %pluginCommand);
+      %windowMenu.addItem( %count, %displayName TAB %accel TAB %pluginCommand);
    }
       
    return %accel;


### PR DESCRIPTION
This PR addresses an issue where you were unable to open editors bound to hotkeys F1-F10 due to the way EditorGui::addToEditorsMenu was implemented.