### PR TITLE
Github actions CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,55 @@
+name: CMake
+
+on:
+  push:
+    branches: [ Preview4_0 ]
+  pull_request:
+    branches: [ Preview4_0 ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Setup Environment
+      run:   |
+             if [ "$RUNNER_OS" == "Linux" ]; then
+                  sudo apt-get install -y \
+                    build-essential \
+                    nasm \
+                    libogg-dev \
+                    libxft-dev \
+                    libx11-dev \
+                    libxxf86vm-dev \
+                    libopenal-dev \
+                    libfreetype6-dev \
+                    libxcursor-dev \
+                    libxinerama-dev \
+                    libxi-dev \
+                    libxrandr-dev \
+                    libxss-dev \
+                    libglu1-mesa-dev \
+                    libgtk-3-dev
+             fi
+      shell: bash
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -G Ninja -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DTORQUE_APP_NAME=Torque3D
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}


### PR DESCRIPTION
Based on the CMake template, builds for win/mac/linux. Build only, no tests or artifacts at this point. Uses Ninja as the build system for speed.

You should be able to merge this and have it Just Work (TM), at least it definitely Just Worked (TM) on my fork repo. Build takes a hot minute to run though, and the mac target fails without the patches from #771.