### PR TITLE
Misc Fixes for 2022/05/10

### DIFF
--- a/Templates/BaseGame/game/core/rendering/scripts/graphicsOptions.tscript
+++ b/Templates/BaseGame/game/core/rendering/scripts/graphicsOptions.tscript
@@ -687,7 +687,7 @@ function AutodetectGraphics_Apply(%shaderVer, %intel, %videoMem )
          $pref::PostFX::EnableVignette = false;
          
          $pref::Video::AA = 0;
-         $pref::Video::disableVerticalSync = 0;
+         $pref::Video::defaultAnisotropy = 0;
       }
       else
       {
@@ -713,7 +713,7 @@ function AutodetectGraphics_Apply(%shaderVer, %intel, %videoMem )
          $pref::PostFX::EnableVignette = false;
          
          $pref::Video::AA = 0;
-         $pref::Video::disableVerticalSync = 0;
+         $pref::Video::defaultAnisotropy = 0;
       }
    }   
    else
@@ -743,7 +743,7 @@ function AutodetectGraphics_Apply(%shaderVer, %intel, %videoMem )
          $pref::PostFX::EnableVignette = true;
          
          $pref::Video::AA = 4;
-         $pref::Video::disableVerticalSync = 16;
+         $pref::Video::defaultAnisotropy = 16;
       }
       else if ( %videoMem > 400 || %videoMem == 0 )
       {
@@ -769,7 +769,7 @@ function AutodetectGraphics_Apply(%shaderVer, %intel, %videoMem )
          $pref::PostFX::EnableVignette = true;
          
          $pref::Video::AA = 4;
-         $pref::Video::disableVerticalSync = 4;
+         $pref::Video::defaultAnisotropy = 4;
          
          if ( %videoMem == 0 )
             echo("Torque was unable to detect available video memory. Applying 'Medium' quality.");
@@ -798,7 +798,7 @@ function AutodetectGraphics_Apply(%shaderVer, %intel, %videoMem )
          $pref::PostFX::EnableVignette = false;
          
          $pref::Video::AA = 0;
-         $pref::Video::disableVerticalSync = 0;
+         $pref::Video::defaultAnisotropy = 0;
       }
    }
    

--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
@@ -308,6 +308,13 @@ function OptionsMenu::refresh(%this)
       %command = %this.optionsCategories.getValue(%this.currentCategory);
       eval(%command);
    }
+   
+   //now, because we reconstruct the displayed set, we'll force the mouse(if we're using it as our input)
+   //to be poked so we can re-track to whatever control, if any, we're over
+   if($activeControllerType !$= "gamepad")
+   {
+      Canvas.setCursorPos(Canvas.getCursorPos());  
+   }
 }
 
 function OptionsMenu::getOptionVariableValue(%this, %variableName)

--- a/Templates/BaseGame/game/data/UI/scripts/profiles.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/profiles.tscript
@@ -348,7 +348,7 @@ new GuiControlProfile( GuiPopupMenuItemBorder : GuiButtonProfile )
    fixedExtent = false;
    justify = "center";
    canKeyFocus = false;
-   bitmap = "data/ui/images/button";
+   bitmapAsset = "UI:menubutton_image";
    category = "Core";
 };
 

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -671,10 +671,17 @@ function AssetBrowser::loadDirectories( %this )
       
    if(%this.selectMode)
    {
+      //Due to a fluke in how this tracks, it overrides the current addres, so we'll
+      //store it real fast
+      %curAdd = AssetBrowser.dirHandler.currentAddress;
+      
+      //Disable these for this go
       AssetBrowser-->filterTree.addSelection(AssetBrowser-->filterTree.collectionsIdx);
       AssetBrowser-->filterTree.addSelection(AssetBrowser-->filterTree.creatorIdx);
-      
       AssetBrowser-->filterTree.hideSelection();
+      AssetBrowser-->filterTree.clearSelection();
+      
+      AssetBrowser.dirHandler.currentAddress = %curAdd;
    }
    
    %this.dirHandler.loadFolders("data", %dataItem);
@@ -699,49 +706,6 @@ function AssetBrowser::loadDirectories( %this )
       %toolsItem = AssetBrowser-->filterTree.insertItem(AssetBrowser-->filterTree.modulesIdx, "tools");
       %this.dirHandler.loadFolders("tools", %toolsItem);
    }
