### PR TITLE
Misc Fixes for 2022/05/24

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -221,8 +221,7 @@ StringTableEntry ImageAsset::getAssetIdByFilename(StringTableEntry fileName)
    }
    else
    {
-      AssetPtr<ImageAsset> imageAsset = imageAssetId;
-      imageAsset->mLoadedState = AssetErrCode::BadFileReference;
+      AssetPtr<ImageAsset> imageAsset = imageAssetId; //ensures the fallback is loaded
    }
 
    return imageAssetId;

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -475,8 +475,7 @@ StringTableEntry ShapeAsset::getAssetIdByFilename(StringTableEntry fileName)
    }
    else
    {
-      AssetPtr<ShapeAsset> shapeAsset = shapeAssetId;
-      shapeAsset->mLoadedState = AssetErrCode::BadFileReference;
+      AssetPtr<ShapeAsset> shapeAsset = shapeAssetId; //ensures the fallback is loaded
    }
 
    return shapeAssetId;

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -419,6 +419,8 @@ bool TSStatic::_createShape()
       // Reapply the current skin
       mAppliedSkinName = "";
       reSkin();
+
+      updateMaterials();
    }
 
    prepCollision();
@@ -1618,8 +1620,6 @@ void TSStatic::updateMaterials()
          }
       }
    }
-
-   mChangingMaterials.clear();
 
    // Initialize the material instances
    mShapeInstance->initMaterialList();

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/looseFileAudit.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/looseFileAudit.tscript
@@ -128,8 +128,8 @@ function LooseFileAuditWindow::refresh(%this)
 
    while( %file !$= "" )
    {      
-      //%filename = fileName(%file);
-      //%filePath = filePath(%file);
+      if(!endsWith(%file, ".cached.dts"))
+      {
       if(!strIsMatchExpr("*.asset.taml", %file) && !strIsMatchExpr("*.taml", %file))
       {
          %assetsFound = AssetDatabase.findAssetLooseFile(%aq, %file);
@@ -137,6 +137,7 @@ function LooseFileAuditWindow::refresh(%this)
          if(%assetsFound == 0)
          {
             LooseFileList.insertItem(1, %file); 
+            }
          }
       }
       

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/popupMenus.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/popupMenus.tscript
@@ -216,7 +216,7 @@ function AssetBrowser::buildPopupMenus(%this)
          Item[ 9 ] = "-";
          Item[ 10 ] = "Delete Module" TAB "" TAB "AssetBrowser.deleteModule();";
          item[ 11 ] = "-";
-         item[ 12 ] = "Import Loose Files" TAB "" TAB "AssetBrowser.importLooseFiles();";
+         item[ 12 ] = "View Loose Files" TAB "" TAB "AssetBrowser.importLooseFiles();";
       };
    }
    
@@ -254,7 +254,7 @@ function AssetBrowser::buildPopupMenus(%this)
          item[ 4 ] = "-";
          item[ 5 ] = "Delete Folder" TAB "" TAB "AssetBrowser.deleteAsset();";
          item[ 6 ] = "-";
-         item[ 7 ] = "Import Loose Files" TAB "" TAB "AssetBrowser.importLooseFiles();";
+         item[ 7 ] = "View Loose Files" TAB "" TAB "AssetBrowser.importLooseFiles();";
       };
    }
    
@@ -326,9 +326,7 @@ function AssetBrowser::buildPopupMenus(%this)
          superClass = "MenuBuilder";
          class = "EditorWorldMenu";
          
-         item[ 0 ] = "Import Project Loose Files" TAB "" TAB "AssetBrowser.importLooseFiles();";
-         Item[ 1 ] = "-";
-         item[ 2 ] = "Import new assets" TAB "" TAB "Canvas.pushDialog(AssetImportCtrl);";
+         item[ 1 ] = "Import new assets" TAB "" TAB "Canvas.pushDialog(AssetImportCtrl);";
       };
    }
    


### PR DESCRIPTION
- Removes erroneous assignment of loaded state onto fallback assets when we fail to find an assetId by filename for image and shape assets
- Fixed handling of TSStatics' materialSlot fields, where if the field has been changed, it properly loads the modified field and ensures the reskin action happens correctly.
- Changed text on some context popup menu to better indicate the action Views loose files, not imports them
- Makes the Loose File Viewer skip cached.dts files.