### PR TITLE
BugFix: Correct compilation for MacOS

### DIFF
--- a/Engine/source/console/bison.simple
+++ b/Engine/source/console/bison.simple
@@ -166,9 +166,9 @@ __yy_memcpy (from, to, count)
      char *to;
      int count;
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -181,9 +181,9 @@ __yy_memcpy (from, to, count)
 static void
 __yy_memcpy (char *from, char *to, int count)
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -211,10 +211,10 @@ int
 yyparse(YYPARSE_PARAM)
      YYPARSE_PARAM_DECL
 {
-  register int yystate;
-  register int yyn;
-  register short *yyssp;
-  register YYSTYPE *yyvsp;
+  int yystate;
+  int yyn;
+  short *yyssp;
+  YYSTYPE *yyvsp;
   int yyerrstatus;	/*  number of tokens to shift before error messages enabled */
   int yychar1 = 0;		/*  lookahead token as an internal (translated) token number */
 

--- a/Engine/source/console/cmdgram.cpp
+++ b/Engine/source/console/cmdgram.cpp
@@ -1247,9 +1247,9 @@ __yy_memcpy (from, to, count)
      char *to;
      int count;
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -1262,9 +1262,9 @@ __yy_memcpy (from, to, count)
 static void
 __yy_memcpy (char *from, char *to, int count)
 {
-  register char *f = from;
-  register char *t = to;
-  register int i = count;
+  char *f = from;
+  char *t = to;
+  int i = count;
 
   while (i-- > 0)
     *t++ = *f++;
@@ -1292,10 +1292,10 @@ int
 yyparse(YYPARSE_PARAM)
      YYPARSE_PARAM_DECL
 {
-  register int yystate;
-  register int yyn;
-  register short *yyssp;
-  register YYSTYPE *yyvsp;
+  int yystate;
+  int yyn;
+  short *yyssp;
+  YYSTYPE *yyvsp;
   int yyerrstatus;	/*  number of tokens to shift before error messages enabled */
   int yychar1 = 0;		/*  lookahead token as an internal (translated) token number */
 

--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -348,6 +348,8 @@ macro(finishLibrary)
         add_library("${PROJECT_NAME}" SHARED ${${PROJECT_NAME}_files})
     endif()
 
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+
     # omg - only use the first folder ... otherwise we get lots of header name collisions
     #foreach(dir ${${PROJECT_NAME}_paths})
     addInclude("${firstDir}")
@@ -384,6 +386,10 @@ macro(finishExecutable)
     else()
         add_executable("${PROJECT_NAME}" WIN32 ${${PROJECT_NAME}_files})
     endif()
+
+    # Torque requires c++17
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
     addInclude("${firstDir}")
 
     _postTargetProcess()

--- a/Tools/CMake/torque3d.cmake
+++ b/Tools/CMake/torque3d.cmake
@@ -656,9 +656,6 @@ finishExecutable()
 ###############################################################################
 ###############################################################################
 
-# Torque requires c++17
-target_compile_features(${TORQUE_APP_NAME} PRIVATE cxx_std_17)
-
 # Set Visual Studio startup project
 if(MSVC)
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${TORQUE_APP_NAME})


### PR DESCRIPTION
This PR addresses compilation errors on MacOS. It uses C++17 on the primary engine executable and C++11 on all libraries we compile ourselves - seemingly not specifying the C++ standard explicitly for libraries caused strange compilation errors in Assimp, for example.