### PR TITLE
Fixed a leak with console stack in the interpreter.

### DIFF
--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -696,7 +696,6 @@ ConsoleValue CodeBlock::exec(U32 ip, const char* functionName, Namespace* thisNa
       {
          // argc is the local count for eval
          gEvalState.pushFrame(NULL, NULL, argc);
-         gCallStack.pushFrame(0);
          popFrame = true;
       }
       else

--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -1628,9 +1628,9 @@ static ConsoleValue _internalExecute(SimObject *object, S32 argc, ConsoleValue a
       ICallMethod *com = dynamic_cast<ICallMethod *>(object);
       if(com)
       {
-         gCallStack.pushFrame(0);
+         ConsoleStackFrameSaver saver;
+         saver.save();
          com->callMethodArgList(argc, argv, false);
-         gCallStack.popFrame();
       }
    }
 


### PR DESCRIPTION
Issue was pushing a new frame in the global scope. Everytime a global scope was called, 1 ConsoleValue got allocated that was never freed. After 4096 'global scope' function calls, the engine would blow. Also cleans up an extra rogue usage of push/pop with the saver helper.