### PR TITLE
BugFix: Correct usage of mkdir in posixVolume.cpp

### DIFF
--- a/Engine/source/platformPOSIX/posixVolume.cpp
+++ b/Engine/source/platformPOSIX/posixVolume.cpp
@@ -196,7 +196,7 @@ FileNodeRef PosixFileSystem::create(const Path& path, FileNode::Mode mode)
    {
       String file = buildFileName(_volume,path);
       
-      if (mkdir(file.c_str(),S_IRWXU | S_IRWXG | S_IRWXO))
+      if (mkdir(file.c_str(),S_IRWXU | S_IRWXG | S_IRWXO) == 0)
          return new PosixDirectory(path,file);
    }
    


### PR DESCRIPTION
This PR addresses a logic error in the directory creation logic where if the directory was created a fail result would be returned and when it failed to create a PosixDirectory handle would be returned to a potentially non-existent directory.

See: https://man7.org/linux/man-pages/man2/mkdir.2.html