### PR TITLE
probe capture cleanups pt1

### DIFF
--- a/Engine/source/T3D/lighting/reflectionProbe.cpp
+++ b/Engine/source/T3D/lighting/reflectionProbe.cpp
@@ -817,7 +817,7 @@ void ReflectionProbe::createEditorResources()
 
 void ReflectionProbe::prepRenderImage(SceneRenderState *state)
 {
-   if (!mEnabled || (!RenderProbeMgr::smRenderReflectionProbes && Con::getVariable("$Probes::Capturing", "0") == "0"))
+   if (!mEnabled || (!RenderProbeMgr::smRenderReflectionProbes && dStrcmp(Con::getVariable("$Probes::Capturing", "0"),"1")))
       return;
 
    Point3F distVec = getRenderPosition() - state->getCameraPosition();

--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -798,7 +798,7 @@ void RenderProbeMgr::render( SceneRenderState *state )
    _setupPerFrameParameters(state);
 
    // Early out if nothing to draw.
-   if ((!RenderProbeMgr::smRenderReflectionProbes && Con::getVariable("$Probes::Capturing", "0") == "0") || (!mHasSkylight && mProbeData.effectiveProbeCount == 0))
+   if ((!RenderProbeMgr::smRenderReflectionProbes && dStrcmp(Con::getVariable("$Probes::Capturing", "0"), "1")) || (!mHasSkylight && mProbeData.effectiveProbeCount == 0))
    {
       getProbeArrayEffect()->setSkip(true);
       mActiveProbes.clear();

--- a/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
@@ -500,7 +500,7 @@ vec4 computeForwardProbes(Surface surface,
    float horizon = saturate( 1 + horizonOcclusion * dot(surface.R, surface.N));
    horizon *= horizon;
 #if CAPTURING == 1
-    return vec4(mix(surface.baseColor.rgb,(irradiance + specular* horizon) ,surface.metalness/2),0);
+    return vec4(mix((irradiance + specular* horizon),surface.baseColor.rgb,surface.metalness),0);
 #else
    return vec4((irradiance + specular* horizon) , 0);//alpha writes disabled
 #endif

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
@@ -506,7 +506,7 @@ float4 computeForwardProbes(Surface surface,
    float horizon = saturate( 1 + horizonOcclusion * dot(surface.R, surface.N));
    horizon *= horizon;
 #if CAPTURING == 1
-    return float4(lerp(surface.baseColor.rgb,(irradiance + specular* horizon) ,surface.metalness/2),0);
+    return float4(lerp((irradiance + specular* horizon),surface.baseColor.rgb,surface.metalness),0);
 #else
    return float4((irradiance + specular* horizon) , 0);//alpha writes disabled
 #endif

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
@@ -205,7 +205,7 @@ void main()
    float horizon = saturate( 1 + horizonOcclusion * dot(surface.R, surface.N));
    horizon *= horizon;
 #if CAPTURING == 1
-   OUT_col = vec4(mix(surface.baseColor.rgb,(irradiance + specular* horizon) ,surface.metalness/2),0);
+   OUT_col = vec4(mix((irradiance + specular* horizon),surface.baseColor.rgb, surface.metalness),0);
 #else
    OUT_col = vec4((irradiance + specular* horizon)*ambientColor, 0);//alpha writes disabled
 #endif

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
@@ -191,7 +191,7 @@ float4 main(PFXVertToPix IN) : SV_TARGET
    float horizon = saturate( 1 + horizonOcclusion * dot(surface.R, surface.N));
    horizon *= horizon;
 #if CAPTURING == 1
-    return float4(lerp(surface.baseColor.rgb,(irradiance + specular* horizon) ,surface.metalness/2),0);
+    return float4(lerp((irradiance + specular* horizon), surface.baseColor.rgb,surface.metalness),0);
 #else
    return float4((irradiance + specular* horizon)*ambientColor, 0);//alpha writes disabled   
 #endif


### PR DESCRIPTION
fix high-metalness object capture (had the lerp the wrong direction for canceling out NULL-ibl due to full metallic)
use dStrcmp for (Con::getVariable("$Probes::Capturing", "0") comparisons. and early out on rendering probes when we are capturing, not when we aren't.