### PR TITLE
WIP: BugFix: Correct 'make install' not working on MacOS

### DIFF
--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -386,7 +386,7 @@ macro(finishExecutable)
     else()
         add_executable("${PROJECT_NAME}" WIN32 ${${PROJECT_NAME}_files})
     endif()
-    
+
     # Torque requires c++17
     target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
@@ -483,8 +483,8 @@ if(UNIX)
 	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${projectOutDir}")
 	SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${projectOutDir}")
 	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${projectOutDir}")
-    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${projectOutDir}")
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${projectOutDir}")
+	SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${projectOutDir}")
+	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${projectOutDir}")
 endif()
 
 # fix the debug/release subfolders on windows

--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -386,7 +386,7 @@ macro(finishExecutable)
     else()
         add_executable("${PROJECT_NAME}" WIN32 ${${PROJECT_NAME}_files})
     endif()
-
+    
     # Torque requires c++17
     target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
@@ -478,18 +478,13 @@ else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}")
 endif()
 
-if(UNIX AND NOT APPLE)
+if(UNIX)
 	SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${projectOutDir}")
 	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${projectOutDir}")
 	SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${projectOutDir}")
 	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${projectOutDir}")
-endif()
-
-if(APPLE)
-  SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${projectOutDir}")
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${projectOutDir}")
-  SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${projectOutDir}")
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${projectOutDir}")
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${projectOutDir}")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${projectOutDir}")
 endif()
 
 # fix the debug/release subfolders on windows


### PR DESCRIPTION
This PR addresses an error where the MacOS executable is not output to the game directory when CMake is invoked without a build target (eg. No -DTORQUE_BUILD_TYPE line). This made it so that debugging or even just running the app is impossible without manual copying.