### PR TITLE
Add funding/sponsor options for support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: [Areloch, Azaezel]
+github: Areloch
 patreon: Areloch

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [Areloch, Azaezel]
+patreon: Areloch


### PR DESCRIPTION
Adds option for people to support Jeff or Az through github (if they set it up) or Jeff through patreon. More options can be added if desired. here is more documentation on the feature https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository