### PR TITLE
getAssetIdByFilename loaded state fix

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -219,6 +219,11 @@ StringTableEntry ImageAsset::getAssetIdByFilename(StringTableEntry fileName)
       //acquire and bind the asset, and return it out
       imageAssetId = query.mAssetList[0];
    }
+   else
+   {
+      AssetPtr<ImageAsset> imageAsset = imageAssetId;
+      imageAsset->mLoadedState = AssetErrCode::BadFileReference;
+   }
 
    return imageAssetId;
 }

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -473,6 +473,11 @@ StringTableEntry ShapeAsset::getAssetIdByFilename(StringTableEntry fileName)
       //acquire and bind the asset, and return it out
       shapeAssetId = query.mAssetList[0];
    }
+   else
+   {
+      AssetPtr<ShapeAsset> shapeAsset = shapeAssetId;
+      shapeAsset->mLoadedState = AssetErrCode::BadFileReference;
+   }
 
    return shapeAssetId;
 }


### PR DESCRIPTION
getAssetIdByFilename should set the <type>Asset->mLoadedState = AssetErrCode::BadFileReference; so we know we're using a fallback