### PR TITLE
pathshape cleanups and callbacks

### DIFF
--- a/Engine/source/T3D/cameraSpline.cpp
+++ b/Engine/source/T3D/cameraSpline.cpp
@@ -51,7 +51,7 @@ CameraSpline::Knot::Knot(const Knot &k)
    prev = NULL; next = NULL;
 }
 
-CameraSpline::Knot::Knot(const Point3F &p, const QuatF &r, F32 s, Knot::Type type, Knot::Path path)
+CameraSpline::Knot::Knot(const Point3F &p, const QuatF &r, F32 s, Knot::Type type, Knot::Path path, String hitCommand)
 {
    mPosition = p;
    mRotation = r;
@@ -59,6 +59,7 @@ CameraSpline::Knot::Knot(const Point3F &p, const QuatF &r, F32 s, Knot::Type typ
    mType = type;
    mPath = path;
    mDistance = 0.0f;
+   mHitCommand = hitCommand;
    prev = NULL; next = NULL;
 }
 

--- a/Engine/source/T3D/cameraSpline.h
+++ b/Engine/source/T3D/cameraSpline.h
@@ -37,6 +37,7 @@ public:
       Point3F mPosition;
       QuatF   mRotation;
       F32     mSpeed;    /// in meters per second
+      String mHitCommand;
       enum Type {
          NORMAL,
          POSITION_ONLY,
@@ -56,7 +57,7 @@ public:
 
       Knot();
       Knot(const Knot &k);
-      Knot(const Point3F &p, const QuatF &r, F32 s, Knot::Type type = NORMAL, Knot::Path path = SPLINE);
+      Knot(const Point3F &p, const QuatF &r, F32 s, Knot::Type type = NORMAL, Knot::Path path = SPLINE, String hitCommand = String::EmptyString);
    };
 
 

--- a/Engine/source/T3D/pathShape.cpp
+++ b/Engine/source/T3D/pathShape.cpp
@@ -76,11 +76,10 @@ PathShape::PathShape()
    mTarget = 0;
    mTargetSet = false;
 
-   MatrixF mat(1);
-   mat.setPosition(Point3F(0,0,700));
+   MatrixF mat = MatrixF::Identity;
+   mLastXform = MatrixF::Identity;
+
    Parent::setTransform(mat);
-   
-   mLastXform = mat; 
    for (U32 i = 0; i < 4; i++)
    {
       mControl[i] = StringTable->insert("");
@@ -350,7 +349,10 @@ void PathShape::popFront()
 void PathShape::onNode(S32 node)
 {
    if (!isGhost())
-      Con::executef(mDataBlock,"onNode",getIdString(), Con::getIntArg(node));
+   {
+      Con::executef(mDataBlock, "onNode", getIdString(), Con::getIntArg(node));
+      Con::executef(mDataBlock, mSpline.getKnot(node)->mHitCommand.c_str(), getIdString());   
+   }
 }
 
 
@@ -523,8 +525,8 @@ static CameraSpline::Knot::Path resolveKnotPath(const char *arg)
    return CameraSpline::Knot::SPLINE;
 }
 
-DefineEngineMethod(PathShape, pushBack, void, (TransformF transform, F32 speed, const char* type, const char* path),
-   (TransformF::Identity, 1.0f, "Normal", "Linear"),
+DefineEngineMethod(PathShape, pushBack, void, (TransformF transform, F32 speed, const char* type, const char* path, const char *hitCommand),
+   (TransformF::Identity, 1.0f, "Normal", "Linear",""),
    "@brief Adds a new knot to the back of a path camera's path.\n"
    "@param transform Transform for the new knot.  In the form of \"x y z ax ay az aa\" such as returned by SceneObject::getTransform()\n"
    "@param speed Speed setting for this knot.\n"
@@ -545,7 +547,7 @@ DefineEngineMethod(PathShape, pushBack, void, (TransformF transform, F32 speed, 
 {
    QuatF rot(transform.getOrientation());
 
-   object->pushBack(new CameraSpline::Knot(transform.getPosition(), rot, speed, resolveKnotType(type), resolveKnotPath(path)));
+   object->pushBack(new CameraSpline::Knot(transform.getPosition(), rot, speed, resolveKnotType(type), resolveKnotPath(path), String(hitCommand)));
 }
 
 DefineEngineMethod(PathShape, pushFront, void, (TransformF transform, F32 speed, const char* type, const char* path),

--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -112,6 +112,7 @@ SceneObject::SceneObject()
 
    mObjScale.set(1,1,1);
    mObjToWorld.identity();
+   mLastXform.identity();
    mWorldToObj.identity();
 
    mObjBox      = Box3F(Point3F(0, 0, 0), Point3F(0, 0, 0));
@@ -416,6 +417,7 @@ void SceneObject::setTransform( const MatrixF& mat )
 
    PROFILE_SCOPE( SceneObject_setTransform );
 // PATHSHAPE
+   UpdateXformChange(mat);
    PerformUpdatesForChildren(mat);
 // PATHSHAPE END
 
@@ -1661,7 +1663,6 @@ void SceneObject::moveRender(const Point3F &delta)
 }
 
 void SceneObject::PerformUpdatesForChildren(MatrixF mat){
-	    UpdateXformChange(mat);
 		for (U32 i=0; i < getNumChildren(); i++) {
 			SceneObject *o = getChild(i);
 			o->updateChildTransform(); //update the position of the child object
@@ -1988,8 +1989,11 @@ DefineEngineMethod(SceneObject, detachChild, bool, (const char*_subObject),, "Sc
         return false;  
 }
 
-// subclasses can do something with these if they care to
-void SceneObject::onNewParent(SceneObject *newParent) {}  
-void SceneObject::onLostParent(SceneObject *oldParent){}    
-void SceneObject::onNewChild(SceneObject *newKid){}   
-void SceneObject::onLostChild(SceneObject *lostKid){}
+IMPLEMENT_CALLBACK(SceneObject, onNewParent, void, (SceneObject *newParent), (newParent), "");
+IMPLEMENT_CALLBACK(SceneObject, onLostParent, void, (SceneObject *oldParent), (oldParent), "");
+IMPLEMENT_CALLBACK(SceneObject, onNewChild, void, (SceneObject *newKid), (newKid), "");
+IMPLEMENT_CALLBACK(SceneObject, onLostChild, void, (SceneObject *lostKid), (lostKid), "");
+void SceneObject::onNewParent(SceneObject *newParent) { onNewParent_callback(newParent); }
+void SceneObject::onLostParent(SceneObject *oldParent) { onLostParent_callback(oldParent); }
+void SceneObject::onNewChild(SceneObject *newKid) { onNewChild_callback(newKid); }
+void SceneObject::onLostChild(SceneObject *lostKid) { onLostChild_callback(lostKid); }

--- a/Engine/source/scene/sceneObject.h
+++ b/Engine/source/scene/sceneObject.h
@@ -840,6 +840,13 @@ class SceneObject : public NetObject, private SceneContainer::Link, public Proce
       SceneObject* nextSibling;        ///< Link to next child object of this object's parent 
       MatrixF      objToParent;   ///< this obects transformation in the parent object's space
       MatrixF      RenderobjToParent;   ///< this obects Render Offset transformation to the parent object
+      AttachInfo() {
+         firstChild = NULL;
+         parent = NULL;
+         nextSibling = NULL;
+         objToParent.identity();
+         RenderobjToParent.identity();
+      };
    } mGraph;
 // PATHSHAPE END
 
@@ -934,13 +941,17 @@ class SceneObject : public NetObject, private SceneContainer::Link, public Proce
 
 
    /// Called to let instance specific code happen 
-   virtual void onLostParent(SceneObject *oldParent);   
+   virtual void onLostParent(SceneObject *oldParent);
+   DECLARE_CALLBACK(void, onLostParent, (SceneObject *oldParent));
    /// Called to let instance specific code happen 
-   virtual void onNewParent(SceneObject *newParent);   
+   virtual void onNewParent(SceneObject *newParent);
+   DECLARE_CALLBACK(void, onNewParent, (SceneObject *oldParent));
    /// notification that a direct child object has been attached
-   virtual void onNewChild(SceneObject *subObject);   
+   virtual void onNewChild(SceneObject *subObject);
+   DECLARE_CALLBACK(void, onNewChild, (SceneObject *subObject));
    /// notification that a direct child object has been detached
-   virtual void onLostChild(SceneObject *subObject);   
+   virtual void onLostChild(SceneObject *subObject);
+   DECLARE_CALLBACK(void, onLostChild, (SceneObject *subObject));
 // PATHSHAPE END
 
    virtual void getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList) {}

--- a/Engine/source/scene/simPath.cpp
+++ b/Engine/source/scene/simPath.cpp
@@ -389,7 +389,7 @@ Marker::Marker()
    mNetFlags.clear(Ghostable);
 
    mTypeMask |= MarkerObjectType;
-
+   mHitCommand = String::EmptyString;
    mSeqNum   = 0;
    mMSToNext = 1000;
    mSmoothingType = SmoothingTypeSpline;
@@ -423,6 +423,7 @@ void Marker::initPersistFields()
 {
    addGroup( "Misc" );
    addField("seqNum",   TypeS32, Offset(mSeqNum,   Marker), "Marker position in sequence of markers on this path.\n");
+   addField("hitCommand", TypeCommand, Offset(mHitCommand, Marker), "The command to execute when a path follower reaches this marker.");
    addField("type", TYPEID< KnotType >(), Offset(mKnotType, Marker), "Type of this marker/knot. A \"normal\" knot will have a smooth camera translation/rotation effect.\n\"Position Only\" will do the same for translations, leaving rotation un-touched.\nLastly, a \"Kink\" means the rotation will take effect immediately for an abrupt rotation change.\n");
    addField("msToNext", TypeS32, Offset(mMSToNext, Marker), "Milliseconds to next marker in sequence.\n");
    addField("smoothingType", TYPEID< SmoothingType >(), Offset(mSmoothingType, Marker), "Path smoothing at this marker/knot. \"Linear\" means no smoothing, while \"Spline\" means to smooth.\n");

--- a/Engine/source/scene/simPath.h
+++ b/Engine/source/scene/simPath.h
@@ -121,6 +121,7 @@ class Marker : public SceneObject
 
 
    U32   mSeqNum;
+   String mHitCommand;
    U32   mSmoothingType;
    U32   mKnotType;
 


### PR DESCRIPTION
sceneObject:
   UpdateXformChange(mat); operates on the parent object, so made no sense to shove it in void SceneObject::PerformUpdatesForChildren(MatrixF mat){
provide callbacks for when the parent/child relationship changes

simpath+camerapline+pathshape
provide a mechanism to embed a callback for a pathshape defined on a path node. example:

            new Marker() {
               seqNum = "7";
               hitCommand = "TheCommand" // <------------------------------;
               position = "-17.0856 -92.2349 4.00051";
               rotation = "0.0334943 -0.254411 0.966516 179.495";
            };

function PathShapeData::TheCommand(%this,%obj)
{
    echo("Do the thing");
}