### PR TITLE
fix opengl device not returning the correct anisotropic value

### DIFF
--- a/Engine/source/gfx/gl/gfxGLDevice.cpp
+++ b/Engine/source/gfx/gl/gfxGLDevice.cpp
@@ -247,7 +247,6 @@ GFXGLDevice::GFXGLDevice(U32 adapterIndex) :
       mActiveTextureType[i] = GL_ZERO;
 
    mNumVertexStream = 2;
-   mSupportsAnisotropic = false;
 
    for(int i = 0; i < GS_COUNT; ++i)
       mModelViewProjSC[i] = NULL;

--- a/Engine/source/gfx/gl/gfxGLDevice.h
+++ b/Engine/source/gfx/gl/gfxGLDevice.h
@@ -152,7 +152,7 @@ public:
    virtual void setupGenericShaders( GenericShaderType type = GSColor );
    
    ///
-   bool supportsAnisotropic() const { return mSupportsAnisotropic; }
+   bool supportsAnisotropic() const { return mCapabilities.anisotropicFiltering; }
 
    GFXGLStateCache* getOpenglCache() { return mOpenglStateCache; }
 
@@ -235,8 +235,6 @@ private:
    void* mPixelFormat;
 
    F32 mPixelShaderVersion;
-   
-   bool mSupportsAnisotropic;   
 
    U32 mNumVertexStream;
    


### PR DESCRIPTION
OpenGL device is returning the wrong anisotropic variable, thus anisotropic filtering can never be enabled. See https://github.com/TorqueGameEngines/Torque3D/blob/Preview4_0/Engine/source/gfx/gl/gfxGLStateBlock.cpp#L64-L65