### PR TITLE
BaseGame Template: Fix script assert on canceling game options changes

### DIFF
--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
@@ -141,7 +141,7 @@ function OptionsMenu::canClose(%this)
       if(%this.unappliedChanges.count() != 0)
       {
          MessageBoxOKCancel("Discard Changes?", "You have unapplied changes to your settings, do you wish to apply or discard them?", 
-                        "OptionsMenu.apply(); MainMenuGUI.popPage();", "%this.unappliedChanges.empty(); " @ %this @ ".navigation.popPage();", 
+                        "OptionsMenu.apply(); MainMenuGUI.popPage();", "" @ %this @ ".unappliedChanges.empty(); " @ %this @ ".navigation.popPage();", 
                         "Apply", "Discard");
          return false;
       }


### PR DESCRIPTION
Resolves `Script Warning: Variable %this referenced before used when compiling script. File: (null) Line: 1` assert when backing out of options and not selecting to save changes.
