### PR TITLE
use internalname for terrain layers

### DIFF
--- a/Engine/source/terrain/terrFile.cpp
+++ b/Engine/source/terrain/terrFile.cpp
@@ -259,8 +259,7 @@ void TerrainFile::_initMaterialInstMapping()
    
    for( U32 i = 0; i < mMaterials.size(); ++ i )
    {
-      Torque::Path path( mMaterials[ i ]->getDiffuseMap());
-      mMaterialInstMapping.push_back( path.getFileName() );
+      mMaterialInstMapping.push_back(mMaterials[i]->getInternalName());
    }
    
    mMaterialInstMapping.mapMaterials();


### PR DESCRIPTION
stops bugs like spaces in filenames and the like from occuring due to pointing right at the diffuse flat file name, as well as corruption from using a different diffuse in the material later