### PR TITLE
Misc Fixes 2022/06/05

### DIFF
--- a/Templates/BaseGame/game/data/UI/scripts/menuNavigation.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/menuNavigation.tscript
@@ -75,7 +75,8 @@ function UINavigation::pushPage(%this, %newPage, %callback)
    }
    
    //don't re-add pages
-   if(%this.pageStack.getIndexFromKey(%newPage) != -1)
+   if(%this.pageStack.getPageCount() != 0 && 
+      %this.pageStack.getIndexFromKey(%newPage) != -1)
       return;
    
    %canChange = true;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/terrain.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/terrain.tscript
@@ -5,9 +5,9 @@ function AssetBrowser::setupCreateNewTerrainAsset(%this)
    NewAssetPropertiesInspector.addField("genWithNoise", "Generate Terrain With Noise", "bool",  "Is this script used on the server?", "0", "2", %this.newAssetSettings);
    NewAssetPropertiesInspector.endGroup();
    
-   NewAssetPropertiesInspector.startGroup("Terrain - Import");
+   /*NewAssetPropertiesInspector.startGroup("Terrain - Import");
    NewAssetPropertiesInspector.addField("importDetails", "Import Heightmap", "button",  "Import an existing heightmap", "", "Canvas.pushDialog( TerrainImportGui );", %this.newAssetSettings);
-   NewAssetPropertiesInspector.endGroup();
+   NewAssetPropertiesInspector.endGroup();*/
 }
 
 function AssetBrowser::createTerrainAsset(%this)

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.tscript
@@ -153,6 +153,14 @@ function TerrainMaterialDlg::dialogApply( %this )
 {
    // Move all new materials we have created to the root group.
    
+   if(%this-->diffuseMapAssetId.text $= "None" ||
+   %this-->detailMapAssetId.text $= "None")
+   {
+      toolsMessageBoxOK("Invalid Terrain Material",
+                  "Terrain Materials require Diffuse and Detail textures to display and blend correctly.");
+      return;
+   }
+   
    %newCount = TerrainMaterialDlgNewGroup.getCount();
    for( %i = 0; %i < %newCount; %i ++ )
       RootGroup.add( TerrainMaterialDlgNewGroup.getObject( %i ) );


### PR DESCRIPTION
- Adds sanity check on UINavigation to avoid crashes if there are no pages in the stack.
- Removes button to fill import terrain images temporarily to contend with limitations in asset creation workflow
- Adds sanity check to saving terrain material that obligates setting of diffuse and detail maps so everything displays and blends properly