### PR TITLE
Fix edgecase where empty string was not being explicitly set to 0 in …

### DIFF
--- a/Engine/source/console/console.h
+++ b/Engine/source/console/console.h
@@ -229,8 +229,10 @@ public:
          return f;
       if (type == ConsoleValueType::cvInteger)
          return i;
-      if (isStringType())
-         return dAtof(s);
+      if (type == ConsoleValueType::cvSTEntry)
+         return s == StringTable->EmptyString() ? 0.0f : dAtof(s);
+      if (type == ConsoleValueType::cvString)
+         return dStrcmp(s, "") == 0 ? 0.0f : dAtof(s);
       return dAtof(getConsoleData());
    }
 
@@ -240,8 +242,10 @@ public:
          return i;
       if (type == ConsoleValueType::cvFloat)
          return f;
-      if (isStringType())
-         return dAtoi(s);
+      if (type == ConsoleValueType::cvSTEntry)
+         return s == StringTable->EmptyString() ? 0 : dAtoi(s);
+      if (type == ConsoleValueType::cvString)
+         return dStrcmp(s, "") == 0 ? 0 : dAtoi(s);
       return dAtoi(getConsoleData());
    }
 
@@ -265,8 +269,10 @@ public:
          return (bool)i;
       if (type == ConsoleValueType::cvFloat)
          return (bool)f;
-      if (isStringType())
-         return dAtob(s);
+      if (type == ConsoleValueType::cvSTEntry)
+         return s == StringTable->EmptyString() ? false : dAtob(s);
+      if (type == ConsoleValueType::cvString)
+         return dStrcmp(s, "") == 0 ? false : dAtob(s);
       return dAtob(getConsoleData());
    }
 


### PR DESCRIPTION
…torquescript when used as integers/floats/bools.

We found this in the setInventory standard module. in setInventory, %max was being set to empty string, but being compared to 0 during TorqueScript comparison ops. I knew to look in ConsoleValue's type conversion functions, as the interpreter internally uses ConsoleValues when working with torquescript variables under the hood. ConsoleValue is responsible for handling all type conversions on the fly as needed inside of the core interpreter logic.