### PR TITLE
Optionally allow to treat script assert as warning

### DIFF
--- a/Engine/source/console/astNodes.cpp
+++ b/Engine/source/console/astNodes.cpp
@@ -57,11 +57,16 @@ namespace Compiler
 using namespace Compiler;
 
 FuncVars gEvalFuncVars;
+FuncVars gGlobalScopeFuncVars;
 FuncVars* gFuncVars = NULL;
 
 inline FuncVars* getFuncVars(S32 lineNumber)
 {
-   AssertISV(gFuncVars, avar("Attemping to use local variable in global scope. File: %s Line: %d", CodeBlock::smCurrentParser->getCurrentFile(), lineNumber));
+   if (gFuncVars == &gGlobalScopeFuncVars)
+   {
+      const char* str = avar("Attemping to use local variable in global scope. File: %s Line: %d", CodeBlock::smCurrentParser->getCurrentFile(), lineNumber);
+      scriptErrorHandler(str);
+   }
    return gFuncVars;
 }
 
@@ -1552,8 +1557,7 @@ U32 FunctionDeclStmtNode::compileStmt(CodeStream& codeStream, U32 ip)
       tbl->add(fnName, nameSpace, varName);
    }
 
-   // In eval mode, global func vars are allowed.
-   gFuncVars = gIsEvalCompile ? &gEvalFuncVars : NULL;
+   gFuncVars = gIsEvalCompile ? &gEvalFuncVars : &gGlobalScopeFuncVars;
 
    return ip;
 }

--- a/Engine/source/console/codeBlock.cpp
+++ b/Engine/source/console/codeBlock.cpp
@@ -38,6 +38,7 @@ CodeBlock *    CodeBlock::smCurrentCodeBlock = NULL;
 ConsoleParser *CodeBlock::smCurrentParser = NULL;
 
 extern FuncVars gEvalFuncVars;
+extern FuncVars gGlobalScopeFuncVars;
 extern FuncVars* gFuncVars;
 
 //-------------------------------------------------------------------------
@@ -637,8 +638,7 @@ ConsoleValue CodeBlock::compileExec(StringTableEntry fileName, const char *inStr
    
    // we are an eval compile if we don't have a file name associated (no exec)
    gIsEvalCompile = fileName == NULL;
-   // In eval mode, global func vars are allowed.
-   gFuncVars = gIsEvalCompile ? &gEvalFuncVars : NULL;
+   gFuncVars = gIsEvalCompile ? &gEvalFuncVars : &gGlobalScopeFuncVars;
 
    // Set up the parser.
    smCurrentParser = getParserForFile(fileName);
@@ -678,7 +678,7 @@ ConsoleValue CodeBlock::compileExec(StringTableEntry fileName, const char *inStr
    codeStream.emit(OP_RETURN_VOID);
    codeStream.emitCodeStream(&codeSize, &code, &lineBreakPairs);
    
-   S32 localRegisterCount = gIsEvalCompile ? gEvalFuncVars.count() : 0;
+   S32 localRegisterCount = gIsEvalCompile ? gEvalFuncVars.count() : gGlobalScopeFuncVars.count();
 
    consoleAllocReset();
 

--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -691,7 +691,8 @@ ConsoleValue CodeBlock::exec(U32 ip, const char* functionName, Namespace* thisNa
          setFrame = -1;
 
       // Do we want this code to execute using a new stack frame?
-      if (setFrame < 0)
+      // compiling a file will force setFrame to 0, forcing us to get a new frame.
+      if (setFrame <= 0)
       {
          // argc is the local count for eval
          gEvalState.pushFrame(NULL, NULL, argc);

--- a/Engine/source/console/compiler.h
+++ b/Engine/source/console/compiler.h
@@ -275,6 +275,8 @@ namespace Compiler
    void *consoleAlloc(U32 size);
    void consoleAllocReset();
 
+   void scriptErrorHandler(const char* str);
+
    extern bool gSyntaxError;
    extern bool gIsEvalCompile;
 };

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -274,6 +274,7 @@ static Vector< String > sInstantGroupStack( __FILE__, __LINE__ );
 static DataChunker consoleLogChunker;
 static Vector<ConsoleLogEntry> consoleLog(__FILE__, __LINE__);
 static bool consoleLogLocked;
+bool scriptWarningsAsAsserts = true;
 static bool logBufferEnabled=true;
 static S32 printLevel = 10;
 static FileStream consoleLogFile;
@@ -353,7 +354,7 @@ void init()
    ConsoleConstructor::setup();
 
    // Set up the parser(s)
-   CON_ADD_PARSER(CMD, TORQUE_SCRIPT_EXTENSION,   true);   // TorqueScript
+   CON_ADD_PARSER(CMD, (char*)TORQUE_SCRIPT_EXTENSION, true);   // TorqueScript
 
    // Setup the console types.
    ConsoleBaseType::initialize();
@@ -377,6 +378,7 @@ void init()
    addVariable("Con::objectCopyFailures", TypeS32, &gObjectCopyFailures, "If greater than zero then it counts the number of object creation "
       "failures based on a missing copy object and does not report an error..\n"
       "@ingroup Console\n");
+   addVariable("Con::scriptWarningsAsAsserts", TypeBool, &scriptWarningsAsAsserts, "If true, script warnings (outside of syntax errors) will be treated as fatal asserts.");
 
    // Current script file name and root
    addVariable( "Con::File", TypeString, &gCurrentFile, "The currently executing script file.\n"


### PR DESCRIPTION
This commit allows us to treat variable use before assign errors and local variables inside of the global scope as warnings instead of asserts. This will allow for easier porting of legacy scripts. It is highly recommended use this as an aid to port scripts, but can be used in production if needbe.