### PR TITLE
Misc importer improvements to handle importing in-place more predictably

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/assetImportConfigs.xml
+++ b/Templates/BaseGame/game/tools/assetBrowser/assetImportConfigs.xml
@@ -1,243 +1,459 @@
 <?xml version="1.0" encoding="UTF-8" standalone ="yes"?>
 <AssetImportSettings>
-    <Group name="DefaultImportConfig">
-        <Group name="Animations">
-            <Setting name="animFPS">2</Setting>
-            <Setting name="animTiming">Seconds</Setting>
-            <Setting name="ImportAnimations">1</Setting>
-            <Setting name="SeparateAnimations">1</Setting>
+    <Group
+        name="DefaultImportConfig">
+        <Group
+            name="Animations">
+            <Setting
+                name="animFPS">2</Setting>
+            <Setting
+                name="animTiming">Seconds</Setting>
+            <Setting
+                name="ImportAnimations">1</Setting>
+            <Setting
+                name="SeparateAnimations">1</Setting>
         </Group>
-        <Group name="Collision">
-            <Setting name="CollisionMeshPrefix">Col</Setting>
-            <Setting name="GenCollisionType">CollisionMesh</Setting>
-            <Setting name="GenerateCollisions">1</Setting>
-            <Setting name="GenerateLOSCollisions">1</Setting>
-            <Setting name="GenLOSCollisionType">CollisionMesh</Setting>
-            <Setting name="LOSCollisionMeshPrefix">LOS</Setting>
+        <Group
+            name="Collision">
+            <Setting
+                name="CollisionMeshPrefix">Col</Setting>
+            <Setting
+                name="GenCollisionType">CollisionMesh</Setting>
+            <Setting
+                name="GenerateCollisions">1</Setting>
+            <Setting
+                name="GenerateLOSCollisions">1</Setting>
+            <Setting
+                name="GenLOSCollisionType">CollisionMesh</Setting>
+            <Setting
+                name="LOSCollisionMeshPrefix">LOS</Setting>
         </Group>
-        <Group name="General">
-            <Setting name="AddDirectoryPrefixToAssetName">0</Setting>
-            <Setting name="AutomaticallyPromptMissingFiles">0</Setting>
-            <Setting name="DuplicatAutoResolution">AutoPrune</Setting>
-            <Setting name="DuplicateAutoResolution">AutoPrune</Setting>
-            <Setting name="PreventImportWithErrors">1</Setting>
-            <Setting name="WarningsAsErrors">0</Setting>
+        <Group
+            name="General">
+            <Setting
+                name="AddDirectoryPrefixToAssetName">0</Setting>
+            <Setting
+                name="AutomaticallyPromptMissingFiles">0</Setting>
+            <Setting
+                name="DuplicatAutoResolution">AutoPrune</Setting>
+            <Setting
+                name="DuplicateAutoResolution">FolderPrefix</Setting>
+            <Setting
+                name="PreventImportWithErrors">1</Setting>
+            <Setting
+                name="WarningsAsErrors">0</Setting>
         </Group>
-        <Group name="Images">
-            <Setting name="AddedImageSuffix">_image</Setting>
-            <Setting name="AlwaysAddImageSuffix">1</Setting>
-            <Setting name="AOTypeSuffixes">_AO,_AMBIENT,_AMBIENTOCCLUSION</Setting>
-            <Setting name="CompositeTypeSuffixes">_COMP,_COMPOSITE,_PBR,-COMP,-COMPOSITE,-PBR,_ORM,-ORM,_C</Setting>
-            <Setting name="Compressed">1</Setting>
-            <Setting name="DiffuseTypeSuffixes">_ALBEDO,_DIFFUSE,_ALB,_DIF,_COLOR,_COL</Setting>
-            <Setting name="GenerateMaterialOnImport">0</Setting>
-            <Setting name="ImageType">N/A</Setting>
-            <Setting name="ImportImages">1</Setting>
-            <Setting name="IsHDR">0</Setting>
-            <Setting name="MetalnessTypeSuffixes">_METAL,_MET,_METALNESS,_METALLIC,_M</Setting>
-            <Setting name="NormalTypeSuffixes">_NORMAL,_NORM,_N</Setting>
-            <Setting name="RoughnessTypeSuffixes">_ROUGH,_ROUGHNESS,_R</Setting>
-            <Setting name="Scaling">1.0</Setting>
-            <Setting name="SmoothnessTypeSuffixes">_SMOOTH,_SMOOTHNESS,_S</Setting>
-            <Setting name="TextureFilteringMode">Bilinear</Setting>
-            <Setting name="UseMips">1</Setting>
+        <Group
+            name="Images">
+            <Setting
+                name="AddedImageSuffix">_image</Setting>
+            <Setting
+                name="AlwaysAddImageSuffix">1</Setting>
+            <Setting
+                name="AOTypeSuffixes">_AO,_AMBIENT,_AMBIENTOCCLUSION</Setting>
+            <Setting
+                name="CompositeTypeSuffixes">_COMP,_COMPOSITE,_PBR,-COMP,-COMPOSITE,-PBR,_ORM,-ORM,_C</Setting>
+            <Setting
+                name="Compressed">1</Setting>
+            <Setting
+                name="DiffuseTypeSuffixes">_ALBEDO,_DIFFUSE,_ALB,_DIF,_COLOR,_COL</Setting>
+            <Setting
+                name="GenerateMaterialOnImport">0</Setting>
+            <Setting
+                name="ImageType">N/A</Setting>
+            <Setting
+                name="ImportImages">1</Setting>
+            <Setting
+                name="IsHDR">0</Setting>
+            <Setting
+                name="MetalnessTypeSuffixes">_METAL,_MET,_METALNESS,_METALLIC,_M</Setting>
+            <Setting
+                name="NormalTypeSuffixes">_NORMAL,_NORM,_N</Setting>
+            <Setting
+                name="RoughnessTypeSuffixes">_ROUGH,_ROUGHNESS,_R</Setting>
+            <Setting
+                name="Scaling">1.0</Setting>
+            <Setting
+                name="SmoothnessTypeSuffixes">_SMOOTH,_SMOOTHNESS,_S</Setting>
+            <Setting
+                name="TextureFilteringMode">Bilinear</Setting>
+            <Setting
+                name="UseMips">1</Setting>
         </Group>
