### PR TITLE
Use screen space coordinates for mouse pointer position

### DIFF
--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -549,8 +549,7 @@ void GuiCanvas::setCursorPos(const Point2I &pt)
    }
    else
    {
-      Point2I screenPt( mPlatformWindow->clientToScreen( pt ) );
-      mPlatformWindow->setCursorPosition( screenPt.x, screenPt.y ); 
+      mPlatformWindow->setCursorPosition(pt.x, pt.y);
    }
 }
 

--- a/Engine/source/windowManager/sdl/sdlCursorController.cpp
+++ b/Engine/source/windowManager/sdl/sdlCursorController.cpp
@@ -64,17 +64,12 @@ S32 PlatformCursorControllerSDL::getDoubleClickHeight()
 
 void PlatformCursorControllerSDL::setCursorPosition( S32 x, S32 y )
 {
-   if( PlatformWindowManager::get() && PlatformWindowManager::get()->getFirstWindow() )
-   {
-      AssertFatal( dynamic_cast<PlatformWindowSDL*>( PlatformWindowManager::get()->getFirstWindow() ), "");
-      PlatformWindowSDL *window = static_cast<PlatformWindowSDL*>( PlatformWindowManager::get()->getFirstWindow() );
-      SDL_WarpMouseInWindow(window->getSDLWindow(), x, y);
-   }
+   SDL_WarpMouseGlobal(x, y);
 }
 
 void PlatformCursorControllerSDL::getCursorPosition( Point2I &point )
 {
-   SDL_GetMouseState( &point.x, &point.y );
+   SDL_GetGlobalMouseState( &point.x, &point.y );
 }
 
 void PlatformCursorControllerSDL::setCursorVisible( bool visible )


### PR DESCRIPTION
Done in order to be consistent with existing engine comments, API help doc string, and how it used to work in Win32 window management code.

- Fixes mouse pointer jump when changing game options while using windowed non-borderless mode.
- This should also prevent any confusion and hassle when working with multiple graphics context windows. Previously it was first graphics context window oriented.

