### PR TITLE
targeted fix for #45

### DIFF
--- a/Engine/source/T3D/fx/splash.cpp
+++ b/Engine/source/T3D/fx/splash.cpp
@@ -481,6 +481,7 @@ void Splash::processTick(const Move*)
       if( mCurrMS >= mEndingMS )
       {
          mDead = true;
+         deleteObject();
       }
    }
 }


### PR DESCRIPTION
as there was no consensus on conversion to explosions from the RFA, holding https://github.com/Azaezel/Torque3D-1/commit/7a88b2d489554729f08715d36fcf50c09e40f200 on back untill we adress that in the ECS pass with 4.1