### PR TITLE
DBEditor callback fix for asset fields

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -989,23 +989,22 @@ function AssetBrowser::changeAsset(%this)
    {
       %inspectorObject = %this.fieldTargetObject;
       %targetObject = %inspectorObject.getInspectObject();
+      
+      %inspectorObject.setObjectField(%this.fieldTargetName, %this.selectedAsset);
    }
-   
-   //alright, we've selectd an asset for a field, so time to set it!
-   if(%this.fieldTargetName $= "")
-      %cmd = %targetObject @ ".apply(\""@ %this.selectedAsset @ "\");";
    else
-      %cmd = %targetObject @ "." @ %this.fieldTargetName @ "=\"" @ %this.selectedAsset @ "\";";
-   //echo("Changing asset via the " @ %cmd @ " command");
-   eval(%cmd);
+   {
+      //alright, we've selectd an asset for a field, so time to set it!
+      if(%this.fieldTargetName $= "")
+         %cmd = %targetObject @ ".apply(\""@ %this.selectedAsset @ "\");";
+      else
+         %cmd = %targetObject @ "." @ %this.fieldTargetName @ "=\"" @ %this.selectedAsset @ "\";";
+      //echo("Changing asset via the " @ %cmd @ " command");
+      eval(%cmd);
+   }
    
    //Force update our object with the field change
    %targetObject.inspectPostApply();
-   
-   if(isObject(%inspectorObject))
-   {
-      %inspectorObject.refresh();
-   }
    
    //Flag us as dirty for editing purposes
    EWorldEditor.setSceneAsDirty();


### PR DESCRIPTION
Tweaks handling when asset value is changed so that any active inspector is called back to apply the value change, ensuring any callbacks are kicked as expected.
Mostly done to ensure that the DB Editor correctly got callback events when an asset field was changed so it could mark the DB as dirty, but will apply across the board.