### PR TITLE
Misc asset import QOL and bugfix changes

### DIFF
--- a/Engine/source/T3D/assets/assetImporter_ScriptBinding.h
+++ b/Engine/source/T3D/assets/assetImporter_ScriptBinding.h
@@ -6,113 +6,114 @@
 //Console Functions
 
 DefineEngineMethod(AssetImportConfig, loadImportConfig, void, (Settings* configSettings, String configName), (nullAsType<Settings*>(), ""),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Loads the provided import config to the importer.\n"
+   "@param configSettings A Settings object containing the import configs.\n"
+   "@param configName The specific name of the config to be used.")
 {
    return object->loadImportConfig(configSettings, configName);
 }
 
 DefineEngineMethod(AssetImporter, setTargetPath, void, (String path), (""),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Sets the target path the importing assets will be put into.\n"
+   "@param A string of the target path.")
 {
    return object->setTargetPath(path);
 }
 
 DefineEngineMethod(AssetImporter, resetImportSession, void, (bool forceResetSession), (false),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Resets the importer's import session. All existing import items, logs, etc will be cleared.")
 {
    return object->resetImportSession(forceResetSession);
 }
 
 DefineEngineMethod(AssetImporter, dumpActivityLog, void, (), ,
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Dumps the import activity log. If the importer is set to, it will save to file, otherwise dump to console.")
 {
    return object->dumpActivityLog();
 }
 
 DefineEngineMethod(AssetImporter, getActivityLogLineCount, S32, (),,
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Gets the number of lines in the import activity log.\n"
+   "@return The number of lines in the import activity log.")
 {
    return object->getActivityLogLineCount();
 }
 
-DefineEngineMethod(AssetImporter, getActivityLogLine, String, (S32 i), (0),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+DefineEngineMethod(AssetImporter, getActivityLogLine, String, (S32 index), (0),
+   "Gets a specific line in the import activity log.\n"
+   "@param index The index of the line to be returned.\n"
+   "@return The string of the requested line of the activity log")
 {
-   return object->getActivityLogLine(i);
+   return object->getActivityLogLine(index);
 }
 
 DefineEngineMethod(AssetImporter, autoImportFile, String, (String path, String typeHint), ("", ""),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Run the full import process on a specific file.\n"
+   "@return If import is successful, the assetId of the new asset. If it failed, an empty string.")
 {
    return object->autoImportFile(path, typeHint);
 }
 
 DefineEngineMethod(AssetImporter, addImportingFile, AssetImportObject*, (String path), (""),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Adds a filepath to the current importing session.\n"
+   "@param path The path to the file to be imported.\n"
+   "@return The AssetImportObject from the import session.")
 {
    return object->addImportingFile(path);
 }
 
 DefineEngineMethod(AssetImporter, addImportingAssetItem, void, (AssetImportObject* assetItem, AssetImportObject* parentItem), (nullAsType< AssetImportObject*>(), nullAsType< AssetImportObject*>()),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Adds an existing AssetImportObject to the current improting session.\n"
+   "@param assetItem The AssetImportObject to be added to the import session.\n"
+   "@param parentItem An AssetImportObject that to act as the parent of the item being added.")
 {
    return object->addImportingAssetItem(assetItem, parentItem);
 }
 
 DefineEngineMethod(AssetImporter, processImportingAssets, void, (), ,
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Processes the importing assets.")
 {
    return object->processImportAssets();
 }
 
-DefineEngineMethod(AssetImporter, validateImportingAssets, bool, (), ,
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+DefineEngineMethod(AssetImporter, hasImportIssues, bool, (), ,
+   "Validates the status of the importing items.\n"
+   "@return False if there are no issues, true if there are importing issues")
 {
    return object->validateAssets();
 }
 
 DefineEngineMethod(AssetImporter, resolveAssetItemIssues, void, (AssetImportObject* assetItem), (nullAsType< AssetImportObject*>()),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Runs the issue resolver to attempt to correct any simple issues, such as utilizing the config's settings to resolve collisions.")
 {
    object->resolveAssetItemIssues(assetItem);
 }
 
 DefineEngineMethod(AssetImporter, importAssets, void, (),,
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Runs the actual import action on the items.")
 {
    return object->importAssets();
 }
 
 DefineEngineMethod(AssetImporter, getAssetItemCount, S32, (),,
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Gets the number of importing asset items.\n"
+   "@return The number of importing asset items")
 {
    return object->getAssetItemCount();
 }
 
 DefineEngineMethod(AssetImporter, getAssetItem, AssetImportObject*, (S32 index), (0),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Gets a specific import asset item.\n"
+   "@param index The index of the AssetImportObject to be returned.\n"
+   "@return AssetImportObject")
 {
    return object->getAssetItem(index);
 }
 
 DefineEngineMethod(AssetImporter, getAssetItemChildCount, S32, (AssetImportObject* assetItem), (nullAsType< AssetImportObject*>()),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Gets number of child items for a given importing asset item.\n"
+   "@param assetItem The AssetImportObject to get the number of children of.\n"
+   "@return The number of child items")
 {
    if (assetItem == nullptr)
       return 0;
@@ -121,8 +122,10 @@ DefineEngineMethod(AssetImporter, getAssetItemChildCount, S32, (AssetImportObjec
 }
 
 DefineEngineMethod(AssetImporter, getAssetItemChild, AssetImportObject*, (AssetImportObject* assetItem, S32 index), (nullAsType< AssetImportObject*>(), 0),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Gets a specific child item of a given importing asset item.\n"
+   "@param assetItem The AssetImportObject to get the child from.\n"
+   "@param index The index of the child to get.\n"
+   "@return The child AssetImportObect")
 {
    if (assetItem == nullptr)
       return nullptr;
@@ -131,31 +134,15 @@ DefineEngineMethod(AssetImporter, getAssetItemChild, AssetImportObject*, (AssetI
 }
 
 DefineEngineMethod(AssetImporter, deleteImportingAsset, void, (AssetImportObject* assetItem), (nullAsType< AssetImportObject*>()),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Deletes an importing AssetImportObject from the import session.\n"
+   "@param assetItem The AssetImportObject to delete.")
 {
    return object->deleteImportingAsset(assetItem);
 }
 
 DefineEngineMethod(AssetImporter, setImportConfig, void, (AssetImportConfig* importConfig), (nullAsType< AssetImportConfig*>()),
-   "Creates a new script asset using the targetFilePath.\n"
-   "@return The bool result of calling exec")
+   "Sets the import config to be used via a AssetImportConfig object.\n"
+   "@param importConfig The AssetImportConfig object to use.")
 {
    return object->setImportConfig(importConfig);
 }
-
-
-/*DefineEngineFunction(enumColladaForImport, bool, (const char* shapePath, const char* ctrl, bool loadCachedDts), ("", "", true),
-   "(string shapePath, GuiTreeViewCtrl ctrl) Collect scene information from "
-   "a COLLADA file and store it in a GuiTreeView control. This function is "
-   "used by the COLLADA import gui to show a preview of the scene contents "
-   "prior to import, and is probably not much use for anything else.\n"
-   "@param shapePath COLLADA filename\n"
-   "@param ctrl GuiTreeView control to add elements to\n"
-   "@param loadCachedDts dictates if it should try and load the cached dts file if it exists"
-   "@return true if successful, false otherwise\n"
-   "@ingroup Editors\n"
-   "@internal")
-{
-   return enumColladaForImport(shapePath, ctrl, loadCachedDts);
-}*/

--- a/Engine/source/ts/assimp/assimpShapeLoader.cpp
+++ b/Engine/source/ts/assimp/assimpShapeLoader.cpp
@@ -425,6 +425,7 @@ bool AssimpShapeLoader::fillGuiTreeView(const char* sourceShapePath, GuiTreeView
 
 void AssimpShapeLoader::updateMaterialsScript(const Torque::Path &path)
 {
+   return;
    Torque::Path scriptPath(path);
    scriptPath.setFileName("materials");
    scriptPath.setExtension(TORQUE_SCRIPT_EXTENSION);

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -461,6 +461,8 @@ void updateMaterialsScript(const Torque::Path &path, bool copyTextures = false)
       return;
 #endif
 
+   return;
+
    Torque::Path scriptPath(path);
    scriptPath.setFileName("materials");
    scriptPath.setExtension(TORQUE_SCRIPT_EXTENSION);

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetImport.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetImport.tscript
@@ -85,8 +85,6 @@ function ImportAssetWindow::onWake(%this)
    %this.importer.targetPath = AssetImportTargetAddress.getText();
    %this.importer.targetModuleId = AssetImportTargetModule.getText();
    
-   ImportActivityLog.empty();
-   
    %this.refresh();
 }
 
@@ -519,7 +517,8 @@ function ImportAssetWindow::doRefresh(%this)
    if(ImportAssetWindow.importConfigsList.count() != 0 
       && EditorSettings.value("Assets/AssetImporDefaultConfig") !$= "" 
       && EditorSettings.value("Assets/AutoImport", false) == true
-      && ImportAssetWindow.hasImportIssues == false
+      && ImportAssetWindow.hasImportIssues() == false
+      && AssetBrowser.isAssetReImport == false
       && ImportAssetWindow.allowAutoImport)
    {
       AssetImportCtrl.setHidden(true);
@@ -722,11 +721,7 @@ function NewAssetsPanelInputs::onRightMouseDown(%this)
 //
 function ImportAssetWindow::removeImportingAsset(%this)
 {
-   ImportActivityLog.add("Removing Asset from Import");
-   
    %this.importer.deleteImportingAsset(ImportAssetActions.assetItem);
-   
-   //ImportAssetWindow.refresh();
 }
 
 function ImportAssetWindow::addNewImportingAsset(%this, %filterType)
@@ -924,9 +919,9 @@ function ImportAssetWindow::toggleLogWindow()
    }
       
    ImportLogTextList.clear();
-   for(%i=0; %i < ImportActivityLog.count(); %i++)
+   for(%i=0; %i < ImportAssetWindow.importer.getActivityLogLineCount(); %i++)
    {
-      ImportLogTextList.addRow(%i, ImportActivityLog.getKey(%i));
+      ImportLogTextList.addRow(%i,ImportAssetWindow.importer.getActivityLogLine(%i));
    }
 }
 //

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetImportConfig.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetImportConfig.tscript
@@ -3,12 +3,6 @@ function ImportAssetConfigList::onSelect( %this, %id, %text )
    //Apply our settings to the assets
    echo("Changed our import config!");
    
-   if(ImportActivityLog.count() != 0)
-      ImportActivityLog.add("");
-      
-   ImportActivityLog.add("Asset Import Configs set to " @ %text);
-   ImportActivityLog.add("");
-   
    ImportAssetWindow.activeImportConfigIndex = %id;
    //ImportAssetWindow.activeImportConfig = ImportAssetWindow.importConfigsList.getKey(%id);
    
@@ -235,12 +229,6 @@ function ImportAssetOptionsWindow::editImportSettings(%this, %assetItem)
 function ImportAssetOptionsWindow::saveAssetOptions(%this)
 {
    %success = AssetImportSettings.write();
-   
-   if(ImportActivityLog.count() != 0)
-      ImportActivityLog.add("");
-      
-   ImportActivityLog.add("Asset Import Configs saved, refreshing Import session");
-   ImportActivityLog.add("");
    
    ImportAssetWindow.refresh();
    ImportAssetOptionsWindow.setVisible(0);   


### PR DESCRIPTION
Disables generation of the materials script files by the internal shape import processor. Material script files are now only generated by the AssetImporter as part of the shape injest process.
Renames validateImportingAssets to hasImportIssues for AssetImporter console method for clarity
Updated console method documentation for AssetImporter methods
Fixed logical error for material asset generation if the import config was set to use existing materials but one was not found.
Fixed logical error when a shapeFile has a material with a texture mapped to it is not in the same directory as the shape, it would not correctly find the texture
Adjusts AssetImport window logic so it will display the window in the event of import issues being detected, or the asset is being re-imported.
Updates the AssetImport window activity log to use the new AssetImporter's log for consistency.