### PR TITLE
Misc Fixes 2022/06/09

### DIFF
--- a/Engine/source/gui/buttons/guiBitmapButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiBitmapButtonCtrl.cpp
@@ -201,6 +201,9 @@ void GuiBitmapButtonCtrl::onSleep()
          mTextures[ i ].mTextureInactive = NULL;
       }
 
+   if (mBitmapAsset.notNull())
+      mBitmap = NULL;
+
    Parent::onSleep();
 }
 

--- a/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
@@ -511,8 +511,25 @@ bool GuiGameSettingsCtrl::onWake()
    if( !Parent::onWake() )
       return false;
 
+   _setNextBitmap(getNextBitmap());
+   _setPreviousBitmap(getPreviousBitmap());
+   _setKeybindBitmap(getKeybindBitmap());
+
    return true;
 }
+
+void GuiGameSettingsCtrl::onSleep()
+{
+   if (mNextBitmapAsset.notNull())
+      mNextBitmap = NULL;
+   if (mPreviousBitmapAsset.notNull())
+      mPreviousBitmap = NULL;
+   if (mKeybindBitmapAsset.notNull())
+      mKeybindBitmap = NULL;
+
+   Parent::onSleep();
+}
+
 void GuiGameSettingsCtrl::activate()
 {
    if(isSelected() && isEnabled() && (mScriptCallback != StringTable->EmptyString()))

--- a/Engine/source/gui/controls/guiGameSettingsCtrl.h
+++ b/Engine/source/gui/controls/guiGameSettingsCtrl.h
@@ -245,6 +245,8 @@ public:
    /// Callback when the control wakes up.
    bool onWake();
 
+   void onSleep();
+
    void clear();
 
    virtual void onMouseMove(const GuiEvent& event);

--- a/Templates/BaseGame/game/data/UI/scripts/menuNavigation.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/menuNavigation.tscript
@@ -75,7 +75,7 @@ function UINavigation::pushPage(%this, %newPage, %callback)
    }
    
    //don't re-add pages
-   if(%this.pageStack.getPageCount() != 0 && 
+   if(%this.getPageCount() != 0 && 
       %this.pageStack.getIndexFromKey(%newPage) != -1)
       return;
    

--- a/Templates/BaseGame/game/tools/gui/uvEditor.ed.gui
+++ b/Templates/BaseGame/game/tools/gui/uvEditor.ed.gui
@@ -499,6 +499,15 @@ function UVEditor::showDialog( %this, %applyCallback, %obj, %uv)
    
    // Get the preview bitmap.  Code copied from Material Selector.
    %material = %obj.material;
+   if(!isObject(%material))
+   {
+      %matAssetId = %obj.materialAsset;
+      if(%matAssetId !$= "")
+      {
+         %matAssetDef = AssetDatabase.acquireAsset(%matAssetId);
+         %material = %matAssetDef.materialDefinitionName;  
+      }
+   }
    if( %material.getToneMap(0) $= "" && %material.getDiffuseMap(0) $= "" && !isObject(%material.cubemap) )
    {
       %previewImage = "core/images/warnmat";
@@ -507,13 +516,14 @@ function UVEditor::showDialog( %this, %applyCallback, %obj, %uv)
    {
       if( %material.toneMap[0] !$= "" )
          %previewImage = %material.getToneMap(0);
+      else if( %material.getDiffuseMapAsset(0) !$= "" )
+         %previewImage = %material.getDiffuseMapAsset(0);
       else if( %material.getDiffuseMap(0) !$= "" )
          %previewImage = %material.getDiffuseMap(0);
       else if( %material.cubemap.cubeFace[0] !$= "" )
          %previewImage = %material.cubemap.cubeFace[0];
          }
    
-   UVEditor-->bitmapPreview.setBitmap(getAssetPreviewImage(%previewImage));
    
    // Set up the color popup
    %popup = UVEditor-->colorPopup;
@@ -535,6 +545,7 @@ function UVEditor::showDialog( %this, %applyCallback, %obj, %uv)
    
    Canvas.pushDialog(UVEditorOverlay);
    UVEditor.setVisible(1);
+   UVEditor-->bitmapPreview.setBitmap(getAssetPreviewImage(%previewImage));
 }
 
 function UVEditor::hideDialog( %this )


### PR DESCRIPTION
- Fixes cleanup handling on guiBitmapButtonCtrl and guiGameSettingsCtrl to release the bound textures like other GUI controls when they sleep, avoiding a texture object leak.
- Fixes a call for UINavigation to getPageCount that was erroneously referencing the pageStack
- Fixes fetch and binding of the image for display when using the uvEditor