### PR TITLE
BugFix: Fix a Windows ASAN reported allocation/deallocation mismatch error.

### DIFF
--- a/Engine/source/sim/netConnection.h
+++ b/Engine/source/sim/netConnection.h
@@ -692,6 +692,7 @@ public:
 
       PacketNotify *nextPacket;  ///< Next packet sent.
       PacketNotify();
+      virtual ~PacketNotify() = default;
    };
    virtual PacketNotify *allocNotify();
    PacketNotify *mNotifyQueueHead;  ///< Head of packet notify list.


### PR DESCRIPTION
This PR addresses an allocation size & deallocation size mismatch error reported by ASAN on Windows when starting a game server. The issue is caused by the following allocation here: https://github.com/TorqueGameEngines/Torque3D/blob/Preview4_0/Engine/source/T3D/gameBase/gameConnection.cpp#L1541

Which is a derivative of NetConnection::PacketNotify but PacketNotify does not have a virtual destructor for the destruction here to work as intended: 
https://github.com/TorqueGameEngines/Torque3D/blob/Preview4_0/Engine/source/sim/netConnection.cpp#L721

See: https://docs.microsoft.com/en-us/cpp/sanitizers/error-new-delete-type-mismatch?view=msvc-170