### PR TITLE
adress mounted turret desync

### DIFF
--- a/Engine/source/T3D/turret/turretShape.cpp
+++ b/Engine/source/T3D/turret/turretShape.cpp
@@ -629,6 +629,9 @@ void TurretShape::processTick(const Move* move)
    if (!isGhost())
       updateAnimation(TickSec);
 
+   if (isMounted()) { // this sets PositionMask at the Item level, forcing a network update and fixing scoping/de-ghosting
+      setVelocity(mMount.object->getVelocity());
+   }
    updateMove(move);
 }
 

--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -433,6 +433,9 @@ void SceneObject::setTransform( const MatrixF& mat )
    if( mSceneManager != NULL )
       mSceneManager->notifyObjectDirty( this );
 
+   if (isMounted()) //try to ensure mounts stay synced
+      setMaskBits(MountedMask);
+
    setRenderTransform( mat );
 }
 


### PR DESCRIPTION
directly fix a reported desync for turrents mounted to other objects when they ghost in and out due to being beyond visibledistance from a given client using the reported workaround from Atomic Walrus
also goes ahead and retriggers setMaskBits(MountedMask) for SceneObject::setTransform as a more generic approach