### PR TITLE
BugFix: Correct the vehicle types double-tapping onAdd and onRemove

### DIFF
--- a/Engine/source/T3D/vehicles/flyingVehicle.cpp
+++ b/Engine/source/T3D/vehicles/flyingVehicle.cpp
@@ -348,9 +348,6 @@ bool FlyingVehicle::onAdd()
       return false;
 
    addToScene();
-
-   if (isServerObject())
-      scriptOnAdd();
    return true;
 }
 
@@ -400,7 +397,6 @@ void FlyingVehicle::onRemove()
    SFX_DELETE( mJetSound );
    SFX_DELETE( mEngineSound );
 
-   scriptOnRemove();
    removeFromScene();
    Parent::onRemove();
 }

--- a/Engine/source/T3D/vehicles/hoverVehicle.cpp
+++ b/Engine/source/T3D/vehicles/hoverVehicle.cpp
@@ -512,10 +512,6 @@ bool HoverVehicle::onAdd()
       }
    }
 
-
-   if (isServerObject())
-      scriptOnAdd();
-
    return true;
 }
 
@@ -526,7 +522,6 @@ void HoverVehicle::onRemove()
    SFX_DELETE( mEngineSound );
    SFX_DELETE( mFloatSound );
 
-   scriptOnRemove();
    removeFromScene();
    Parent::onRemove();
 }

--- a/Engine/source/T3D/vehicles/wheeledVehicle.cpp
+++ b/Engine/source/T3D/vehicles/wheeledVehicle.cpp
@@ -565,8 +565,6 @@ bool WheeledVehicle::onAdd()
       return false;
 
    addToScene();
-   if (isServerObject())
-      scriptOnAdd();
    return true;
 }
 
@@ -588,7 +586,6 @@ void WheeledVehicle::onRemove()
    SFX_DELETE( mSquealSound );
 
    //
-   scriptOnRemove();
    removeFromScene();
    Parent::onRemove();
 }


### PR DESCRIPTION
This PR addresses a bug where vehicle onAdd and onRemove callbacks are called twice. We simply remove the calls from the affected classes because a parent higher up in the chain (RigidShape) ultimately triggers these callbacks.