### PR TITLE
Fixes some mishandled cases when preprocessing objects and functions for project import

### DIFF
--- a/Templates/BaseGame/game/tools/projectImporter/importers/pre40/T3Dpre4ProjectImporter.tscript
+++ b/Templates/BaseGame/game/tools/projectImporter/importers/pre40/T3Dpre4ProjectImporter.tscript
@@ -1038,6 +1038,12 @@ function T3Dpre4ProjectImporter::processMaterialObject(%this, %fileObject, %obje
       
       %assetScriptPath = %assetDef.getScriptPath();
       
+      if(fileExt(%assetScriptPath) $= "")
+      {
+         //try the default extension
+         %assetScriptPath = %assetScriptPath @ "." @ $TorqueScriptFileExtension;  
+      }
+      
       if(isFile(%assetScriptPath) && isObject(%objectName))
       {
          //Regular material in a companion file, so we'll want to write it to the

--- a/Templates/BaseGame/game/tools/projectImporter/scripts/projectImporter.tscript
+++ b/Templates/BaseGame/game/tools/projectImporter/scripts/projectImporter.tscript
@@ -476,7 +476,7 @@ function preprocessImportingFiles()
          {
             %line = $ProjectImporter::fileObject.readLine();
             
-            if(strIsMatchExpr("* new*(*)*", %line))
+            if(strIsMatchExpr("*new *(*)*", %line))
             {
                %start = strpos(%line, "new ");
                %end = strpos(%line, "(", %start);
@@ -484,6 +484,14 @@ function preprocessImportingFiles()
                if(%start != -1 && %end != -1)
                {
                   %className = getSubStr(%line, %start + 4, %end-%start-4);
+               }
+               
+               if(%className $= "")
+               {
+                  //we clearly have some unusual formatting, potentially a progromattic 
+                  //object block creation going on here. so we'll just skip it and move on  
+                  %currentFileSectionObject.add(%line);
+                  continue;
                }
                
                %nameEnd = strpos(%line, ")", %end);
@@ -530,7 +538,7 @@ function preprocessImportingFiles()
                      %insideObjectBlock = true;
                }
             }
-            else if(strIsMatchExpr("* datablock*(*)*", %line))
+            else if(strIsMatchExpr("*datablock *(*)*", %line))
             {
                %start = strpos(%line, "datablock ");
                %end = strpos(%line, "(", %start);
@@ -584,7 +592,7 @@ function preprocessImportingFiles()
                      %insideObjectBlock = true;
                }
             }
-            else if(strIsMatchExpr("* singleton*(*)*", %line))
+            else if(strIsMatchExpr("*singleton *(*)*", %line))
             {
                %start = strpos(%line, "singleton ");
                %end = strpos(%line, "(", %start);
@@ -638,7 +646,7 @@ function preprocessImportingFiles()
                      %insideObjectBlock = true;
                }
             }
-            else if(strIsMatchExpr("*function*(*)*", %line))
+            else if(strIsMatchExpr("*function *(*)*", %line))
             {
                %start = strpos(%line, "function ");
                %end = strpos(%line, "(", %start);

--- a/Templates/BaseGame/game/tools/projectImporter/scripts/projectImporter.tscript
+++ b/Templates/BaseGame/game/tools/projectImporter/scripts/projectImporter.tscript
@@ -488,7 +488,7 @@ function preprocessImportingFiles()
                
                if(%className $= "")
                {
-                  //we clearly have some unusual formatting, potentially a progromattic 
+                  //we clearly have some unusual formatting, potentially a programmatic 
                   //object block creation going on here. so we'll just skip it and move on  
                   %currentFileSectionObject.add(%line);
                   continue;
@@ -505,6 +505,8 @@ function preprocessImportingFiles()
                   %parentName = getSubStr(%objectName, %inheritanceSplit + 1);
                   %objectName = getSubStr(%objectName, 0, %inheritanceSplit);
                }
+               
+               %objectName = trim(%objectName);
                
                %parentFileSectionObject = %currentFileSectionObject;
                
@@ -548,6 +550,14 @@ function preprocessImportingFiles()
                   %className = getSubStr(%line, %start + 10, %end-%start-10);
                }
                
+               if(%className $= "")
+               {
+                  //we clearly have some unusual formatting, potentially a programmatic 
+                  //object block creation going on here. so we'll just skip it and move on  
+                  %currentFileSectionObject.add(%line);
+                  continue;
+               }
+               
                %nameEnd = strpos(%line, ")", %end);
                
                %objectName = getSubStr(%line, %end+1, %nameEnd-%end-1);
@@ -559,6 +569,8 @@ function preprocessImportingFiles()
                   %parentName = getSubStr(%objectName, %inheritanceSplit + 1);
                   %objectName = getSubStr(%objectName, 0, %inheritanceSplit);
                }
+               
+               %objectName = trim(%objectName);
                
                %parentFileSectionObject = %currentFileSectionObject;
                
@@ -602,6 +614,14 @@ function preprocessImportingFiles()
                   %className = getSubStr(%line, %start + 10, %end-%start-10);
                }
                
+               if(%className $= "")
+               {
+                  //we clearly have some unusual formatting, potentially a programmatic 
+                  //object block creation going on here. so we'll just skip it and move on  
+                  %currentFileSectionObject.add(%line);
+                  continue;
+               }
+               
                %nameEnd = strpos(%line, ")", %end);
                
                %objectName = getSubStr(%line, %end+1, %nameEnd-%end-1);
@@ -613,6 +633,8 @@ function preprocessImportingFiles()
                   %parentName = getSubStr(%objectName, %inheritanceSplit + 1);
                   %objectName = getSubStr(%objectName, 0, %inheritanceSplit);
                }
+
+               %objectName = trim(%objectName);
 
                %parentFileSectionObject = %currentFileSectionObject;
                


### PR DESCRIPTION
Adjusts formatting when parsing for object and function definitions in the project importer to be more accurate

Adds handling for progrommatic new object delcarations where the class type is defined via () encapsulated code so the project import doesn't mangle it.