### PR TITLE
addsa material.setAnimflags(LAYER,TAGS STRING); method

### DIFF
--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -755,6 +755,30 @@ DefineEngineMethod(Material, getAnimFlags, const char*, (U32 id), , "")
    return animFlags;
 }
 
+DefineEngineMethod(Material, setAnimFlags, void, (S32 id, const char *flags), (0, ""), "setAnimFlags")
+{
+   object->mAnimFlags[id] = 0;
+
+   if (String(flags).find("$Scroll") != String::NPos)
+      object->mAnimFlags[id] |= Material::Scroll;
+
+   if (String(flags).find("$Rotate") != String::NPos)
+      object->mAnimFlags[id] |= Material::Rotate;
+
+   if (String(flags).find("$Wave") != String::NPos)
+      object->mAnimFlags[id] |= Material::Wave;
+
+   if (String(flags).find("$Scale") != String::NPos)
+      object->mAnimFlags[id] |= Material::Scale;
+
+   if (String(flags).find("$Sequence") != String::NPos)
+      object->mAnimFlags[id] |= Material::Sequence;
+
+   //if we're still unset, see if they tried assigning a number
+   if (object->mAnimFlags[id] == 0)
+      object->mAnimFlags[id] = dAtoi(flags);
+}
+
 DefineEngineMethod(Material, getFilename, const char*, (), , "Get filename of material")
 {
    SimObject* material = static_cast<SimObject*>(object);

--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -1432,13 +1432,13 @@ function MaterialEditorGui::updateAnimationFlags(%this)
    %action.oldValue = %oldFlags;
    MaterialEditorGui.submitUndo( %action );
    
-   materialEd_previewMaterial.animFlags[MaterialEditorGui.currentLayer] = %flags;
+   materialEd_previewMaterial.setAnimFlags(MaterialEditorGui.currentLayer, %flags);
    materialEd_previewMaterial.flush();
    materialEd_previewMaterial.reload();
    
    if (MaterialEditorGui.livePreview == true)
    {
-      MaterialEditorGui.currentMaterial.animFlags[MaterialEditorGui.currentLayer] = %flags;
+      MaterialEditorGui.currentMaterial.setAnimFlags(MaterialEditorGui.currentLayer, %flags);
       MaterialEditorGui.currentMaterial.flush();
       MaterialEditorGui.currentMaterial.reload();
    }


### PR DESCRIPTION
workaround for mat.animFlags[#]= foo; not taking
time of writing seems to not work for scroll for some reason. might be a different bug