### PR TITLE
BugFix: Correct invalid fall-through behavior in sdlInputManager.cpp.

### DIFF
--- a/Engine/source/platformSDL/sdlInputManager.cpp
+++ b/Engine/source/platformSDL/sdlInputManager.cpp
@@ -303,6 +303,7 @@ void SDLInputManager::processEvent(SDL_Event &evt)
    {
       onSDLDeviceDisconnected_callback(evt.jdevice.which);
       closeJoystick(evt.jdevice.which);
+      break;
    }
 
    case SDL_CONTROLLERAXISMOTION:


### PR DESCRIPTION
This PR addresses a simple incorrect fall through in a switch case in the SDL InputManager.