### PR TITLE
brdf handling corrections

### DIFF
--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -290,7 +290,7 @@ bool RenderProbeMgr::onAdd()
    }
 
    String brdfTexturePath = GFXTextureManager::getBRDFTexturePath();
-   if (!mBRDFTexture.set(brdfTexturePath, &GFXTexturePersistentSRGBProfile, "BRDFTexture"))
+   if (!mBRDFTexture.set(brdfTexturePath, &GFXTexturePersistentProfile, "BRDFTexture"))
    {
       Con::errorf("RenderProbeMgr::onAdd: Failed to load BRDF Texture");
       return false;

--- a/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
@@ -650,8 +650,7 @@ vec4 debugVizForwardProbes(Surface surface,
    vec3 kD = 1.0f - F;
    kD *= 1.0f - surface.metalness;
 
-   float dfgNdotV = max( surface.NdotV , 0.0009765625f ); //0.5f/512.0f (512 is size of dfg/brdf lookup tex)
-   vec2 envBRDF = textureLod(BRDFTexture, vec2(dfgNdotV, surface.roughness),0).rg;
+   vec2 envBRDF = textureLod(BRDFTexture, vec2(surface.NdotV, surface.roughness),0).rg;
    specular *= F * envBRDF.x + surface.f90 * envBRDF.y;
    irradiance *= kD * surface.baseColor.rgb;
 

--- a/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
@@ -106,7 +106,7 @@ struct Surface
 
 void updateSurface(inout Surface surface)
 {
-	surface.NdotV = abs(dot(surface.N, surface.V)) + 1e-5f; // avoid artifact
+	surface.NdotV = clamp( dot(surface.N, surface.V), 0.0009765625f,0.9990234375f);  //0.5f/512.0f (512 is size of dfg/brdf lookup tex)
 
     surface.linearRoughness = surface.roughness * surface.roughness;
     surface.linearRoughnessSq = surface.linearRoughness * surface.linearRoughness;

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
@@ -105,10 +105,9 @@ struct Surface
 
 	inline void Update()
 	{
-		NdotV = abs(dot(N, V)) + 1e-5f; // avoid artifact
-   
-      linearRoughness = roughness * roughness;
-      linearRoughnessSq = linearRoughness * linearRoughness;
+		NdotV = clamp( dot(N, V), 0.0009765625f,0.9990234375f); // avoid artifact
+        linearRoughness = roughness * roughness;
+        linearRoughnessSq = linearRoughness * linearRoughness;
 
 		albedo = baseColor.rgb * (1.0f - metalness);
 		f0 = lerp(0.04f, baseColor.rgb, metalness);

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
@@ -653,8 +653,7 @@ float4 debugVizForwardProbes(Surface surface,
    float3 kD = 1.0f - F;
    kD *= 1.0f - surface.metalness;
 
-   float dfgNdotV = max( surface.NdotV , 0.0009765625f ); //0.5f/512.0f (512 is size of dfg/brdf lookup tex)
-   float2 envBRDF = TORQUE_TEX2DLOD(BRDFTexture, float4(dfgNdotV, surface.roughness,0,0)).rg;
+   float2 envBRDF = TORQUE_TEX2DLOD(BRDFTexture, float4(surface.NdotV, surface.roughness,0,0)).rg;
    specular *= F * envBRDF.x + surface.f90 * envBRDF.y;
    irradiance *= kD * surface.baseColor.rgb;
 

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
@@ -202,14 +202,13 @@ void main()
    return;
 #endif
 
-
+   
    //energy conservation
    vec3 F = FresnelSchlickRoughness(surface.NdotV, surface.f0, surface.roughness);
    vec3 kD = 1.0f - F;
    kD *= 1.0f - surface.metalness;
 
-   float dfgNdotV = max( surface.NdotV , 0.0009765625f ); //0.5f/512.0f (512 is size of dfg/brdf lookup tex)
-   vec2 envBRDF = textureLod(BRDFTexture, vec2(dfgNdotV, surface.roughness),0).rg;
+   vec2 envBRDF = textureLod(BRDFTexture, vec2(surface.NdotV, surface.roughness),0).rg;
    specular *= F * envBRDF.x + surface.f90 * envBRDF.y;
    irradiance *= kD * surface.baseColor.rgb;
 

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
@@ -197,8 +197,7 @@ float4 main(PFXVertToPix IN) : SV_TARGET
    float3 kD = 1.0f - F;
    kD *= 1.0f - surface.metalness;
 
-   float dfgNdotV = max( surface.NdotV , 0.0009765625f ); //0.5f/512.0f (512 is size of dfg/brdf lookup tex)
-   float2 envBRDF = TORQUE_TEX2DLOD(BRDFTexture, float4(dfgNdotV, surface.roughness,0,0)).rg;
+   float2 envBRDF = TORQUE_TEX2DLOD(BRDFTexture, float4(surface.NdotV, surface.roughness,0,0)).rg;
    specular *= F * envBRDF.x + surface.f90 * envBRDF.y;
    irradiance *= kD * surface.baseColor.rgb;
 


### PR DESCRIPTION
1-handle the brdfTexture in linear space, not srgb.
2-clamp surface.NoV across the board for consistency. (solves several new and ongoing artifacts)