### PR TITLE
Fix Misc ConvexShape Tooling Issues

### DIFF
--- a/Engine/source/T3D/convexShape.cpp
+++ b/Engine/source/T3D/convexShape.cpp
@@ -263,7 +263,7 @@ bool ConvexShape::protectedSetSurfaceTexture(void *object, const char *index, co
 
    surfaceMaterial surface;
 
-   surface._setMaterial(data);
+   surface._setMaterial(StringTable->insert(data));
 
    shape->mSurfaceTextures.push_back(surface);
 

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
@@ -1075,7 +1075,7 @@ void GuiConvexEditorCtrl::renderScene(const RectI & updateRect)
          Point3F boxPos = objBox.getCenter();
          objMat.mulP( boxPos );
          
-         drawer->drawObjectBox( desc, objBox.getExtents(), boxPos, objMat, ColorI::WHITE );
+         drawer->drawObjectBox( desc, objBox.getExtents() / 2, boxPos, objMat, ColorI::WHITE );
       }
       else
       {

--- a/Templates/BaseGame/game/tools/convexEditor/convexEditorGui.tscript
+++ b/Templates/BaseGame/game/tools/convexEditor/convexEditorGui.tscript
@@ -38,7 +38,7 @@ function ConvexEditorGui::onWake( %this )
 		   %mat = %matName;
 		}
 		
-		ConvexEditorOptionsWindow-->matPreviewBtn.setBitmap( getAssetPreviewImage(%mat.getDiffuseMap(0)));
+		ConvexEditorOptionsWindow-->matPreviewBtn.bitmapAsset = getAssetPreviewImage(%mat.getDiffuseMap(0));
 		
 		ConvexEditorOptionsWindow.activeMaterial = %mat;
 	}
@@ -78,7 +78,7 @@ function ConvexEditorGui::onSelectionChanged( %this, %shape, %face )
 
    ConvexEditorOptionsWindow-->defMatPreviewBtn.setText("");
    %shapeMat = %shape.getMaterial();
-   ConvexEditorOptionsWindow-->defMatPreviewBtn.setBitmap(getAssetPreviewImage(%shapeMat.getDiffuseMap(0)));
+   ConvexEditorOptionsWindow-->defMatPreviewBtn.bitmapAsset = getAssetPreviewImage(%shapeMat.getDiffuseMap(0));
 
    ConvexEditorOptionsWindow.activeShape = %shape;
       
@@ -166,18 +166,8 @@ function ConvexEditorMaterialBtn::gotMaterialName(%this, %name)
    //eval(%this.object @ "." @ %this.targetField @ " = " @ %name @ ";");
    //%this.object.changeMaterial(getTrailingNumber(%this.targetField), %name);
    //%this.object.inspectorApply();
-   %diffusemap = %materialAsset.materialDefinitionName.getDiffuseMap(0);
-   if(%diffusemap $= "")
-   {
-      %diffuseAsset = %materialAsset.materialDefinitionName.getDiffuseMapAsset(0);
-      if(%diffuseAsset !$= "")
-      {
-         %diffuseAssetDef = AssetDatabase.acquireAsset(%diffuseAsset);
-         %diffusemap = %diffuseAssetDef.getImagePath();
-      }
-   }
-
-   ConvexEditorOptionsWindow-->matPreviewBtn.setBitmap(getAssetPreviewImage(%diffusemap));
+   %diffusemap = %materialAsset.materialDefinitionName.getDiffuseMapAsset(0);
+   ConvexEditorOptionsWindow-->matPreviewBtn.bitmapAsset = getAssetPreviewImage(%diffusemap);
 
    ConvexEditorOptionsWindow.activeMaterial = %materialAsset.getAssetId();
 }
@@ -242,7 +232,7 @@ function ConvexEditorDefaultMaterialBtn::gotMaterialName(%this, %name)
       }
    }
 
-   ConvexEditorOptionsWindow-->defMatPreviewBtn.setBitmap(getAssetPreviewImage(%diffusemap));
+   ConvexEditorOptionsWindow-->defMatPreviewBtn.bitmapAsset = getAssetPreviewImage(%diffusemap);
 
    ConvexEditorOptionsWindow.activeShape.setMaterial(%name);
 

