### PR TITLE
Disconnect and Shutdown fixes

### DIFF
--- a/Engine/source/shaderGen/featureMgr.cpp
+++ b/Engine/source/shaderGen/featureMgr.cpp
@@ -32,7 +32,7 @@
 MODULE_BEGIN( ShaderGenFeatureMgr )
 
    MODULE_INIT_BEFORE( ShaderGen )
-   MODULE_SHUTDOWN_AFTER( Sim ) // allow registered features to be removed before destroying singleton
+   MODULE_SHUTDOWN_AFTER(Scene)
 
    MODULE_INIT
    {

--- a/Templates/BaseGame/game/core/clientServer/scripts/client/connectionToServer.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/client/connectionToServer.tscript
@@ -71,6 +71,20 @@ function GameConnection::onControlObjectChange(%this)
    //turnOffZoom();
 }
 
+function GameConnection::onConnectionTimedOut(%this)
+{
+   // Called when an established connection times out
+   disconnectedCleanup();
+   MessageBoxOK( "TIMED OUT", "The server connection has timed out.");
+}
+
+function GameConnection::onConnectionDropped(%this, %msg)
+{
+   // Established connection was dropped by the server
+   disconnectedCleanup();
+   MessageBoxOK( "DISCONNECT", "The server has dropped the connection: " @ %msg);
+}
+
 function GameConnection::onConnectionError(%this, %msg)
 {
    // General connection error, usually raised by ghosted objects

--- a/Templates/BaseGame/game/data/UI/guis/mainMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/mainMenu.tscript
@@ -35,6 +35,8 @@ function MainMenuGui::onWake(%this)
    //This will ultimately call MainMenuButtons::onOpen(), so to see where the navigation
    //chain continues, see that function.
    %this.setRootPage(MainMenuButtons);
+   
+   %this.refreshPage();
 }
 
 function MainMenuButtonHolder::onWake(%this)

--- a/Templates/BaseGame/game/data/UI/scripts/menuNavigation.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/menuNavigation.tscript
@@ -288,3 +288,17 @@ function UINavigation::getPageCount(%this)
       
    return %count;
 }
+
+//==============================================================================
+/// Summary:
+/// Force the page to reprocess to ensure it's status is up to date
+function UINavigation::refreshPage(%this)
+{
+   %page = %this.getCurrentPage();
+   if(!isObject(%page))
+      return;
+      
+   if(%page.isMethod("onOpen"))
+      %page.call("onOpen");
+}
+


### PR DESCRIPTION
- Adjusts engine cleanup ordering on shaderFeatureMgr to avoid periodic crashes on Mac ARM machines
- Adds missing disconnect/timeout handling callbacks to the clientServer core module
- Adds page refresh function to UINavigation to be able to selectively nudge the current page to refresh its contents if needbe