-        <Group name="Materials">
-            <Setting name="AddedMaterialSuffix">_mat</Setting>
-            <Setting name="AlwaysAddMaterialSuffix">0</Setting>
-            <Setting name="CreateComposites">1</Setting>
-            <Setting name="CreateORMConfig">1</Setting>
-            <Setting name="IgnoreMaterials">DefaultMaterial,ColorEffect*</Setting>
-            <Setting name="ImportMaterials">1</Setting>
-            <Setting name="PopulateMaterialMaps">1</Setting>
-            <Setting name="UseDiffuseSuffixOnOriginImage">1</Setting>
-            <Setting name="UseExistingMaterials">1</Setting>
+        <Group
+            name="Materials">
+            <Setting
+                name="AddedMaterialSuffix">_mat</Setting>
+            <Setting
+                name="AlwaysAddMaterialSuffix">1</Setting>
+            <Setting
+                name="CreateComposites">1</Setting>
+            <Setting
+                name="CreateORMConfig">1</Setting>
+            <Setting
+                name="IgnoreMaterials">DefaultMaterial,ColorEffect*</Setting>
+            <Setting
+                name="ImportMaterials">1</Setting>
+            <Setting
+                name="PopulateMaterialMaps">1</Setting>
+            <Setting
+                name="UseDiffuseSuffixOnOriginImage">1</Setting>
+            <Setting
+                name="UseExistingMaterials">1</Setting>
         </Group>
-        <Group name="Meshes">
-            <Setting name="AddedShapeSuffix">_shape</Setting>
-            <Setting name="AdjustCenter">0</Setting>
-            <Setting name="AdjustFloor">0</Setting>
-            <Setting name="AlwaysAddShapeSuffix">0</Setting>
-            <Setting name="calcTangentSpace">0</Setting>
-            <Setting name="CollapseSubmeshes">0</Setting>
-            <Setting name="convertLeftHanded">0</Setting>
-            <Setting name="DoScaleOverride">0</Setting>
-            <Setting name="DoUpAxisOverride">0</Setting>
-            <Setting name="findInstances">0</Setting>
-            <Setting name="flipUVCoords">0</Setting>
-            <Setting name="genUVCoords">0</Setting>
-            <Setting name="IgnoreNodeScale">0</Setting>
-            <Setting name="ImportMesh">1</Setting>
-            <Setting name="invertNormals">0</Setting>
-            <Setting name="JoinIdenticalVerts">0</Setting>
-            <Setting name="limitBoneWeights">0</Setting>
-            <Setting name="LODType">TrailingNumber</Setting>
-            <Setting name="removeRedundantMats">0</Setting>
-            <Setting name="reverseWindingOrder">0</Setting>
-            <Setting name="ScaleOverride">1</Setting>
-            <Setting name="TransformUVs">0</Setting>
-            <Setting name="UpAxisOverride">Z_AXIS</Setting>
+        <Group
+            name="Meshes">
+            <Setting
+                name="AddedShapeSuffix">_shape</Setting>
+            <Setting
+                name="AdjustCenter">0</Setting>
+            <Setting
+                name="AdjustFloor">0</Setting>
+            <Setting
+                name="AlwaysAddShapeSuffix">0</Setting>
+            <Setting
+                name="calcTangentSpace">0</Setting>
+            <Setting
+                name="CollapseSubmeshes">0</Setting>
+            <Setting
+                name="convertLeftHanded">0</Setting>
+            <Setting
+                name="DoScaleOverride">0</Setting>
+            <Setting
+                name="DoUpAxisOverride">0</Setting>
+            <Setting
+                name="findInstances">0</Setting>
+            <Setting
+                name="flipUVCoords">0</Setting>
+            <Setting
+                name="genUVCoords">0</Setting>
+            <Setting
+                name="IgnoreNodeScale">0</Setting>
+            <Setting
+                name="ImportMesh">1</Setting>
+            <Setting
+                name="invertNormals">0</Setting>
+            <Setting
+                name="JoinIdenticalVerts">0</Setting>
+            <Setting
+                name="limitBoneWeights">0</Setting>
+            <Setting
+                name="LODType">TrailingNumber</Setting>
+            <Setting
+                name="removeRedundantMats">0</Setting>
+            <Setting
+                name="reverseWindingOrder">0</Setting>
+            <Setting
+                name="ScaleOverride">1</Setting>
+            <Setting
+                name="TransformUVs">0</Setting>
+            <Setting
+                name="UpAxisOverride">Z_AXIS</Setting>
         </Group>
