### PR TITLE
 BugFix: Correct an ASAN memory access error in TSShapeEdit caused b…

### DIFF
--- a/Engine/source/ts/tsShapeEdit.cpp
+++ b/Engine/source/ts/tsShapeEdit.cpp
@@ -1584,7 +1584,8 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
          offset = srcShape->groundTranslations.size() - 1;
       }
 
-      groundTranslations.push_back(srcShape->groundTranslations[offset]);
+      const Point3F pointValueToCopy = srcShape->groundTranslations[offset];
+      groundTranslations.push_back(pointValueToCopy);
 
       S32 offset2 = groundBase + i;
       if (offset2 >= srcShape->groundRotations.size())
@@ -1593,7 +1594,8 @@ bool TSShape::addSequence(const Torque::Path& path, const String& fromSeq,
          offset2 = srcShape->groundRotations.size() - 1;
       }
 
-      groundRotations.push_back(srcShape->groundRotations[offset2]);
+      const Quat16 quatValueToCopy = srcShape->groundRotations[offset2];
+      groundRotations.push_back(quatValueToCopy);
    }
 
    // Add triggers


### PR DESCRIPTION
…y reading a reference from the same vector we are pushing to at the same time.