### PR TITLE
supress smallborderless support

### DIFF
--- a/Templates/BaseGame/game/core/gui/scripts/canvas.tscript
+++ b/Templates/BaseGame/game/core/gui/scripts/canvas.tscript
@@ -164,7 +164,7 @@ function GuiCanvas::checkCanvasRes(%this, %mode, %deviceId, %deviceMode, %startu
 {
    // Toggle for selecting the borderless window allowed sizes. Set true to allow
    // borderless windows to be less than the device res.
-   %allowSmallBorderless = true;
+   %allowSmallBorderless = false;
 
    %resX = getWord(%mode, $WORD::RES_X);
    %resY = getWord(%mode, $WORD::RES_Y);


### PR DESCRIPTION
for multi-monitor setups, allowing smaller than screensize borderless windows was causing issues swapping the window between them. short circuited that but left it in in case someone *really* wants to make that  along term project