-        <Group name="Sounds">
-            <Setting name="Compressed">0</Setting>
-            <Setting name="PitchAdjust">1.0</Setting>
-            <Setting name="VolumeAdjust">1.0</Setting>
-        </Group>
-    </Group>
-    <Group name="LegacyProjectImport">
-        <Group name="Animations">
-            <Setting name="animFPS">2</Setting>
-            <Setting name="animTiming">Seconds</Setting>
-            <Setting name="ImportAnimations">1</Setting>
-            <Setting name="SeparateAnimations">1</Setting>
-        </Group>
-        <Group name="Collision">
-            <Setting name="CollisionMeshPrefix">Col</Setting>
-            <Setting name="GenCollisionType">CollisionMesh</Setting>
-            <Setting name="GenerateCollisions">1</Setting>
-            <Setting name="GenerateLOSCollisions">1</Setting>
-            <Setting name="GenLOSCollisionType">CollisionMesh</Setting>
-            <Setting name="LOSCollisionMeshPrefix">LOS</Setting>
-        </Group>
-        <Group name="General">
-            <Setting name="AddDirectoryPrefixToAssetName">0</Setting>
-            <Setting name="AutomaticallyPromptMissingFiles">0</Setting>
-            <Setting name="DuplicateAutoResolution">FolderPrefix</Setting>
-            <Setting name="PreventImportWithErrors">1</Setting>
-            <Setting name="WarningsAsErrors">0</Setting>
-        </Group>
-        <Group name="Images">
-            <Setting name="AddedImageSuffix">_image</Setting>
-            <Setting name="AlwaysAddImageSuffix">1</Setting>
-            <Setting name="AOTypeSuffixes">_AO,_AMBIENT,_AMBIENTOCCLUSION</Setting>
-            <Setting name="CompositeTypeSuffixes">_COMP,_COMPOSITE</Setting>
-            <Setting name="Compressed">1</Setting>
-            <Setting name="DiffuseTypeSuffixes">_ALBEDO,_DIFFUSE,_ALB,_DIF,_COLOR,_COL</Setting>
-            <Setting name="GenerateMaterialOnImport">0</Setting>
-            <Setting name="ImageType">N/A</Setting>
-            <Setting name="ImportImages">1</Setting>
-            <Setting name="IsHDR">0</Setting>
-            <Setting name="MetalnessTypeSuffixes">_METAL,_MET,_METALNESS,_METALLIC</Setting>
-            <Setting name="NormalTypeSuffixes">_NORMAL,_NORM</Setting>
-            <Setting name="RoughnessTypeSuffixes">_ROUGH,_ROUGHNESS</Setting>
-            <Setting name="Scaling">1.0</Setting>
-            <Setting name="SmoothnessTypeSuffixes">_SMOOTH,_SMOOTHNESS</Setting>
-            <Setting name="TextureFilteringMode">Bilinear</Setting>
-            <Setting name="UseMips">1</Setting>
-        </Group>
-        <Group name="Materials">
-            <Setting name="AddedMaterialSuffix">_mat</Setting>
-            <Setting name="AlwaysAddMaterialSuffix">1</Setting>
-            <Setting name="CreateComposites">1</Setting>
-            <Setting name="ImportMaterials">1</Setting>
-            <Setting name="IgnoreMaterials">DefaultMaterial,ColorEffect*</Setting>
-            <Setting name="PopulateMaterialMaps">1</Setting>
-            <Setting name="UseDiffuseSuffixOnOriginImage">1</Setting>
-            <Setting name="UseExistingMaterials">1</Setting>
-        </Group>
-        <Group name="Meshes">
-            <Setting name="AddedShapeSuffix">_shape</Setting>
-            <Setting name="AdjustCenter">0</Setting>
-            <Setting name="AdjustFloor">0</Setting>
-            <Setting name="AlwaysAddShapeSuffix">0</Setting>
-            <Setting name="calcTangentSpace">0</Setting>
-            <Setting name="CollapseSubmeshes">0</Setting>
-            <Setting name="convertLeftHanded">0</Setting>
-            <Setting name="DoScaleOverride">0</Setting>
-            <Setting name="DoUpAxisOverride">0</Setting>
-            <Setting name="findInstances">0</Setting>
-            <Setting name="flipUVCoords">0</Setting>
-            <Setting name="genUVCoords">0</Setting>
-            <Setting name="IgnoreNodeScale">0</Setting>
-            <Setting name="ImportMesh">1</Setting>
-            <Setting name="invertNormals">0</Setting>
-            <Setting name="JoinIdenticalVerts">0</Setting>
-            <Setting name="limitBoneWeights">0</Setting>
-            <Setting name="LODType">TrailingNumber</Setting>
-            <Setting name="removeRedundantMats">0</Setting>
-            <Setting name="reverseWindingOrder">0</Setting>
-            <Setting name="ScaleOverride">1</Setting>
-            <Setting name="TransformUVs">0</Setting>
-            <Setting name="UpAxisOverride">Z_AXIS</Setting>
-        </Group>
-        <Group name="Sounds">
-            <Setting name="Compressed">0</Setting>
-            <Setting name="PitchAdjust">1.0</Setting>
-            <Setting name="VolumeAdjust">1.0</Setting>
+        <Group
+            name="Sounds">
+            <Setting
+                name="Compressed">0</Setting>
+            <Setting
+                name="PitchAdjust">1.0</Setting>
+            <Setting
+                name="VolumeAdjust">1.0</Setting>
         </Group>
     </Group>
