### PR TITLE
make use of folder properties in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 3.10.2)
 
+set_property(GLOBAL PROPERTY USE_FOLDERS TRUE)
+set(TORQUE_LIBS_FOLDER_NAME "Libs" CACHE STRING "The solution folder name to place all libs under")
 set(TORQUE_APP_NAME "" CACHE STRING "the app name")
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/temp" CACHE PATH "default install path" FORCE )

--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -340,6 +340,9 @@ macro(finishLibrary)
     #endforeach()
 
     _postTargetProcess()
+
+    #set the folder property name
+    set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER ${TORQUE_LIBS_FOLDER_NAME})
 endmacro()
 
 # macro to add an executable

--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -969,3 +969,20 @@ if(TORQUE_TEMPLATE)
         INSTALL(FILES "${CMAKE_SOURCE_DIR}/Templates/${TORQUE_TEMPLATE}/DeletePrefs.bat"      DESTINATION "${TORQUE_APP_DIR}")
     endif()
 endif()
+
+###############################################################################
+# Properties folder
+###############################################################################
+# we only need to add libs that we add via add_subdirectory command, basics.cmake
+# will take care of the other source libs added via addLib 
+
+if(TORQUE_SFX_OPENAL AND WIN32)
+    set_target_properties(OpenAL PROPERTIES FOLDER ${TORQUE_LIBS_FOLDER_NAME})
+     #why is openal adding these two?
+    set_target_properties(common PROPERTIES FOLDER ${TORQUE_LIBS_FOLDER_NAME})
+    set_target_properties(ex-common PROPERTIES FOLDER ${TORQUE_LIBS_FOLDER_NAME})
+endif()
+
+if(TORQUE_SDL)
+    set_target_properties(SDL2 PROPERTIES FOLDER ${TORQUE_LIBS_FOLDER_NAME})
+endif()


### PR DESCRIPTION
This makes use of folder properties for IDEs that support it. It arranges the third party libs into a folder called 'libs' and places the cmake targets into 'CMakePredefinedTargets'. See picture for the difference. The 'libs' folder can be set via TORQUE_LIBS_FOLDER_NAME in cmake.

Before:

![before](https://user-images.githubusercontent.com/4123979/142792873-79f59f7f-f55e-41bc-8968-d34b02ebb554.png)

After:

![after](https://user-images.githubusercontent.com/4123979/142792935-946a1b1c-bbe5-4271-a112-a34343d343b1.png)

After expanded:
![after_expanded](https://user-images.githubusercontent.com/4123979/142792943-4aecd8b2-0ac6-4476-97d2-2b2aa8cf77b8.png)


