### PR TITLE
kill the ap if no valid core directory found.

### DIFF
--- a/Templates/BaseGame/game/main.tscript.in
+++ b/Templates/BaseGame/game/main.tscript.in
@@ -14,7 +14,8 @@ $appName = "@TORQUE_APP_NAME@";
 // Load up scripts to initialise subsystems.
 ModuleDatabase.setModuleExtension("module");
 ModuleDatabase.scanModules( "core", false );
-ModuleDatabase.LoadExplicit( "CoreModule" );
+if (!ModuleDatabase.LoadExplicit( "CoreModule" ))
+    quit();
 
 // Display a splash window immediately to improve app responsiveness before
 // engine is initialized and main window created.


### PR DESCRIPTION
closes the application if no core module found, ie folks didn't run install, or the project manager failed to pre-copy folders