-    <Group name="NewTest">
-        <Group name="Animations">
-            <Setting name="animFPS">2</Setting>
-            <Setting name="animTiming">Seconds</Setting>
-            <Setting name="ImportAnimations">1</Setting>
-            <Setting name="SeparateAnimations">1</Setting>
+    <Group
+        name="LegacyProjectImport">
+        <Group
+            name="Animations">
+            <Setting
+                name="animFPS">2</Setting>
+            <Setting
+                name="animTiming">Seconds</Setting>
+            <Setting
+                name="ImportAnimations">1</Setting>
+            <Setting
+                name="SeparateAnimations">1</Setting>
         </Group>
-        <Group name="Collision">
-            <Setting name="CollisionMeshPrefix">Col</Setting>
-            <Setting name="GenCollisionType">CollisionMesh</Setting>
-            <Setting name="GenerateCollisions">1</Setting>
-            <Setting name="GenerateLOSCollisions">1</Setting>
-            <Setting name="GenLOSCollisionType">CollisionMesh</Setting>
-            <Setting name="LOSCollisionMeshPrefix">LOS</Setting>
+        <Group
+            name="Collision">
+            <Setting
+                name="CollisionMeshPrefix">Col</Setting>
+            <Setting
+                name="GenCollisionType">CollisionMesh</Setting>
+            <Setting
+                name="GenerateCollisions">1</Setting>
+            <Setting
+                name="GenerateLOSCollisions">1</Setting>
+            <Setting
+                name="GenLOSCollisionType">CollisionMesh</Setting>
+            <Setting
+                name="LOSCollisionMeshPrefix">LOS</Setting>
         </Group>
-        <Group name="General">
-            <Setting name="AddDirectoryPrefixToAssetName">0</Setting>
-            <Setting name="AutomaticallyPromptMissingFiles">0</Setting>
-            <Setting name="DuplicatAutoResolution">AutoPrune</Setting>
-            <Setting name="PreventImportWithErrors">1</Setting>
-            <Setting name="WarningsAsErrors">0</Setting>
+        <Group
+            name="General">
+            <Setting
+                name="AddDirectoryPrefixToAssetName">0</Setting>
+            <Setting
+                name="AutomaticallyPromptMissingFiles">0</Setting>
+            <Setting
+                name="DuplicateAutoResolution">FolderPrefix</Setting>
+            <Setting
+                name="PreventImportWithErrors">1</Setting>
+            <Setting
+                name="WarningsAsErrors">0</Setting>
         </Group>
