### PR TITLE
set convexshape to use a standard vertex type

### DIFF
--- a/Engine/source/T3D/convexShape.h
+++ b/Engine/source/T3D/convexShape.h
@@ -77,9 +77,6 @@ GFXDeclareVertexFormat( ConvexVert )
 
 class PhysicsBody;
 
-// Define our vertex format here so we don't have to
-// change it in multiple spots later
-typedef ConvexVert VertexType;
 
 class ConvexShape : public SceneObject
 {
@@ -99,6 +96,10 @@ public:
    // Declaring these structs directly within ConvexShape to prevent
    // the otherwise excessively deep scoping we had.
    // eg. ConvexShape::Face::Triangle ...
+
+   // Define our vertex format here so we don't have to
+   // change it in multiple spots later
+   typedef GFXVertexPNTTB VertexType;
 
    struct Edge
    {


### PR DESCRIPTION
we were seeing vert type vs shadergen mismatches. this is a route to conform the former to the latter, which avoids generating a unique shader/processedmaterial combo