### PR TITLE
Misc Fixes 2022/07/02

### DIFF
--- a/Engine/source/T3D/sfx/sfxEmitter.cpp
+++ b/Engine/source/T3D/sfx/sfxEmitter.cpp
@@ -690,7 +690,7 @@ void SFXEmitter::_update()
 
    if (mSoundAsset.notNull() )
    {
-      mLocalProfile = *mSoundAsset->getSfxProfile();
+      //mLocalProfile = *mSoundAsset->getSfxProfile();
       mDescription = *mSoundAsset->getSfxDescription();
    }
 

--- a/Engine/source/Verve/VPath/VPathEditor.cpp
+++ b/Engine/source/Verve/VPath/VPathEditor.cpp
@@ -20,6 +20,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
+#include "torqueConfig.h"
+
 #ifdef TORQUE_TOOLS
 #include "VPathEditor.h"
 

--- a/Engine/source/Verve/VPath/VPathEditor.h
+++ b/Engine/source/Verve/VPath/VPathEditor.h
@@ -22,6 +22,8 @@
 //-----------------------------------------------------------------------------
 #ifndef _VT_VPATHEDITOR_H_
 #define _VT_VPATHEDITOR_H_
+
+#include "torqueConfig.h"
 #ifdef TORQUE_TOOLS
 #ifndef _EDITTSCTRL_H_
 #include "gui/worldEditor/editTSCtrl.h"

--- a/Engine/source/afx/ui/afxGuiSubstitutionField.cpp
+++ b/Engine/source/afx/ui/afxGuiSubstitutionField.cpp
@@ -22,6 +22,7 @@
 // IN THE SOFTWARE.
 //
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
+#include "torqueConfig.h"
 #ifdef TORQUE_TOOLS
 #include "afx/arcaneFX.h"
 

--- a/Engine/source/afx/ui/afxGuiSubstitutionField.h
+++ b/Engine/source/afx/ui/afxGuiSubstitutionField.h
@@ -25,6 +25,7 @@
 
 #ifndef _AFX_GUI_SUBSTITUTION_FIELD_H_
 #define _AFX_GUI_SUBSTITUTION_FIELD_H_
+#include "torqueConfig.h"
 #ifdef TORQUE_TOOLS
 #include "console/simFieldDictionary.h"
 #include "gui/editor/inspector/field.h"

--- a/Engine/source/assets/assetManager.cpp
+++ b/Engine/source/assets/assetManager.cpp
@@ -2988,7 +2988,8 @@ void AssetManager::unloadAsset( AssetDefinition* pAssetDefinition )
     PROFILE_SCOPE(AssetManager_UnloadAsset);
 
     // Destroy the asset.
-    pAssetDefinition->mpAssetBase->deleteObject();
+    if(pAssetDefinition->mpAssetBase->isProperlyAdded())
+      pAssetDefinition->mpAssetBase->deleteObject();
 
     // Increase unloaded count.
     pAssetDefinition->mAssetUnloadedCount++;

--- a/Engine/source/navigation/guiNavEditorCtrl.cpp
+++ b/Engine/source/navigation/guiNavEditorCtrl.cpp
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
+#include "torqueConfig.h"
 #ifdef TORQUE_TOOLS
 #include "platform/platform.h"
 #include "guiNavEditorCtrl.h"

--- a/Engine/source/navigation/guiNavEditorCtrl.h
+++ b/Engine/source/navigation/guiNavEditorCtrl.h
@@ -22,6 +22,7 @@
 
 #ifndef _GUINAVEDITORCTRL_H_
 #define _GUINAVEDITORCTRL_H_
+#include "torqueConfig.h"
 #ifdef TORQUE_TOOLS
 #ifndef _EDITTSCTRL_H_
 #include "gui/worldEditor/editTSCtrl.h"

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -1090,14 +1090,17 @@ function AssetBrowserPreviewButton::onRightClick(%this)
       EditAssetPopup.enableItem(9, false);
    }
    
-   %assetDef = AssetDatabase.acquireAsset(EditAssetPopup.assetId);
-   if(%assetDef.originalFilePath $= "" || !isFile(%assetDef.originalFilePath))
+   if(AssetDatabase.acquireAsset(EditAssetPopup.assetId))
    {
-      //if we have no noted original import file path or it's invalid
-      //we can't reimport either
-      EditAssetPopup.enableItem(9, false);
+      %assetDef = AssetDatabase.acquireAsset(EditAssetPopup.assetId);
+      if(%assetDef.originalFilePath $= "" || !isFile(%assetDef.originalFilePath))
+      {
+         //if we have no noted original import file path or it's invalid
+         //we can't reimport either
+         EditAssetPopup.enableItem(9, false);
+      }
+      AssetDatabase.releaseAsset(EditAssetPopup.assetId);
    }
-   AssetDatabase.releaseAsset(EditAssetPopup.assetId);
    
    if(%assetType $= "LevelAsset")
    {

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/editAsset.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/editAsset.tscript
@@ -33,6 +33,17 @@ function AssetBrowser::editAsset(%this, %assetDef)
          {
             AssetBrowser.navigateTo(%folder);
          }
+         else
+         {
+            %object = getToken(EditAssetPopup.assetId, ":", 1);
+            if(isObject(%object))
+            {
+               if(%object.isMemberOfClass("SimDatablock"))
+               {
+                  DatablockEditorPlugin.openDatablock( %object );
+               }
+            }
+         }
       }
    }
    else if(AssetDatabase.isDeclaredAsset(%assetDef))
@@ -42,12 +53,14 @@ function AssetBrowser::editAsset(%this, %assetDef)
       %assetDef = AssetDatabase.acquireAsset(%assetDef);
    }
       
+   if(%assetDef !$= "")
+   {
+      %assetType = %assetDef.getClassName();
       
-   %assetType = %assetDef.getClassName();
-   
-   //Build out the edit command
-   %buildCommand = %this @ ".edit" @ %assetType @ "(" @ %assetDef @ ");";
-   eval(%buildCommand);
+      //Build out the edit command
+      %buildCommand = %this @ ".edit" @ %assetType @ "(" @ %assetDef @ ");";
+      eval(%buildCommand);
+   }
 }
 
 function AssetBrowser::appendSubLevel(%this)


### PR DESCRIPTION
- Fixes issue with using Edit Asset in RMB menu in AB on datablocks where it wouldn't correctly recognize the datablock
- Fixes issue where the local sfxProfile in a sfxEmitter would share pointer reference to the utilized soundAsset's sound buffer, so when it's deleted it would nuke the soundAsset's buffer, causing reference exceptions
- Adds includes to torqueConfig.h in several files that are blocked out with TORQUE_TOOLS to ensure that if the flag is on in the config file, the files are loaded/compiled as expected
- Add sanity check to AssetManager::unloadAsset to ensure that the assetDef being unloaded was actually correctly loaded/registered into the console in the first place