### PR TITLE
kill advanced or basic lighting render switch in editor

### DIFF
--- a/Templates/BaseGame/game/tools/worldEditor/scripts/lighting.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/lighting.ed.tscript
@@ -23,7 +23,7 @@
 function EditorLightingMenu::onAdd( %this )
 {
    Parent::onAdd( %this );
-   
+   return;
    // Get the light manager names.
    %lightManagers = getLightManagerNames();
 


### PR DESCRIPTION
we don't use it, we haven't had it player facing selectable via options menu for years, and we've been actively discouraging folks from poking at The Busted for quite a while now. time it went bye bye