### PR TITLE
Tweaks handling of "invisible" files

### DIFF
--- a/Engine/source/console/fileSystemFunctions.cpp
+++ b/Engine/source/console/fileSystemFunctions.cpp
@@ -395,6 +395,15 @@ DefineEngineFunction(isFile, bool, ( const char* fileName ),,
    Con::expandScriptFilename(sgScriptFilenameBuffer, sizeof(sgScriptFilenameBuffer), cleanfilename.c_str());
 
    Torque::Path givenPath(Torque::Path::CompressPath(sgScriptFilenameBuffer));
+
+   if (givenPath.getFileName().isEmpty() && givenPath.getExtension().isNotEmpty())
+   {
+      //specially named or hidden files, like .gitignore parse incorrectly due to having
+      //"no" filename, so we adjust that
+      givenPath.setFileName(String(".") + givenPath.getExtension());
+      givenPath.setExtension("");
+   }
+
    return Torque::FS::IsFile(givenPath);
 }
 

--- a/Engine/source/core/volume.cpp
+++ b/Engine/source/core/volume.cpp
@@ -750,10 +750,6 @@ S32 MountSystem::findByPattern( const Path &inBasePath, const String &inFilePatt
 
    while ( dir->read( &attrs ) )
    {
-      // skip hidden files
-      if ( attrs.name.c_str()[0] == '.' )
-         continue;
-
       String   name( attrs.name );
 
       if ( (attrs.flags & FileNode::Directory) && inRecursive )


### PR DESCRIPTION
Tweaks handling of "invisible" files, files which start with a '.', effectively making them have no filename and only an extension.

This allows the engine to actually process and work with such files.