### PR TITLE
BugFix: Correct data corruption potential in GuiInspectorField

### DIFF
--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -318,7 +318,8 @@ void GuiInspectorField::setData( const char* data, bool callbacks )
          {
             char buffer[ 2048 ];
             expandEscape( buffer, newValue );
-            newValue = (const char*)Con::evaluatef( "$f = \"%s\"; return ( %s );", oldValue.c_str(), buffer );
+            ConsoleValue result = Con::evaluatef("$f = \"%s\"; return ( %s );", oldValue.c_str(), buffer);
+            newValue = result.getString();
             Con::evaluatef("$f=0;");
          }
          else if(    type == TypeS32Vector
@@ -354,13 +355,13 @@ void GuiInspectorField::setData( const char* data, bool callbacks )
                char buffer[ 2048 ];
                expandEscape( buffer, newComponentExpr );
 
-               const char* newComponentVal = Con::evaluatef( "$f = \"%s\"; $v = \"%s\"; return ( %s );",
-                  oldComponentVal, oldValue.c_str(), buffer );
+               ConsoleValue result = Con::evaluatef("$f = \"%s\"; $v = \"%s\"; return ( %s );",
+                  oldComponentVal, oldValue.c_str(), buffer);
                Con::evaluatef("$f=0;$v=0;");
 
                if( !isFirst )
                   strNew.append( ' ' );
-               strNew.append( newComponentVal );
+               strNew.append( result.getString() );
                
                isFirst = false;
             }

--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -314,12 +314,13 @@ void GuiInspectorField::setData( const char* data, bool callbacks )
          
          String newValue = strData;
          S32 type= mField->type;
+         ConsoleValue evaluationResult;
          if( type == TypeS8 || type == TypeS32 || type == TypeF32 )
          {
             char buffer[ 2048 ];
             expandEscape( buffer, newValue );
-            ConsoleValue result = Con::evaluatef("$f = \"%s\"; return ( %s );", oldValue.c_str(), buffer);
-            newValue = result.getString();
+            evaluationResult = Con::evaluatef("$f = \"%s\"; return ( %s );", oldValue.c_str(), buffer);
+            newValue = evaluationResult.getString();
             Con::evaluatef("$f=0;");
          }
          else if(    type == TypeS32Vector
@@ -355,13 +356,13 @@ void GuiInspectorField::setData( const char* data, bool callbacks )
                char buffer[ 2048 ];
                expandEscape( buffer, newComponentExpr );
 
-               ConsoleValue result = Con::evaluatef("$f = \"%s\"; $v = \"%s\"; return ( %s );",
+               evaluationResult = Con::evaluatef("$f = \"%s\"; $v = \"%s\"; return ( %s );",
                   oldComponentVal, oldValue.c_str(), buffer);
                Con::evaluatef("$f=0;$v=0;");
 
                if( !isFirst )
                   strNew.append( ' ' );
-               strNew.append( result.getString() );
+               strNew.append( evaluationResult.getString() );
                
                isFirst = false;
             }

--- a/Engine/source/sfx/sfxDescription.cpp
+++ b/Engine/source/sfx/sfxDescription.cpp
@@ -454,7 +454,8 @@ bool SFXDescription::onAdd()
    const char* channelValue = getDataField( sChannel, NULL );
    if( channelValue && channelValue[ 0 ] )
    {
-      const char* group = Con::evaluatef( "return sfxOldChannelToGroup( %s );", channelValue );
+      ConsoleValue result = Con::evaluatef( "return sfxOldChannelToGroup( %s );", channelValue );
+      const char* group = result.getString();
       if( !Sim::findObject( group, mSourceGroup ) )
          Con::errorf( "SFXDescription::onAdd - could not resolve channel '%s' to SFXSource", channelValue );
    }


### PR DESCRIPTION
This PR addresses incorrect usage of Con::evaluatef that led to data corruption when eg. keying in color names (Red, Green, Blue, etc) to a GUI inspector field. It also corrects a similar error in the SFXDescription programming.