### PR TITLE
Better allocator for TorqueScript temp conversions during interpretation

### DIFF
--- a/Engine/source/console/console.cpp
+++ b/Engine/source/console/console.cpp
@@ -46,29 +46,28 @@
 extern StringStack STR;
 extern ConsoleValueStack<4096> gCallStack;
 
-Vector<ConsoleValue::ConversionBuffer> ConsoleValue::sConversionBuffer;
+DataChunker ConsoleValue::sConversionAllocator;
 
 void ConsoleValue::init()
 {
-   sConversionBuffer.reserve(8192);
+   sConversionAllocator.setChunkSize(8092);
 }
 
 void ConsoleValue::resetConversionBuffer()
 {
-   sConversionBuffer.resetAndTreatAsScratchBuffer();
+   sConversionAllocator.freeBlocks();
 }
 
 char* ConsoleValue::convertToBuffer() const
 {
-   ConversionBuffer conversion;
+   char* buffer = static_cast<char*>(sConversionAllocator.alloc(32));
    
    if (type == ConsoleValueType::cvFloat)
-      dSprintf(conversion.buffer, ConversionBufferStride, "%.9g", f);
+      dSprintf(buffer, 32, "%.9g", f);
    else
-      dSprintf(conversion.buffer, ConversionBufferStride, "%lld", i);
+      dSprintf(buffer, 32, "%lld", i);
 
-   sConversionBuffer.push_back(std::move(conversion));
-   return sConversionBuffer.last().buffer;
+   return buffer;
 }
 
 const char* ConsoleValue::getConsoleData() const

--- a/Engine/source/console/console.h
+++ b/Engine/source/console/console.h
@@ -146,17 +146,7 @@ class ConsoleValue
 
    S32 type;
 
-   enum Constants
-   {
-      ConversionBufferStride = 32
-   };
-
-   struct ConversionBuffer
-   {
-      char buffer[ConversionBufferStride];
-   };
-   
-   static Vector<ConversionBuffer> sConversionBuffer;
+   static DataChunker sConversionAllocator;
 
    char* convertToBuffer() const;
 

--- a/Engine/source/core/util/tVector.h
+++ b/Engine/source/core/util/tVector.h
@@ -160,7 +160,6 @@ class Vector
    void erase(U32 index, U32 count);
    void erase_fast(iterator);
    void clear();
-   void resetAndTreatAsScratchBuffer();
    void compact();
    void sort(compare_func f);
    void fill( const T& value );
@@ -527,15 +526,6 @@ template<class T> inline const T& Vector<T>::last() const
 template<class T> inline void Vector<T>::clear()
 {
    destroy(0, mElementCount);
-   mElementCount = 0;
-}
-
-/// This method sets the vector as its 0 and will overwrite memory on subsequent usage.
-/// Note that the current memory in use is never freed or deallocated, so only use this if the vector
-/// is being used as a scratch buffer only.
-template<class T> inline
-void Vector<T>::resetAndTreatAsScratchBuffer()
-{
    mElementCount = 0;
 }
 


### PR DESCRIPTION
instead of using a Vector<> that never frees and grows for torquescript temporaries created when doing type conversions. The old one technically leaked hard. Especially for large scripts that run per frame.