### PR TITLE
Misc FIxes for 2022/04/09

### DIFF
--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -174,11 +174,6 @@ void MaterialAsset::initializeAsset()
       return;
    }
 
-   if (mMatDefinitionName == StringTable->insert("DetailBlue"))
-   {
-      bool asdfsd = true;
-   }
-
    if (size() != 0 && mScriptPath == StringTable->EmptyString())
    {
       mLoadedState = EmbeddedDefinition;

--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -1633,7 +1633,7 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
          {
             String diffuseToken = StringUnit::getUnit(activeImportConfig->DiffuseTypeSuffixes, 0, ",;\t");
             assetItem->assetName = assetItem->assetName + diffuseToken;
-            assetItem->cleanAssetName = assetItem->assetName;
+            //assetItem->cleanAssetName = assetItem->assetName;
          }
          else
          {
@@ -1642,7 +1642,7 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
             if ((materialAsset && materialAsset->assetName.compare(assetItem->assetName) == 0) || activeImportConfig->AlwaysAddImageSuffix)
             {
                assetItem->assetName = assetItem->assetName + activeImportConfig->AddedImageSuffix;
-               assetItem->cleanAssetName = assetItem->assetName;
+               //assetItem->cleanAssetName = assetItem->assetName;
             }
          }
 
@@ -1673,8 +1673,8 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
 
    if(assetItem->assetName == assetItem->cleanAssetName && activeImportConfig->AlwaysAddImageSuffix)
    {
-      assetItem->assetName = assetItem->assetName + activeImportConfig->AddedImageSuffix;
-      assetItem->cleanAssetName = assetItem->assetName;
+      if (!assetItem->assetName.endsWith(activeImportConfig->AddedImageSuffix.c_str()))
+         assetItem->assetName = assetItem->assetName + activeImportConfig->AddedImageSuffix;
    }
 
    assetItem->importStatus = AssetImportObject::Processed;
@@ -1752,8 +1752,8 @@ void AssetImporter::processMaterialAsset(AssetImportObject* assetItem)
    {
       if (activeImportConfig->AlwaysAddMaterialSuffix) //we only opt to force on the suffix if we're not obligating using the original material defs
       {
-         assetItem->assetName += activeImportConfig->AddedMaterialSuffix;
-         assetItem->cleanAssetName = assetItem->assetName;
+         if(!assetItem->assetName.endsWith(activeImportConfig->AddedMaterialSuffix.c_str()))
+            assetItem->assetName += activeImportConfig->AddedMaterialSuffix;
       }
 
       if (activeImportConfig->PopulateMaterialMaps)
@@ -1936,7 +1936,7 @@ void AssetImporter::processMaterialAsset(AssetImportObject* assetItem)
                      if (newImageAssetObj->assetName == assetItem->assetName)
                      {
                         newImageAssetObj->assetName += StringUnit::getUnit(suffixList.c_str(), 0, ",;\t");
-                        newImageAssetObj->cleanAssetName = newImageAssetObj->assetName;
+                        //newImageAssetObj->cleanAssetName = newImageAssetObj->assetName;
                      }
 
                      newImageAssetObj->imageSuffixType = ImageAsset::getImageTypeNameFromType(ImageAsset::ImageTypes::Albedo);
@@ -1954,7 +1954,7 @@ void AssetImporter::processMaterialAsset(AssetImportObject* assetItem)
                if (matchedImageTypes[t]->assetName == assetItem->assetName)
                {
                   matchedImageTypes[t]->assetName += StringUnit::getUnit(suffixList.c_str(), 0, ",;\t");
-                  matchedImageTypes[t]->cleanAssetName = matchedImageTypes[t]->assetName;
+                  //matchedImageTypes[t]->cleanAssetName = matchedImageTypes[t]->assetName;
                }
             }
          }
@@ -2000,8 +2000,8 @@ void AssetImporter::processShapeAsset(AssetImportObject* assetItem)
 
    if (activeImportConfig->AlwaysAddShapeSuffix)
    {
-      assetItem->assetName += activeImportConfig->AddedShapeSuffix;
-      assetItem->cleanAssetName = assetItem->assetName;
+      if(!assetItem->assetName.endsWith(activeImportConfig->AddedShapeSuffix.c_str()))
+         assetItem->assetName += activeImportConfig->AddedShapeSuffix;
    }
 
    S32 meshCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_meshCount"), nullptr));