-   
-   //Add Non-Asset Scripted Objects. Datablock, etc based
-   /*%category = getWord( %breadcrumbPath, 1 );                  
-   %dataGroup = "DataBlockGroup";
-   
-   if(%dataGroup.getCount() != 0)
-   {
-      %scriptedItem = AssetBrowser-->filterTree.insertItem(1, "Scripted");
-      
-      for ( %i = 0; %i < %dataGroup.getCount(); %i++ )
-      {
-         %obj = %dataGroup.getObject(%i);
-         // echo ("Obj: " @ %obj.getName() @ " - " @ %obj.category );
-         
-         //if ( %obj.category $= "" && %obj.category == 0 )
-         //   continue;
-         
-         %dbFilename = %obj.getFileName();
-         %dbFilePath = filePath(%dbFilename);
-         
-         if(%breadcrumbPath $= %dbFilePath)
-         {
-         
-         //if ( %breadcrumbPath $= "" )
-         //{         
-            %catItem = AssetBrowser-->filterTree.findItemByName(%obj.category);
-            
-            if(%catItem == 0)
-               AssetBrowser-->filterTree.insertItem(%scriptedItem, %obj.category, "scripted");
-            /*%ctrl = %this.findIconCtrl( %obj.category );
-            if ( %ctrl == -1 )
-            {
-               %this.addFolderIcon( %obj.category );
-            }*/
-         //}
-         /*else if ( %breadcrumbPath $= %obj.category )
-         {            
-            AssetBrowser-->filterTree.insertItem(%scriptedItem, %obj.getName());
-         }*/
-         //}
-      //}
-  // }
-   
    
    AssetBrowser-->filterTree.buildVisibleTree(true);
    
@@ -768,9 +732,6 @@ function AssetBrowser::loadDirectories( %this )
       AssetBrowser-->filterTree.selectItem(%newModuleItem);
       AssetBrowser.newModuleId = ""; 
    }
-   
-   //%dataItem = AssetBrowser-->filterTree.findItemByName("data");
-   //AssetBrowser-->filterTree.expandItem(%dataItem);
    
    AssetBrowser.dirHandler.expandTreeToAddress(AssetBrowser.dirHandler.currentAddress);
    
@@ -1476,6 +1437,40 @@ function AssetBrowser::doRebuildAssetArray(%this)
 
    %finalAssetCount = 0;
    
+   //Add folders
+   if(EditorSettings.value("Assets/Browser/showFolders", true) == true)
+   {
+      %folders = getDirectoryList(%breadcrumbPath);
+      for(%f=0; %f < getFieldCount(%folders); %f++)
+      {
+         %folderName = getField(%folders, %f);
+         
+         %searchActive = AssetSearchTerms.count() != 0;
+         if(%searchActive)
+         {
+            if(matchesSearch(%folderName, "Folder", ""))
+            {
+               $AssetBrowser::AssetArray.add( %breadcrumbPath, "Folder" TAB %folderName );
+               continue;
+            }
+         }
+         else
+         {
+            //got it.	
+            if(%folderName $= "shaderCache" || %folderName $= "cache" || %folderName $= ".git")
+               continue;
+               
+            if(!%this.coreModulesFilter && %folderName $= "core" && %breadcrumbPath $= "")
+               continue;
+               
+            if(!%this.toolsModulesFilter && %folderName $= "tools" && %breadcrumbPath $= "")
+               continue;
+               
+            $AssetBrowser::AssetArray.add( %breadcrumbPath, "Folder" TAB %folderName );
+         }
+      }
+   }
+   
     //now, we'll iterate through, and find the assets that are in this module, and this category
     for( %i=0; %i < %numAssetsFound; %i++)
     {
@@ -1541,40 +1536,6 @@ function AssetBrowser::doRebuildAssetArray(%this)
                if(%assetType !$= "Folder")
                   %finalAssetCount++;
             }
-         }
-      }
-   }
-   
-   //Add folders
-   if(EditorSettings.value("Assets/Browser/showFolders", true) == true)
-   {
-      %folders = getDirectoryList(%breadcrumbPath);
-      for(%f=0; %f < getFieldCount(%folders); %f++)
-      {
-         %folderName = getField(%folders, %f);
-         
-         %searchActive = AssetSearchTerms.count() != 0;
-         if(%searchActive)
-         {
-            if(matchesSearch(%folderName, "Folder", ""))
-            {
-               $AssetBrowser::AssetArray.add( %breadcrumbPath, "Folder" TAB %folderName );
-               continue;
-            }
-         }
-         else
-         {
-            //got it.	
-            if(%folderName $= "shaderCache" || %folderName $= "cache" || %folderName $= ".git")
-               continue;
-               
-            if(!%this.coreModulesFilter && %folderName $= "core" && %breadcrumbPath $= "")
-               continue;
-               
-            if(!%this.toolsModulesFilter && %folderName $= "tools" && %breadcrumbPath $= "")
-               continue;
-               
-            $AssetBrowser::AssetArray.add( %breadcrumbPath, "Folder" TAB %folderName );
          }
       }
    }

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
@@ -530,7 +530,7 @@ function AssetBrowser::generateMaterialAssetPreviewImage(%this, %previewButton, 
          }
       }
       
