### PR TITLE
Fix extension case handling when looking up assimp importer

### DIFF
--- a/Engine/source/ts/assimp/assimpShapeLoader.cpp
+++ b/Engine/source/ts/assimp/assimpShapeLoader.cpp
@@ -178,8 +178,9 @@ void AssimpShapeLoader::enumerateScene()
       // Setup default units for shape format
       String importFormat;
 
-      const aiImporterDesc* importerDescription = aiGetImporterDesc(shapePath.getExtension().c_str());
-      if (StringTable->insert(importerDescription->mName) == StringTable->insert("Autodesk FBX Importer"))
+      String fileExt = String::ToLower(shapePath.getExtension());
+      const aiImporterDesc* importerDescription = aiGetImporterDesc(fileExt.c_str());
+      if (importerDescription && StringTable->insert(importerDescription->mName) == StringTable->insert("Autodesk FBX Importer"))
       {
          ColladaUtils::getOptions().formatScaleFactor = 0.01f;
       }


### PR DESCRIPTION
Assimp checks against lowercase extensions, so we force the extension of the file to lower before fetching the importer.

Also adds sanity check that the importer was actually found before we try and use it.