### PR TITLE
WinKey+Shift+L/R Arrow handler.

### DIFF
--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -672,6 +672,11 @@ void PlatformWindowSDL::_processSDLEvent(SDL_Event &evt)
             case SDL_WINDOWEVENT_RESTORED:
                Con::setBoolVariable("pref::Video::isMaximized", false);
                break;
+            case SDL_WINDOWEVENT_DISPLAY_CHANGED:
+               Con::printf("Window moved to display #%d", evt.window.data1);
+               Con::setIntVariable("pref::Video::deviceId", evt.window.data1);
+               Con::evaluate("configureCanvas();");
+               break;
 
             default:
                break;


### PR DESCRIPTION
Attempts to constrain canvas when switching between monitors via keyboard shortcut.