@@ -2094,8 +2094,8 @@ void AssetImporter::processShapeAnimationAsset(AssetImportObject* assetItem)
 
    if (activeImportConfig->AlwaysAddShapeAnimationSuffix)
    {
-      assetItem->assetName += activeImportConfig->AddedShapeAnimationSuffix;
-      assetItem->cleanAssetName = assetItem->assetName;
+      if (!assetItem->assetName.endsWith(activeImportConfig->AddedShapeAnimationSuffix.c_str()))
+         assetItem->assetName += activeImportConfig->AddedShapeAnimationSuffix;
    }
 
    S32 animCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_animCount"), nullptr));
@@ -2237,8 +2237,8 @@ void AssetImporter::processSoundAsset(AssetImportObject* assetItem)
 
    if (activeImportConfig->AlwaysAddSoundSuffix)
    {
-      assetItem->assetName += activeImportConfig->AddedSoundSuffix;
-      assetItem->cleanAssetName = assetItem->assetName;
+      if (!assetItem->assetName.endsWith(activeImportConfig->AddedSoundSuffix.c_str()))
+         assetItem->assetName += activeImportConfig->AddedSoundSuffix;
    }
 
    assetItem->importStatus = AssetImportObject::Processed;
@@ -2916,7 +2916,7 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
    {
       Material* newMat = new Material();
       newMat->registerObject(assetName);
-      newMat->mMapTo = assetName;
+      newMat->mMapTo = assetItem->cleanAssetName;
 
       bool hasRoughness = false;
       for (U32 i = 0; i < assetItem->childAssetItems.size(); i++)

--- a/Engine/source/T3D/assets/assetImporter.h
+++ b/Engine/source/T3D/assets/assetImporter.h
@@ -914,6 +914,12 @@ public:
    /// </summary>
    Torque::Path importShapeAnimationAsset(AssetImportObject* assetItem);
 
+   /// <summary>
+   /// Iterates over all the items in the current session and acquires them, which jumpstarts the loading/init'ng process on them, making the available for use immediately
+   /// <para>@param assetItem, if null, will loop over and recurse the main import asset items, if a specific AssetImportObject is passed in, it will recurse it's children</para>
+   /// </summary>
+   void acquireAssets(AssetImportObject* assetItem = nullptr);
+
    //
    /// <summary>
    /// Gets the currently active import configuration

--- a/Engine/source/T3D/assets/assetImporter_ScriptBinding.h
+++ b/Engine/source/T3D/assets/assetImporter_ScriptBinding.h
@@ -92,7 +92,9 @@ DefineEngineMethod(AssetImporter, resolveAssetItemIssues, void, (AssetImportObje
 DefineEngineMethod(AssetImporter, importAssets, void, (),,
    "Runs the actual import action on the items.")
 {
-   return object->importAssets();
+   object->importAssets();
+
+   object->acquireAssets();
 }
 
 DefineEngineMethod(AssetImporter, getAssetItemCount, S32, (),,

--- a/Engine/source/console/fileSystemFunctions.cpp
+++ b/Engine/source/console/fileSystemFunctions.cpp
@@ -892,4 +892,20 @@ DefineEngineFunction( createPath, bool, ( const char* path ),,
    return Platform::createPath( pathName );
 }
 
+DefineEngineFunction(deleteDirectory, bool, (const char* path), ,
+   "@brief Delete a directory from the hard drive\n\n"
+
+   "@param path Name and path of the folder to delete\n"
+   "@note THERE IS NO RECOVERY FROM THIS. Deleted files are gone for good.\n"
+   "@return True if file was successfully deleted\n"
+   "@ingroup FileSystem")
+{
+   static char fileName[1024];
+   static char sandboxFileName[1024];
+
+   Con::expandScriptFilename(fileName, sizeof(fileName), path);
+   Platform::makeFullPathName(fileName, sandboxFileName, sizeof(sandboxFileName));
+
+   return Platform::deleteDirectory(sandboxFileName);
+}
 #endif // TORQUE_TOOLS

--- a/Engine/source/gui/buttons/guiIconButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiIconButtonCtrl.cpp
@@ -240,10 +240,15 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
    {
       // If there is a bitmap array then render using it.  
       // Otherwise use a standard fill.
-      if(mProfile->mUseBitmapArray && mProfile->mBitmapArrayRects.size())
+      if (mProfile->mUseBitmapArray && mProfile->mBitmapArrayRects.size())
+      {
          renderBitmapArray(boundsRect, stateMouseOver);
+      }
       else
-         renderSlightlyRaisedBox(boundsRect, mProfile);
+      {
+         drawer->drawRectFill(boundsRect, mProfile->mFillColorHL);
+         drawer->drawRect(boundsRect, mProfile->mBorderColorHL);
+      }
    }
    else
    {
@@ -258,8 +263,16 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
       }
       else
       {
-         drawer->drawRectFill(boundsRect, mProfile->mFillColorNA);
-         drawer->drawRect(boundsRect, mProfile->mBorderColorNA);
+         if (mActive)
+         {
+            drawer->drawRectFill(boundsRect, mProfile->mFillColor);
+            drawer->drawRect(boundsRect, mProfile->mBorderColor);
+         }
+         else
+         {
+            drawer->drawRectFill(boundsRect, mProfile->mFillColorNA);
+            drawer->drawRect(boundsRect, mProfile->mBorderColorNA);
+         }
       }
    }
 
@@ -302,7 +315,7 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
       } 
       else
       {
-         iconRect.set( offset + mButtonMargin, getExtent() - (mButtonMargin * 2) );
+         iconRect.set( offset + mButtonMargin, getExtent() - (Point2I(mAbs(mButtonMargin.x), mAbs(mButtonMargin.y)) * 2) );
          
          if ( mMakeIconSquare )
          {
@@ -311,6 +324,20 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
                iconRect.extent.y = iconRect.extent.x;
             else
                iconRect.extent.x = iconRect.extent.y;            
+         }
+
+         if (mIconLocation == IconLocRight)
+         {
+            iconRect.point.x = (offset.x + getWidth()) - iconRect.extent.x + mButtonMargin.x;
+         }
+         else if (mIconLocation == IconLocLeft)
+         {
+            //default state presumes left positioning
+         }
+         else if (mIconLocation == IconLocCenter)
+         {
+            iconRect.point.x = offset.x + (getWidth() / 2) - (iconRect.extent.x / 2) + mButtonMargin.x;
+            iconRect.point.y = offset.y + (getHeight() / 2) - (iconRect.extent.y / 2) + mButtonMargin.y;
          }
 
          drawer->drawBitmapStretch( mBitmap, iconRect );

--- a/Engine/source/gui/controls/guiDecoyCtrl.cpp
+++ b/Engine/source/gui/controls/guiDecoyCtrl.cpp
@@ -146,12 +146,14 @@ void GuiDecoyCtrl::onMouseMove(const GuiEvent &event)
 		GuiControl *tempControl = parent->findHitControl(localPoint);
 
 		//the decoy control has the responsibility of keeping track of the decoyed controls status
-		if(mMouseOverDecoy == false && mDecoyReference != NULL)
+		if(mMouseOverDecoy == false && mDecoyReference != NULL &&
+               !mDecoyReference->isDeleted() && !mDecoyReference->isRemoved())
 		{
 			tempControl->onMouseEnter(event);
 			mMouseOverDecoy = true;
 		}
-		else if(tempControl != mDecoyReference && mDecoyReference != NULL)
+		else if(tempControl != mDecoyReference && mDecoyReference != NULL &&
+               !mDecoyReference->isDeleted() && !mDecoyReference->isRemoved())
 		{
 			mDecoyReference->onMouseLeave(event);
 			mMouseOverDecoy = false;

--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
@@ -200,7 +200,7 @@ function OptionsMenu::apply(%this)
             //for updates
             if ( %targetVar $= "$pref::Video::displayDevice" )
             {
-               MessageBoxOK( "Change requires restart", "Please restart the game for a display device change to take effect." );
+               schedule(32, 0, "MessageBoxOK", "Change requires restart", "Please restart the game for a display device change to take effect.");
             }
             else if(startsWith(%targetVar, "$pref::PostFX::"))
             {
@@ -349,11 +349,6 @@ function populateDisplaySettingsList()
    OptionName.setText("");
    OptionDescription.setText("");
    
-   //First, lets double-check the active device is accurate. Sometimes the default value in our prefs doesn't match the active one
-   %displayDevice = getDisplayDeviceType();
-   if($changingDisplayDevice !$= "")
-      %displayDevice = $changingDisplayDevice;
-      
    %apiList = "";
    %apiCount = GFXInit::getAdapterCount();
    %apiIdx = 0;
@@ -374,7 +369,11 @@ function populateDisplaySettingsList()
    
    trim(%apiList);
    
-   OptionsMenuSettingsList.addOptionRow("Display API", "$pref::Video::DisplayAPI", %apiList, false, "",  true, "The display API used for rendering.", %displayDevice);
+   %displayDevice = OptionsMenu.getOptionVariableValue("$pref::Video::displayDevice");
+   if(%displayDevice $= "")
+      %displayDevice = getDisplayDeviceType();
+   
+   OptionsMenuSettingsList.addOptionRow("Display API", "$pref::Video::displayDevice", %apiList, false, "",  true, "The display API used for rendering.", %displayDevice);
    
    %numDevices = Canvas.getMonitorCount();
    %devicesList = "";
@@ -977,6 +976,8 @@ function MenuOptionsButton::onChange(%this)
    OptionName.setText(%optionName);
    OptionDescription.setText(%tooltipText);
    
+   if(%optionMode == 0)
+   {
    %currentValue = %this.getCurrentOption();
    if(%currentValue !$= "")
    {
@@ -995,6 +996,20 @@ function MenuOptionsButton::onChange(%this)
       }
       else
          OptionsMenu.unappliedChanges.setValue("\"" @ %saveReadyValue @ "\"", %prefIndex);
+      }
+   }
+   else if(%optionMode == 1)
+   {
+      %currentValue = %this.getValue();
+      
+      %prefIndex = OptionsMenu.unappliedChanges.getIndexFromKey(%targetVar);
+      if(%prefIndex == -1)
+      {
+         echo("Setting UnappliedChanges via add: key:" @ %targetVar @", value: " @ %currentValue);
+         OptionsMenu.unappliedChanges.add(%targetVar, "\"" @ %currentValue @ "\"" );
+      }
+      else
+         OptionsMenu.unappliedChanges.setValue("\"" @ %currentValue @ "\"", %prefIndex);
    }
    
    //Update the UI in case there's responsive logic

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
@@ -462,10 +462,17 @@ function AssetBrowser::buildMaterialAssetPreview(%this, %assetDef, %previewData,
    
       if(isObject(%assetDef.materialDefinitionName))
       {
+         //real fast, we'll be 100% sure that the image resource we need is loaded
+         %diffuseMapAssetId = %assetDef.materialDefinitionName.getDiffuseMapAsset(0);
+         if(AssetDatabase.isDeclaredAsset(%diffuseMapAssetId))
+         {
+            %diffuseMapAsset = AssetDatabase.acquireAsset(%diffuseMapAssetId);
+            AssetDatabase.releaseAsset(%diffuseMapAssetId);
+         }
          %previewShapeDef = AssetDatabase.acquireAsset("ToolsModule:previewSphereShape");
          %generatedFilePath = %previewShapeDef.generateCachedPreviewImage(256, %assetDef.materialDefinitionName);
       
-         pathCopy(%generatedFilePath, %previewFilePath);
+         pathCopy(%generatedFilePath, %previewFilePath, false);
          fileDelete(%generatedFilePath);
 
          if(!AssetDatabase.isDeclaredAsset("ToolsModule:" @ %previewAssetName))

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
@@ -290,12 +290,21 @@ function AssetBrowser::buildShapeAssetPreview(%this, %assetDef, %previewData, %f
    {
       displayEditorLoadingGui("Generating Shape Asset Preview...");
       
+      //real fast, we'll be 100% sure that the image resource we need is loaded
+      
+      %matSlot0AssetId = %assetDef.materialSlot0;
+      if(AssetDatabase.isDeclaredAsset(%matSlot0AssetId))
+      {
+         %matAsset = AssetDatabase.acquireAsset(%matSlot0AssetId);
+         AssetDatabase.releaseAsset(%matSlot0AssetId);
+      }
+      
       //This is slightly hacky, but we're going to utilize the imposter/last detail system
       //to generate our previews for us and then clean up the unneeded bits
       
       %filePath = %assetDef.generateCachedPreviewImage();
       
-      pathCopy(%filePath, %previewFilePath);
+      pathCopy(%filePath, %previewFilePath, false);
       fileDelete(%filePath); //cleanup
       
       if(!AssetDatabase.isDeclaredAsset("ToolsModule:" @ %previewAssetName))

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/popupMenus.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/popupMenus.tscript
@@ -237,6 +237,7 @@ function AssetBrowser::buildPopupMenus(%this)
    AddNewArtAssetPopup.enableItem(7, false); //shape animation
    AddNewArtAssetPopup.enableItem(13, false); //sound asset
    AddNewArtAssetPopup.enableItem(15, false); //particle effect
+   AddNewArtAssetPopup.enableItem(17, false); //cubemap
    
    if( !isObject( EditFolderPopup ) )
    {


### PR DESCRIPTION
- Changes behavior with suffix appending of asset importer so it doesn't contaminate the original "clean" name, which is used for setting the mapTo value of material definitions
- Also adds a sanity check when applying the type suffix to see if it's already there to avoid needless doubleups
- Fixes offsetting/positioning behavior on icon buttons to actually respect the icon position variable
- Adds sanity checks to ensure we're not trying to utilize a in-process-of-deleting decoy dummy
- Fixes handling of sliders in option menus to properly store and test unapplied values
- Fixes handling of display device setting to properly store and test unapplied values
- Adds additional logic to creation of shape and material asset previews to attempt to force-load dependencies to improve likelihood that they'll actually be loaded when we go to generate the preview.
- Temp disables creating cubemap 'assets' via the RMB context menu in the AB