### PR TITLE
Fixes creation of convex shapes via editor

### DIFF
--- a/Templates/BaseGame/game/tools/convexEditor/convexEditorGui.tscript
+++ b/Templates/BaseGame/game/tools/convexEditor/convexEditorGui.tscript
@@ -51,6 +51,8 @@ function ConvexEditorGui::onSleep( %this )
 function ConvexEditorGui::createConvexBox( %this )
 {
    %obj = genericCreateObject( "ConvexShape" );
+   %obj.setMaterial(%this.materialName); //set whatever the editor has as it's default material to the new one
+   
    %this.handleDeselect();
    %this.selectConvex( %obj );
    %this.dropSelectionAtScreenCenter();

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editors/creator.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editors/creator.ed.tscript
@@ -227,6 +227,10 @@ function ObjectCreator::createObject( %this, %cmd )
       %this.setNewObjectGroup( getScene(0) );
 
    pushInstantGroup();
+   
+   if(startsWith(%cmd, "return "))
+      %objId = eval(%cmd);
+   else
    %objId = eval("return " @ %cmd);
    popInstantGroup();
    


### PR DESCRIPTION
Fixes handling in the generic creator function to deal with commands formatted with "return " at the start AND without
Fixes assignment of default material to convex shape when the toolbar button is pressed to create a 1u cube automatically.