### PR TITLE
BugFix: Correct an invalid memory access error caused by the tab autocomplete

### DIFF
--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -485,6 +485,13 @@ U32 tabComplete(char* inputBuffer, U32 cursorPos, U32 maxResultLength, bool forw
       }
       completionBaseStart = p;
       completionBaseLen = cursorPos - p;
+
+      // Bail if we end up at start of string
+      if (p == 0)
+      {
+          return cursorPos;
+      }
+
       // Is this function being invoked on an object?
       if (inputBuffer[p - 1] == '.') 
       {


### PR DESCRIPTION
This PR addresses an ASAN reported memory access error caused by attempting to autocomplete at the start of the console input while there is text to the right.

Eg. Hit space a few times, type A and then use your left arrow key until you are back at the start of input and press tab.