--- a/Templates/BaseGame/game/tools/convexEditor/convexEditorSidebarGui.gui
+++ b/Templates/BaseGame/game/tools/convexEditor/convexEditorSidebarGui.gui
@@ -23,7 +23,7 @@ $guiContnt = new GuiControl(ConvexEditorOptions)
       anchorRight = "0";
       Position = Canvas.extent.x - 209
             SPC getWord(EditorGuiToolbar.extent, 1) - 2;
-      Extent = "210 485";
+      Extent = "210 550";
       minExtent = "210 298";
       horizSizing = "windowRelative";
       vertSizing = "windowRelative";
@@ -743,6 +743,93 @@ $guiContnt = new GuiControl(ConvexEditorOptions)
                   class = "ConvexEditorUVVertFlipBtn";
                };
             };
+         };
+      };
+   
+      new GuiContainer() {
+         docking = "Top";
+         margin = "0 0 3 3";
+         padding = "0 0 0 0";
+         anchorTop = "1";
+         anchorBottom = "0";
+         anchorLeft = "1";
+         anchorRight = "0";
+         position = "4 502";
+         extent = "1432 50";
+         minExtent = "8 2";
+         horizSizing = "width";
+         vertSizing = "bottom";
+         profile = "inspectorStyleRolloutDarkProfile";
+         visible = "1";
+         active = "1";
+         tooltipProfile = "GuiToolTipProfile";
+         hovertime = "1000";
+         isContainer = "1";
+         canSave = "1";
+         canSaveDynamicFields = "0";
+
+         new GuiTextCtrl() {
+            text = "Brush Actions";
+            maxLength = "1024";
+            margin = "0 0 0 0";
+            padding = "0 0 0 0";
+            anchorTop = "1";
+            anchorBottom = "0";
+            anchorLeft = "1";
+            anchorRight = "0";
+            position = "5 0";
+            extent = "121 18";
+            minExtent = "8 2";
+            horizSizing = "right";
+            vertSizing = "bottom";
+            profile = "ToolsGuiDefaultProfile";
+            visible = "1";
+            active = "1";
+            tooltipProfile = "GuiToolTipProfile";
+            hovertime = "1000";
+            isContainer = "1";
+            canSave = "1";
+            canSaveDynamicFields = "0";
+         };
+         
+         new GuiButtonCtrl() {
+            text = "Hollow Selected";
+            groupNum = "-1";
+            buttonType = "PushButton";
+            position = "5 22";
+            extent = "90 21";
+            minExtent = "8 2";
+            horizSizing = "right";
+            vertSizing = "bottom";
+            profile = "ToolsGuiButtonProfile";
+            visible = "1";
+            active = "1";
+            tooltipProfile = "GuiToolTipProfile";
+            hovertime = "1000";
+            isContainer = "0";
+            canSave = "1";
+            canSaveDynamicFields = "0";
+            command = "ConvexEditorGui.hollowSelection();";
+         };
+         
+         new GuiButtonCtrl() {
+            text = "Recenter Selected";
+            groupNum = "-1";
+            buttonType = "PushButton";
+            position = "100 22";
+            extent = "110 21";
+            minExtent = "8 2";
+            horizSizing = "right";
+            vertSizing = "bottom";
+            profile = "ToolsGuiButtonProfile";
+            visible = "1";
+            active = "1";
+            tooltipProfile = "GuiToolTipProfile";
+            hovertime = "1000";
+            isContainer = "0";
+            canSave = "1";
+            canSaveDynamicFields = "0";
+            command = "ConvexEditorGui.recenterSelection();";
          };
       };
    };


### PR DESCRIPTION
- Fixes bounds scaling issue making the object box in the editor be double the convex's size
- Fixes loading of modified surfaceTextures by properly inserting into stringtable
- Fixes display of the active and default material previews in the ConvexShape editor
- Adds buttons to hollow and recenter selected convex to tool window