### PR TITLE
Feature: Properly detect ARM32/ARM64 in the CMake build process

### DIFF
--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -22,10 +22,19 @@
 
 project("Torque3DEngine")
 
-if( CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 8 )
-    set( TORQUE_CPU_X64 ON )
-elseif( CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 4 )
-    set( TORQUE_CPU_X32 ON )
+# Detect 32bit and 64bit x86/ARM
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+    if( CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 8 )
+        set( TORQUE_CPU_ARM64 ON )
+    elseif( CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 4 )
+        set( TORQUE_CPU_ARM32 ON )
+    endif()
+else()
+    if( CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 8 )
+        set( TORQUE_CPU_X64 ON )
+    elseif( CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 4 )
+        set( TORQUE_CPU_X32 ON )
+    endif()
 endif()
 
 if(NOT TORQUE_TEMPLATE)

--- a/Tools/CMake/libraries/lpng.cmake
+++ b/Tools/CMake/libraries/lpng.cmake
@@ -24,13 +24,17 @@ project(lpng)
 
 # addDef(PNG_NO_ASSEMBLER_CODE)
 
-# Issues with Neon at the moment (Arm support)
-# https://sourceforge.net/p/libpng/bugs/281/
-set(PNG_ARM_NEON off CACHE STRING "")
-add_definitions(-DPNG_ARM_NEON_OPT=0)
+# Enables NEON for libpng
+if ( TORQUE_CPU_ARM32 OR TORQUE_CPU_ARM64 )
+    set(PNG_INTEL_NEON on CACHE STRING "")
+    add_definitions(-DPNG_ARM_NEON_OPT=1)
+    addPath("${libDir}/lpng/arm")
+else()
+    set(PNG_ARM_NEON off CACHE STRING "")
+    add_definitions(-DPNG_ARM_NEON_OPT=0)
+endif()
 
 # Enables SSE for libpng - also takes care of compiler warnings.
-# If we don't want SSE, we should set it to off/0.
 if ( TORQUE_CPU_X32 OR TORQUE_CPU_X64 )
     set(PNG_INTEL_SSE on CACHE STRING "")
     add_definitions(-DPNG_INTEL_SSE_OPT=1)


### PR DESCRIPTION
This PR adds CMake variables TORQUE_CPU_ARM64 and TORQUE_CPU_ARM32 which may be used for detecting 64bit and 32bit ARM compilations respectively. It also uses this information to enable NEON for lpng.