### PR TITLE
Fixes issue where nested callOnModules would thrash the queued exec lists from other invokes

### DIFF
--- a/Templates/BaseGame/game/core/utility/scripts/module.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/module.tscript
@@ -6,7 +6,8 @@ if (!isObject(ExecFilesList))
 function callOnModules(%functionName, %moduleGroup, %var0, %var1, %var2, %var3, %var4, %var5, %var6)
 {   
    //clear per module group file execution chain
-   ExecFilesList.empty();
+   %execArray = new ArrayObject("callOn" @ %functionName @ "_" @ %moduleGroup);
+   ExecFilesList.push_back(%execArray);
    //Get our modules so we can exec any specific client-side loading/handling
    %modulesList = ModuleDatabase.findModules(false);
    for(%i=0; %i < getWordCount(%modulesList); %i++)
@@ -23,12 +24,21 @@ function callOnModules(%functionName, %moduleGroup, %var0, %var1, %var2, %var3, 
         %module.scopeSet.call(%functionName, %var0, %var1, %var2, %var3, %var4, %var5, %var6);
    }
    
-   %execFilecount = ExecFilesList.count();
+   %execFilecount = %execArray.count();
+   
+   if($traceModuleCalls)
+   {
+      error("ExecFilesList at actual exec point:");
+      %execArray.echo();
+   }
+   
    for (%i=0;%i<%execFilecount;%i++)
    {
-        %filename = ExecFilesList.getKey(%i);
+        %filename = %execArray.getKey(%i);
         exec(%filename);
    }
+   
+   ExecFilesList.pop_back(); //cleanup
 }
 
 function loadModuleMaterials(%moduleGroup)
@@ -213,7 +223,7 @@ function SimSet::queueExec(%scopeSet, %execFilePath, %isExclusive)
       return;
    }
    
-   if(!isObject(ExecFilesList))
+   if(!isObject(ExecFilesList) || ExecFilesList.count() == 0)
    {
       error("Module::queueExec() - ExecFilesList array object doesn't exist!");
       return;
@@ -225,10 +235,11 @@ function SimSet::queueExec(%scopeSet, %execFilePath, %isExclusive)
    %fullPath = pathConcat(%moduleDef.ModulePath, %execFilePath);
    ///go through all entries
    %locked = false;
-   %execFilecount = ExecFilesList.count();
+   %execFileList = ExecFilesList.getKey(ExecFilesList.count()-1);
+   %execFilecount = %execFileList.count();
    for (%i=0;%i<%execFilecount;%i++)
    {
-        %check = ExecFilesList.getKey(%i);
+        %check = %execFileList.getKey(%i);
         //look for a substring match
         %isMatch = strIsMatchExpr("*"@ strReplace(%execFilePath,"./","/"),%check );
         if (%isMatch)
@@ -237,13 +248,13 @@ function SimSet::queueExec(%scopeSet, %execFilePath, %isExclusive)
             //and kill off any duplicates
             //do note that doing it in this order means setting exclusive twice
             //allows one to override exclusive with exclusive
-            %locked = ExecFilesList.getValue(%i);
+            %locked = %execFileList.getValue(%i);
             if ((%locked && !%isExclusive)&&($reportModuleFileConflicts))
                 error("found" SPC %execFilePath SPC "duplicate file!");
             if (%isExclusive)
             { // Replacing an existing entry, update in-place
-                ExecFilesList.setKey(%fullPath, %i);
-                ExecFilesList.setValue(%isExclusive, %i);
+                %execFileList.setKey(%fullPath, %i);
+                %execFileList.setValue(%isExclusive, %i);
                 %locked = true; //Done, but don't return and bypass trace logging below
             }
             break;
@@ -251,9 +262,9 @@ function SimSet::queueExec(%scopeSet, %execFilePath, %isExclusive)
    }
    //if we're not locked, go ahead and add it to the pile
    if (!%locked)
-       ExecFilesList.add(%fullPath,%isExclusive);
+       %execFileList.add(%fullPath,%isExclusive);
    if ($traceModuleCalls)       
-      ExecFilesList.echo();
+      %execFileList.echo();
 }
 
 function SimSet::unQueueExec(%scopeSet, %execFilePath)
@@ -269,7 +280,7 @@ function SimSet::unQueueExec(%scopeSet, %execFilePath)
       return;
    }
    
-   if(!isObject(ExecFilesList))
+   if(!isObject(ExecFilesList) || ExecFilesList.count() == 0)
    {
       error("Module::unRegisterDatablock() - ExecFilesList array object doesn't exist!");
       return;
@@ -280,23 +291,24 @@ function SimSet::unQueueExec(%scopeSet, %execFilePath)
    %fullPath = pathConcat(%moduleDef.ModulePath, %relativePath);
    ///go through all entries
    %locked = false;
-   %execFilecount = ExecFilesList.count();
+   %execFileList = ExecFilesList.getKey(ExecFilesList.count()-1);
+   %execFilecount = %execFileList.count();
    for (%i=0;%i<%execFilecount;%i++)
    {
-        %check = ExecFilesList.getKey(%i);
+        %check = %execFileList.getKey(%i);
         //look for a substring match
         %isMatch = strIsMatchExpr("*"@ %execFilePath,%check );
         if (%isMatch)
         {
             //check if we're already locked in. if not, kill it.
-            %locked = ExecFilesList.getValue(%i);
+            %locked = %execFileList.getValue(%i);
             if (!%locked)
             {
-                ExecFilesList.erase(%i);
+                %execFileList.erase(%i);
             }
         }
    }
    if ($traceModuleCalls)
-      ExecFilesList.echo();
+      %execFileList.echo();
 }
 

--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.gui
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.gui
@@ -4,15 +4,7 @@ $guiContent = new GuiControl(OptionsMenu) {
    profile = "GuiDefaultProfile";
    tooltipProfile = "GuiToolTipProfile";
    isContainer = "1";
-   canSaveDynamicFields = "1";
-      currentCategory = "Display";
-      optionsCategories = "17177";
-      pageTabIndex = "0";
-      returnGui = "MainMenuGui";
-      tamlReader = "20088";
-      tile = "0";
-      unappliedChanges = "17178";
-      useVariable = "0";
+   canSaveDynamicFields = "0";
 
    new GuiControl() {
       position = "48 56";


### PR DESCRIPTION
Also removes unwanted reference ids from the OptionsMenu gui object and disabled the ability for dynamic fields to be saved on it to prevent it from happening again.