-        <Group name="Images">
-            <Setting name="AOTypeSuffixes">_AO,_AMBIENT,_AMBIENTOCCLUSION</Setting>
-            <Setting name="Compressed">1</Setting>
-            <Setting name="DiffuseTypeSuffixes">_ALBEDO,_DIFFUSE,_ALB,_DIF,_COLOR,_COL</Setting>
-            <Setting name="GenerateMaterialOnImport">1</Setting>
-            <Setting name="ImageType">N/A</Setting>
-            <Setting name="IsHDR">0</Setting>
-            <Setting name="MetalnessTypeSuffixes">_METAL,_MET,_METALNESS,_METALLIC</Setting>
-            <Setting name="NormalTypeSuffixes">_NORMAL,_NORM</Setting>
-            <Setting name="PBRTypeSuffixes">_COMP,_COMPOSITE,_PBR,-COMP,-COMPOSITE,-PBR,_ORM,-ORM</Setting>
-            <Setting name="RoughnessTypeSuffixes">_ROUGH,_ROUGHNESS</Setting>
-            <Setting name="Scaling">1.0</Setting>
-            <Setting name="SmoothnessTypeSuffixes">_SMOOTH,_SMOOTHNESS</Setting>
-            <Setting name="TextureFilteringMode">Bilinear</Setting>
-            <Setting name="UseMips">1</Setting>
+        <Group
+            name="Images">
+            <Setting
+                name="AddedImageSuffix">_image</Setting>
+            <Setting
+                name="AlwaysAddImageSuffix">1</Setting>
+            <Setting
+                name="AOTypeSuffixes">_AO,_AMBIENT,_AMBIENTOCCLUSION</Setting>
+            <Setting
+                name="CompositeTypeSuffixes">_COMP,_COMPOSITE</Setting>
+            <Setting
+                name="Compressed">1</Setting>
+            <Setting
+                name="DiffuseTypeSuffixes">_ALBEDO,_DIFFUSE,_ALB,_DIF,_COLOR,_COL</Setting>
+            <Setting
+                name="GenerateMaterialOnImport">0</Setting>
+            <Setting
+                name="ImageType">N/A</Setting>
+            <Setting
+                name="ImportImages">1</Setting>
+            <Setting
+                name="IsHDR">0</Setting>
+            <Setting
+                name="MetalnessTypeSuffixes">_METAL,_MET,_METALNESS,_METALLIC</Setting>
+            <Setting
+                name="NormalTypeSuffixes">_NORMAL,_NORM</Setting>
+            <Setting
+                name="RoughnessTypeSuffixes">_ROUGH,_ROUGHNESS</Setting>
+            <Setting
+                name="Scaling">1.0</Setting>
+            <Setting
+                name="SmoothnessTypeSuffixes">_SMOOTH,_SMOOTHNESS</Setting>
+            <Setting
+                name="TextureFilteringMode">Bilinear</Setting>
+            <Setting
+                name="UseMips">1</Setting>
         </Group>
-        <Group name="Materials">
-            <Setting name="CreateComposites">1</Setting>
-            <Setting name="ImportMaterials">1</Setting>
-            <Setting name="PopulateMaterialMaps">1</Setting>
-            <Setting name="UseDiffuseSuffixOnOriginImage">1</Setting>
-            <Setting name="UseExistingMaterials">1</Setting>
+        <Group
+            name="Materials">
+            <Setting
+                name="AddedMaterialSuffix">_mat</Setting>
+            <Setting
+                name="AlwaysAddMaterialSuffix">1</Setting>
+            <Setting
+                name="CreateComposites">1</Setting>
+            <Setting
+                name="IgnoreMaterials">DefaultMaterial,ColorEffect*</Setting>
+            <Setting
+                name="ImportMaterials">1</Setting>
+            <Setting
+                name="PopulateMaterialMaps">1</Setting>
+            <Setting
+                name="UseDiffuseSuffixOnOriginImage">1</Setting>
+            <Setting
+                name="UseExistingMaterials">1</Setting>
         </Group>
-        <Group name="Meshes">
-            <Setting name="AdjustCenter">0</Setting>
-            <Setting name="AdjustFloor">0</Setting>
-            <Setting name="calcTangentSpace">0</Setting>
-            <Setting name="CollapseSubmeshes">0</Setting>
-            <Setting name="convertLeftHanded">0</Setting>
-            <Setting name="DoScaleOverride">0</Setting>
-            <Setting name="DoUpAxisOverride">0</Setting>
-            <Setting name="findInstances">0</Setting>
-            <Setting name="flipUVCoords">0</Setting>
-            <Setting name="genUVCoords">0</Setting>
-            <Setting name="IgnoreNodeScale">0</Setting>
-            <Setting name="ImportMesh">1</Setting>
-            <Setting name="invertNormals">0</Setting>
-            <Setting name="JoinIdenticalVerts">0</Setting>
-            <Setting name="limitBoneWeights">0</Setting>
-            <Setting name="LODType">TrailingNumber</Setting>
-            <Setting name="removeRedundantMats">0</Setting>
-            <Setting name="reverseWindingOrder">0</Setting>
-            <Setting name="ScaleOverride">1</Setting>
-            <Setting name="TransformUVs">0</Setting>
-            <Setting name="UpAxisOverride">Z_AXIS</Setting>
+        <Group
+            name="Meshes">
+            <Setting
+                name="AddedShapeSuffix">_shape</Setting>
+            <Setting
+                name="AdjustCenter">0</Setting>
+            <Setting
+                name="AdjustFloor">0</Setting>
+            <Setting
+                name="AlwaysAddShapeSuffix">0</Setting>
+            <Setting
+                name="calcTangentSpace">0</Setting>
+            <Setting
+                name="CollapseSubmeshes">0</Setting>
+            <Setting
+                name="convertLeftHanded">0</Setting>
+            <Setting
+                name="DoScaleOverride">0</Setting>
+            <Setting
+                name="DoUpAxisOverride">0</Setting>
+            <Setting
+                name="findInstances">0</Setting>
+            <Setting
+                name="flipUVCoords">0</Setting>
+            <Setting
+                name="genUVCoords">0</Setting>
+            <Setting
+                name="IgnoreNodeScale">0</Setting>
+            <Setting
+                name="ImportMesh">1</Setting>
+            <Setting
+                name="invertNormals">0</Setting>
+            <Setting
+                name="JoinIdenticalVerts">0</Setting>
+            <Setting
+                name="limitBoneWeights">0</Setting>
+            <Setting
+                name="LODType">TrailingNumber</Setting>
+            <Setting
+                name="removeRedundantMats">0</Setting>
+            <Setting
+                name="reverseWindingOrder">0</Setting>
+            <Setting
+                name="ScaleOverride">1</Setting>
+            <Setting
+                name="TransformUVs">0</Setting>
+            <Setting
+                name="UpAxisOverride">Z_AXIS</Setting>
         </Group>
