### PR TITLE
[Tokenizer] BugFix: Correct a malloc/delete mismatch

### DIFF
--- a/Engine/source/core/tokenizer.cpp
+++ b/Engine/source/core/tokenizer.cpp
@@ -109,7 +109,10 @@ void Tokenizer::setBuffer(const char* buffer, U32 bufferSize)
 void Tokenizer::setSingleTokens(const char* singleTokens)
 {
    if (mSingleTokens)
-      SAFE_DELETE(mSingleTokens);
+   {
+      free(mSingleTokens);
+      mSingleTokens = NULL;
+   }
 
    if (singleTokens)
       mSingleTokens = dStrdup(singleTokens);


### PR DESCRIPTION
This PR addresses an ASAN reported allocation and deallocation mismatch in the tokenizer.

We are using SAFE_DELETE (which uses delete) here: https://github.com/TorqueGameEngines/Torque3D/blob/Preview4_0/Engine/source/core/tokenizer.cpp#L112

But that value is allocated using dStrdup which uses malloc: https://github.com/TorqueGameEngines/Torque3D/blob/Preview4_0/Engine/source/core/strings/stringFunctions.cpp#L219