### PR TITLE
Minor cmake corrections

### DIFF
--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -48,8 +48,6 @@ if(UNIX)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse")
         endif()
     endif()
-
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
 ###############################################################################
@@ -658,8 +656,11 @@ finishExecutable()
 ###############################################################################
 ###############################################################################
 
+# Torque requires c++17
+target_compile_features(${TORQUE_APP_NAME} PRIVATE cxx_std_17)
+
 # Set Visual Studio startup project
-if((${CMAKE_VERSION} VERSION_EQUAL 3.6.0) OR (${CMAKE_VERSION} VERSION_GREATER 3.6.0) AND MSVC)
+if(MSVC)
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${TORQUE_APP_NAME})
 endif()
 


### PR DESCRIPTION
* Torque now requires c++17 due to new torque script code. The old cmake code was using set CMAKE_CXX_FLAGS which is bad, it was also in a unix if section, this should be set for all compilers.
* Minimum version of cmake is now beyond 3.6.0, no need to check for that when selecting VS_STARTUP_PROJECT