-        <Group name="Sounds">
-            <Setting name="Compressed">0</Setting>
-            <Setting name="PitchAdjust">1.0</Setting>
-            <Setting name="VolumeAdjust">1.0</Setting>
+        <Group
+            name="Sounds">
+            <Setting
+                name="Compressed">0</Setting>
+            <Setting
+                name="PitchAdjust">1.0</Setting>
+            <Setting
+                name="VolumeAdjust">1.0</Setting>
+        </Group>
+    </Group>
+    <Group
+        name="NewTest">
+        <Group
+            name="Animations">
+            <Setting
+                name="animFPS">2</Setting>
+            <Setting
+                name="animTiming">Seconds</Setting>
+            <Setting
+                name="ImportAnimations">1</Setting>
+            <Setting
+                name="SeparateAnimations">1</Setting>
+        </Group>
+        <Group
+            name="Collision">
+            <Setting
+                name="CollisionMeshPrefix">Col</Setting>
+            <Setting
+                name="GenCollisionType">CollisionMesh</Setting>
+            <Setting
+                name="GenerateCollisions">1</Setting>
+            <Setting
+                name="GenerateLOSCollisions">1</Setting>
+            <Setting
+                name="GenLOSCollisionType">CollisionMesh</Setting>
+            <Setting
+                name="LOSCollisionMeshPrefix">LOS</Setting>
+        </Group>
+        <Group
+            name="General">
+            <Setting
+                name="AddDirectoryPrefixToAssetName">0</Setting>
+            <Setting
+                name="AutomaticallyPromptMissingFiles">0</Setting>
+            <Setting
+                name="DuplicatAutoResolution">AutoPrune</Setting>
+            <Setting
+                name="PreventImportWithErrors">1</Setting>
+            <Setting
+                name="WarningsAsErrors">0</Setting>
+        </Group>
+        <Group
+            name="Images">
+            <Setting
+                name="AOTypeSuffixes">_AO,_AMBIENT,_AMBIENTOCCLUSION</Setting>
+            <Setting
+                name="Compressed">1</Setting>
+            <Setting
+                name="DiffuseTypeSuffixes">_ALBEDO,_DIFFUSE,_ALB,_DIF,_COLOR,_COL</Setting>
+            <Setting
+                name="GenerateMaterialOnImport">1</Setting>
+            <Setting
+                name="ImageType">N/A</Setting>
+            <Setting
+                name="IsHDR">0</Setting>
+            <Setting
+                name="MetalnessTypeSuffixes">_METAL,_MET,_METALNESS,_METALLIC</Setting>
+            <Setting
+                name="NormalTypeSuffixes">_NORMAL,_NORM</Setting>
+            <Setting
+                name="PBRTypeSuffixes">_COMP,_COMPOSITE,_PBR,-COMP,-COMPOSITE,-PBR,_ORM,-ORM</Setting>
+            <Setting
+                name="RoughnessTypeSuffixes">_ROUGH,_ROUGHNESS</Setting>
+            <Setting
+                name="Scaling">1.0</Setting>
+            <Setting
+                name="SmoothnessTypeSuffixes">_SMOOTH,_SMOOTHNESS</Setting>
+            <Setting
+                name="TextureFilteringMode">Bilinear</Setting>
+            <Setting
+                name="UseMips">1</Setting>
+        </Group>
+        <Group
+            name="Materials">
+            <Setting
+                name="CreateComposites">1</Setting>
+            <Setting
+                name="ImportMaterials">1</Setting>
+            <Setting
+                name="PopulateMaterialMaps">1</Setting>
+            <Setting
+                name="UseDiffuseSuffixOnOriginImage">1</Setting>
+            <Setting
+                name="UseExistingMaterials">1</Setting>
+        </Group>
+        <Group
+            name="Meshes">
+            <Setting
+                name="AdjustCenter">0</Setting>
+            <Setting
+                name="AdjustFloor">0</Setting>
+            <Setting
+                name="calcTangentSpace">0</Setting>
+            <Setting
+                name="CollapseSubmeshes">0</Setting>
+            <Setting
+                name="convertLeftHanded">0</Setting>
+            <Setting
+                name="DoScaleOverride">0</Setting>
+            <Setting
+                name="DoUpAxisOverride">0</Setting>
+            <Setting
+                name="findInstances">0</Setting>
+            <Setting
+                name="flipUVCoords">0</Setting>
+            <Setting
+                name="genUVCoords">0</Setting>
+            <Setting
+                name="IgnoreNodeScale">0</Setting>
+            <Setting
+                name="ImportMesh">1</Setting>
+            <Setting
+                name="invertNormals">0</Setting>
+            <Setting
+                name="JoinIdenticalVerts">0</Setting>
+            <Setting
+                name="limitBoneWeights">0</Setting>
+            <Setting
+                name="LODType">TrailingNumber</Setting>
+            <Setting
+                name="removeRedundantMats">0</Setting>
+            <Setting
+                name="reverseWindingOrder">0</Setting>
+            <Setting
+                name="ScaleOverride">1</Setting>
+            <Setting
+                name="TransformUVs">0</Setting>
+            <Setting
+                name="UpAxisOverride">Z_AXIS</Setting>
+        </Group>
+        <Group
+            name="Sounds">
+            <Setting
+                name="Compressed">0</Setting>
+            <Setting
+                name="PitchAdjust">1.0</Setting>
+            <Setting
+                name="VolumeAdjust">1.0</Setting>
         </Group>
     </Group>
 </AssetImportSettings>

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -2491,8 +2491,10 @@ function AssetBrowser::autoImportSimpleLooseFiles(%this)
 
    while( %file !$= "" )
    {      
-      if(!strIsMatchExpr("*.asset.taml", %file) && !strIsMatchExpr("*.taml", %file) && !strIsMatchExpr("*.cached.dts", %file))
+      if(!strIsMatchExpr("*.asset.taml", %file) && !strIsMatchExpr("*.taml", %file) && !strIsMatchExpr("*.cached.dts", %file) 
+         && !strIsMatchExpr("*.cs", %file) && !strIsMatchExpr("*.tscript", %file) && !strIsMatchExpr("*.module", %file))
       {
+         %aq.clear();
          %assetsFound = AssetDatabase.findAssetLooseFile(%aq, %file);
          
          if(%assetsFound == 0)

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetImportConfigEditor.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetImportConfigEditor.tscript
@@ -33,8 +33,8 @@ function AssetImportConfigEditor::apply(%this)
 
 function AssetImportConfigList::onSelect( %this, %id, %text )
 {
-   ImportOptionsConfigList.clearFields();
-   ImportOptionsConfigList.setAutoUpdate(false); //we don't want to be updating every time we add a field in here
+   AssetImportConfigEditorInspector.clearFields();
+   AssetImportConfigEditorInspector.setAutoUpdate(false); //we don't want to be updating every time we add a field in here
    
    %this.currentConfig = %text;
    
@@ -46,7 +46,7 @@ function AssetImportConfigList::onSelect( %this, %id, %text )
    %this.populateConfigListByGroup("Animations");
    //%this.populateConfigListByGroup("Collision");
    
-   ImportOptionsConfigList.update();  
+   AssetImportConfigEditorInspector.update();  
 }
 
 function AssetImportConfigList::populateConfigListByGroup(%this, %groupName)

--- a/Templates/BaseGame/game/tools/projectImporter/importers/pre40/pre40ImporterGuis.tscript
+++ b/Templates/BaseGame/game/tools/projectImporter/importers/pre40/pre40ImporterGuis.tscript
@@ -46,12 +46,7 @@ function Pre40ImporterPage0::openPage(%this)
          
          %targetFolder = filePath(%targetFilePath);
          
-         if(!isDirectory(%targetFolder))
-         {
-            DirectoryHandler::createFolder(0, %targetFolder);
-         }
-         
-         if(!pathCopy(%file, %targetFilePath, false))
+         if(!copyFileToDestination(%file, %targetFilePath))
          {
             $ProjectImporter::log.add("Legacy Project Importer, failed to copy file: " @ %file @ " to destination: " @ %targetFilePath);
             continue;

--- a/Templates/BaseGame/game/tools/projectImporter/scripts/projectImporter.tscript
+++ b/Templates/BaseGame/game/tools/projectImporter/scripts/projectImporter.tscript
@@ -373,6 +373,28 @@ function ProjectImportWindow::addImporterPage(%this, %page)
 // functions that'll pretty much be used regardless of version being targeted
 //==============================================================================
 //==============================================================================
+// Takes a source file and attempts to copy it to the destination path.
+// If the paths are the same, we just exit out with a success indicator
+//==============================================================================
+function copyFileToDestination(%sourceFile, %destinationFile)
+{
+   %fullSourcePath = makeFullPath(%sourceFile); 
+   %fullDestPath = makeFullPath(%destinationFile); 
+   
+   if(!IsDirectory(filePath(%fullDestPath)))
+   {
+      DirectoryHandler::createFolder(0, filePath(%fullDestPath));  
+   }
+   
+   if(%fullSourcePath $= %fullDestPath)
+      return true; //no need to copy, we're already here!
+      
+   if(!pathCopy(%fullSourcePath, %fullDestPath, false))
+      return false;
+      
+   return true;
+}
+//==============================================================================
 // Runs through the files in the source directory and preprocessing them.
 // All valid files are added to a list, and script-based files are pre-parsed 
 // so the importer can easily process their contents later
@@ -1436,12 +1458,7 @@ function beginShapeImport()
       %destinationPath = %rootFileSectionObject.fileDestination;
       if(isFile(%file) && %rootFileSectionObject.isShapeFile == true && %rootFileSectionObject.imported == false)
       {    
-         if(!IsDirectory(filePath(%destinationPath)))
-         {
-            DirectoryHandler::createFolder(0, filePath(%destinationPath));  
-         }
-         
-         if(!pathCopy(%file, %destinationPath, false))
+         if(!copyFileToDestination(%file, %destinationPath))
          {
             projectImporterLog("ProjectImporter::beginShapeImport() - failed to copy shape: " @ %file @
                                     " to destination: " @ %destinationPath);
@@ -1502,12 +1519,7 @@ function beginImageImport()
       %destinationPath = %rootFileSectionObject.fileDestination;
       if(isFile(%file) && %rootFileSectionObject.isImageFile == true && %rootFileSectionObject.imported == false)
       {    
-         if(!IsDirectory(filePath(%destinationPath)))
-         {
-            DirectoryHandler::createFolder(0, filePath(%destinationPath));  
-         }
-         
-         if(!pathCopy(%file, %destinationPath, false))
+         if(!copyFileToDestination(%file, %destinationPath))
          {
             projectImporterLog("ProjectImporter::beginImageImport() - failed to copy image: " @ %file @
                                     " to destination: " @ %destinationPath);
@@ -1577,12 +1589,8 @@ function beginTerrainImport()
             %fileName = fileName(%file); 
             %filePath = filePath(%file);
          }*/
-         if(!IsDirectory(filePath(%destinationPath)))
-         {
-            DirectoryHandler::createFolder(0, filePath(%destinationPath));  
-         }
          
-         if(!pathCopy(%file, %destinationPath, false))
+         if(!copyFileToDestination(%file, %destinationPath))
          {
             projectImporterLog("ProjectImporter::beginTerrainImport() - failed to copy terrain: " @ %file @
                                     " to destination: " @ %destinationPath);
@@ -1666,12 +1674,8 @@ function beginSoundImport()
             %fileName = fileName(%file); 
             %filePath = filePath(%file);
          }*/
-         if(!IsDirectory(filePath(%destinationPath)))
-         {
-            DirectoryHandler::createFolder(0, filePath(%destinationPath));  
-         }
          
-         if(!pathCopy(%file, %destinationPath, false))
+         if(!copyFileToDestination(%file, %destinationPath))
          {
             projectImporterLog("ProjectImporter::beginSoundImport() - failed to copy sound: " @ %file @
                                     " to destination: " @ %destinationPath);
@@ -1775,7 +1779,7 @@ function beginGUIImport()
 
             //Check if we need to even copy in the first place. If we do, ensure
             //the copy actually worked
-            if((makeRelativePath(%file) !$= %destinationPath) && !pathCopy(%file, %destinationPath, false))
+            if(!copyFileToDestination(%file, %destinationPath))
             {
                projectImporterLog("ProjectImporter::beginGUIImport() - failed to copy GUI: " @ %file @
                   " to destination: " @ %destinationPath);
@@ -1888,12 +1892,7 @@ function beginLevelImport()
          %fileBase = fileBase(%destinationPath);
          %filePath = filePath(%destinationPath);
          
-         if(!IsDirectory(filePath(%destinationPath)))
-         {
-            DirectoryHandler::createFolder(0, filePath(%destinationPath));  
-         }
-         
-         if(!pathCopy(%file, %destinationPath, false))
+         if(!copyFileToDestination(%file, %destinationPath))
          {
             projectImporterLog("ProjectImporter::beginLevelImport() - failed to copy level: " @ %file @
                                     " to destination: " @ %destinationPath);


### PR DESCRIPTION
Standardizes project import copy behavior to validate if we're in-place importing to avoid erroring out needlessly with a new utility function

Fixed wrong variable preventing ImportConfig Editor from refreshing when selecting different configs
Standardized DefaultImportConfig's settings against Legacy Import setting, specifically collision resolution behavior and appending _mat suffix to materials