### PR TITLE
update translucent lighting default

### DIFF
--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -207,7 +207,7 @@ Material::Material()
    mDoubleSided = false;
 
    mTranslucent = false;
-   mTranslucentBlendOp = LerpAlpha;
+   mTranslucentBlendOp = PreMul;
    mTranslucentZWrite = false;
 
    mAlphaTest = false;


### PR DESCRIPTION
default translucency for PBR authoring tools generally assume premul, not lerpalpha nowadays