### PR TITLE
Misc FIxes 2022/07/24

### DIFF
--- a/Engine/source/core/volume.cpp
+++ b/Engine/source/core/volume.cpp
@@ -579,6 +579,9 @@ bool MountSystem::copyFile(const Path& source, const Path& destination, bool noO
    }
 
    FileRef sourceFile = openFile(source, FS::File::AccessMode::Read);
+   if (!sourceFile)
+      return false;
+
    const U64 sourceFileSize = sourceFile->getSize();
 
    void* writeBuffer = dMalloc(sourceFileSize);

--- a/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
@@ -1386,6 +1386,9 @@ bool GuiPopUpMenuCtrlEx::onKeyDown(const GuiEvent &event)
 //------------------------------------------------------------------------------
 void GuiPopUpMenuCtrlEx::onAction()
 {
+   if (!mActive)
+      return;
+
    GuiControl *canCtrl = getParent();
 
    addChildren();

--- a/Engine/source/platformWin32/winVolume.cpp
+++ b/Engine/source/platformWin32/winVolume.cpp
@@ -89,7 +89,10 @@ static String _BuildFileName(const String& prefix,const Path& path)
    // internal path name.
    String file = prefix;
    file = Path::Join(file, '/', path.getPath());
-   file = Path::Join(file, '/', path.getFileName());
+   if (path.getFileName().isEmpty() && path.getExtension().isNotEmpty()) //weird, filename-less file, so handle it slightly special-case
+      file += String("/");
+   else
+      file = Path::Join(file, '/', path.getFileName());
    file = Path::Join(file, '.', path.getExtension());
    return file;
 }


### PR DESCRIPTION
- Adds handling to winVolume's _BuildFileName so if it's a filename-less filename(has only extension but no name) then we process the filename string correctly
- Adds logic so when trying to do a path copy, if it's not a valid source filename, we merely fail the copy, rather than crashing due to a nullref
- Makes guiPopUpCtrlEx respect the mActive flag so the mouse cannot interact with it if it's inactive