### PR TITLE
Revert "provide a new levelinfo. fallbackAmbient value for scenes wit…

### DIFF
--- a/Engine/source/T3D/levelInfo.cpp
+++ b/Engine/source/T3D/levelInfo.cpp
@@ -68,7 +68,7 @@ extern ColorI gCanvasClearColor;
 
 /// @see DecalManager
 extern F32 gDecalBias;
-extern LinearColorF gFallbackAmbient;
+
 /// @see AccumulationVolume
 extern GFXTexHandle gLevelAccuMap;
 
@@ -86,7 +86,6 @@ LevelInfo::LevelInfo()
       mDecalBias( 0.0015f ),
       mCanvasClearColor( 255, 0, 255, 255 ),
       mAmbientLightBlendPhase( 1.f ),
-      mFallbackAmbient(LinearColorF(0.1f, 0.1f, 0.1f, 1.0f)),
       mSoundAmbience( NULL ),
       mSoundDistanceModel( SFXDistanceModelLinear ),
       mSoundscape( NULL )
@@ -164,8 +163,6 @@ void LevelInfo::initPersistFields()
       addField( "ambientLightBlendCurve", TypeEaseF, Offset( mAmbientLightBlendCurve, LevelInfo ),
          "Interpolation curve to use for blending from one ambient light color to a different one." );
 
-      addField("fallbackAmbient", TypeColorF, Offset(mFallbackAmbient, LevelInfo),
-         "Ambient Color to use if no global light source exists.");
       //addField( "advancedLightmapSupport", TypeBool, Offset( mAdvancedLightmapSupport, LevelInfo ),
       //   "Enable expanded support for mixing static and dynamic lighting (more costly)" );
 
@@ -214,7 +211,6 @@ U32 LevelInfo::packUpdate(NetConnection *conn, U32 mask, BitStream *stream)
    stream->writeFlag( mAdvancedLightmapSupport );
    stream->write( mAmbientLightBlendPhase );
    mathWrite( *stream, mAmbientLightBlendCurve );
-   stream->write(mFallbackAmbient);
 
    sfxWrite( stream, mSoundAmbience );
    stream->writeInt( mSoundDistanceModel, 1 );
@@ -245,7 +241,6 @@ void LevelInfo::unpackUpdate(NetConnection *conn, BitStream *stream)
    mAdvancedLightmapSupport = stream->readFlag();
    stream->read( &mAmbientLightBlendPhase );
    mathRead( *stream, &mAmbientLightBlendCurve );
-   stream->read(&mFallbackAmbient);
 
    String errorStr;
    if( !sfxReadAndResolve( stream, &mSoundAmbience, errorStr ) )
@@ -328,8 +323,8 @@ void LevelInfo::_updateSceneGraph()
    scene->setVisibleGhostDistance( mVisibleGhostDistance );
 
    gDecalBias = mDecalBias;
+
    // Set ambient lighting properties.
-   gFallbackAmbient = mFallbackAmbient;
 
    scene->setAmbientLightTransitionTime( mAmbientLightBlendPhase * 1000.f );
    scene->setAmbientLightTransitionCurve( mAmbientLightBlendCurve );

--- a/Engine/source/T3D/levelInfo.h
+++ b/Engine/source/T3D/levelInfo.h
@@ -78,7 +78,7 @@ class LevelInfo : public NetObject
       /// Interpolation for going from one global ambient color
       /// to a different one.
       EaseF mAmbientLightBlendCurve;
-      LinearColorF mFallbackAmbient;
+
       /// @}
       
       /// @name Sound Properties

--- a/Engine/source/lighting/lightManager.cpp
+++ b/Engine/source/lighting/lightManager.cpp
@@ -42,7 +42,6 @@
 Signal<void(const char*,bool)> LightManager::smActivateSignal;
 LightManager *LightManager::smActiveLM = NULL;
 
-LinearColorF gFallbackAmbient;
 
 LightManager::LightManager( const char *name, const char *id )
    :  mName( name ),
@@ -163,28 +162,19 @@ LightInfo* LightManager::getDefaultLight()
 {
    // The sun is always our default light when
    // when its registered.
-   if (mSpecialLights[LightManager::slSunLightType])
-   {
-      mSpecialLights[LightManager::slSunLightType]->setAmbient(gFallbackAmbient);
-      return mSpecialLights[LightManager::slSunLightType];
-   }
+   if ( mSpecialLights[ LightManager::slSunLightType ] )
+      return mSpecialLights[ LightManager::slSunLightType ];
 
    // Else return a dummy special light.
-   if (!mDefaultLight)
-   {
+   if ( !mDefaultLight )
       mDefaultLight = createLightInfo();
-   }
-   mDefaultLight->setAmbient(gFallbackAmbient);
    return mDefaultLight;
 }
 
 LightInfo* LightManager::getSpecialLight( LightManager::SpecialLightTypesEnum type, bool useDefault )
 {
-   if (mSpecialLights[type])
-   {
-      mSpecialLights[LightManager::slSunLightType]->setAmbient(gFallbackAmbient);
+   if ( mSpecialLights[type] )
       return mSpecialLights[type];
-   }
 
    if ( useDefault )
       return getDefaultLight();


### PR DESCRIPTION
…h no global light source"

This reverts commit 270cf0e0544b89eed13c269e10093173d4be54a9.
it killed night mode. not worth it for the corner case of having no general light source at all.