### PR TITLE
drop the prior requirement for a createcomposite to have a minimum of…

### DIFF
--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -1238,7 +1238,7 @@ GFXTextureObject *GFXTextureManager::createCompositeTexture(GBitmap*bmp[4], U32 
          if (bmp[2])
             bChan = bmp[2]->getChanelValueAt(x, y, inputKey[2]);
          else
-            bChan = 255;
+            bChan = 0;
 
          if (bmp[3])
             aChan = bmp[3]->getChanelValueAt(x, y, inputKey[3]);

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -491,7 +491,7 @@ void ProcessedMaterial::_setStageData()
       }
       else
       {
-         if ((mMaterial->getRoughMap(i) != StringTable->EmptyString()) && (mMaterial->getMetalMap(i) != StringTable->EmptyString()))
+         if ((mMaterial->getAOMap(i) != StringTable->EmptyString()) || (mMaterial->getRoughMap(i) != StringTable->EmptyString()) || (mMaterial->getMetalMap(i) != StringTable->EmptyString()))
          {
             U32 inputKey[4];
             inputKey[0] = mMaterial->mAOChan[i];


### PR DESCRIPTION
… roughness and metalness. also kick it off if it's got just an ao map.