-         %previewButton.bitmapAsset = %previewAssetName;
+         %previewButton.bitmapAsset = "ToolsModule:" @ %previewAssetName;
          return true;
    }
    }

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
@@ -362,12 +362,8 @@ function AssetBrowser::generateShapeAssetPreviewImage(%this, %previewButton, %fo
             return false; //failed to register the preview image for some reason?
    }
    }
-   else
-   {
-         %previewAssetName = "ToolsModule:" @ %previewAssetName;
-   }
    
-      %previewButton.bitmapAsset = %previewAssetName;
+      %previewButton.bitmapAsset = "ToolsModule:" @ %previewAssetName;
       return true;
    }
    else

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/terrainMaterial.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/terrainMaterial.tscript
@@ -201,7 +201,7 @@ function AssetBrowser::generateTerrainMaterialAssetPreviewImage(%this, %previewB
          }
       }
       
-         %previewButton.bitmapAsset = %previewAssetName;
+         %previewButton.bitmapAsset = "ToolsModule:" @ %previewAssetName;
          return true;
    }
    }

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/directoryHandling.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/directoryHandling.tscript
@@ -91,38 +91,6 @@ function directoryHandler::navigateTo(%this, %address, %historyNav, %selectionNa
    
    //break down the address
    %folderCount = getTokenCount(%address, "/");
-      
-   /*%rebuiltPath = "";
-   for(%f=0; %f < %folderCount; %f++)
-   {
-      %folderName = getToken(%address, "/", %f);
-      
-      %rebuiltPath = %f == 0 ? %folderName : %rebuiltPath @ "/" @ %folderName;
-      
-      %folderNavButton = new GuiButtonCtrl()
-      {
-         profile = ToolsGuiButtonProfile;
-         text = %folderName;
-         command = "AssetBrowser.navigateTo(\"" @ %rebuiltPath @ "\");";
-         extent = "100" SPC AssetBrowser_BreadcrumbBar.extent.y;
-      };
-      
-      AssetBrowser_BreadcrumbBar.add(%folderNavButton);
-      
-      if(%f != %folderCount-1)
-      {
-         %folderSpacerButton = new GuiBitmapButtonCtrl()
-         {
-            profile = ToolsGuiButtonProfile;
-            bitmapAsset = "ToolsModule:rightArrowWhite_image";
-            bitmapMode = "Centered";
-            extent = "25" SPC AssetBrowser_BreadcrumbBar.extent.y;
-            //command = "AssetBrowser.navigateTo(\"" @ %rebuiltPath @ "\");";
-         };
-         
-         AssetBrowser_BreadcrumbBar.add(%folderSpacerButton);
-      }
-   }*/
 
    //find our folder tree and action on it tree
    %folderId = %this.getFolderTreeItemFromAddress(%address);

--- a/Templates/BaseGame/game/tools/guiEditor/scripts/guiEditorCanvas.ed.tscript
+++ b/Templates/BaseGame/game/tools/guiEditor/scripts/guiEditorCanvas.ed.tscript
@@ -81,7 +81,7 @@ function GuiEditCanvas::onCreateMenu(%this)
          internalName = "FileMenu";
          
          item[0] = "New Gui..." TAB %cmdCtrl SPC "N" TAB %this @ ".create();";
-         item[1] = "Open..." TAB %cmdCtrl SPC "O" TAB %this @ ".open();";
+         item[1] = "Open GUI File..." TAB %cmdCtrl SPC "O" TAB %this @ ".open();";
          item[2] = "Save" TAB %cmdCtrl SPC "S" TAB %this @ ".save( false, true );";
          item[3] = "Save As..." TAB %cmdCtrl @ "-Shift S" TAB %this @ ".save( false );";
          item[4] = "Save Selected As..." TAB %cmdCtrl @ "-Alt S" TAB %this @ ".save( true );";


### PR DESCRIPTION
- Fixed graphical level values to set defaultAnisotropy instead of vsync
- Forced update of cursor position when using keyboard/mouse on options menu when changing an option to re-establish focus after refresh
- Updated missed bitmap field on GuiPopupMenuItemBorder to use assetId
- Made folders display before other preview entries in the AB for ease of navigation
- Fixed issue where when re-opening the AB the path would reset, especially with select mode
- Fixed issue when generating previews for materials, terrain materials and shapes where the very first time the preview generated it wouldn't map correctly
- Cleaned up some old commented code blocks
- Added text to the Open menubar entry in the GUIEditor to indicate it opens files specifically to add clarity