### PR TITLE
to avoid further confusion, hide the old library tab

### DIFF
--- a/Templates/BaseGame/game/tools/worldEditor/gui/WorldEditorTreeWindow.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/WorldEditorTreeWindow.ed.gui
@@ -175,7 +175,7 @@ $guiContent = new GuiControl() {
                   showClassNameForUnnamedObjects = "1";
                };
             };
-         };
+         };/*
          new GuiTabPageCtrl(EWCreatorWindow) {
             canSaveDynamicFields = "0";
             internalName = "CreatorWindow";
@@ -500,7 +500,7 @@ $guiContent = new GuiControl() {
                   };
                };
             };
-         };
+         };*/
       };
       new GuiBitmapButtonCtrl() {
          canSaveDynamicFields = "0";


### PR DESCRIPTION
the asset browser is the intended usage tool for this, so given repeated instances of confusion, remming out the old display but keeping the codehooks around for adaptation should anything left have been missed