### PR TITLE
adds light fade and cap trackign to probe manager

### DIFF
--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -470,6 +470,21 @@ void RenderProbeMgr::reloadTextures()
    }
 }
 
+void RenderProbeMgr::preBake()
+{
+   Con::setVariable("$Probes::Capturing", "1");
+   mRenderMaximumNumOfLights = AdvancedLightBinManager::smMaximumNumOfLights;
+   mRenderUseLightFade = AdvancedLightBinManager::smUseLightFade;
+
+   AdvancedLightBinManager::smMaximumNumOfLights = -1;
+   AdvancedLightBinManager::smUseLightFade = false;
+}
+void RenderProbeMgr::postBake()
+{
+   Con::setVariable("$Probes::Capturing", "0");
+   AdvancedLightBinManager::smMaximumNumOfLights = mRenderMaximumNumOfLights;
+   AdvancedLightBinManager::smUseLightFade = mRenderUseLightFade;
+}
 void RenderProbeMgr::bakeProbe(ReflectionProbe* probe)
 {
    GFXDEBUGEVENT_SCOPE(RenderProbeMgr_Bake, ColorI::WHITE);
@@ -477,7 +492,7 @@ void RenderProbeMgr::bakeProbe(ReflectionProbe* probe)
    Con::warnf("RenderProbeMgr::bakeProbe() - Beginning bake!");
    U32 startMSTime = Platform::getRealMilliseconds();
 
-   Con::setVariable("$Probes::Capturing", "1");
+   preBake();
 
    String path = Con::getVariable("$pref::ReflectionProbes::CurrentLevelPath", "levels/");
    U32 resolution = Con::getIntVariable("$pref::ReflectionProbes::BakeResolution", 64);
@@ -598,7 +613,7 @@ void RenderProbeMgr::bakeProbe(ReflectionProbe* probe)
    if (!renderWithProbes)
       RenderProbeMgr::smRenderReflectionProbes = probeRenderState;
 
-   Con::setVariable("$Probes::Capturing", "0");
+   postBake();
 
    cubeRefl.unregisterReflector();
 

--- a/Engine/source/renderInstance/renderProbeMgr.h
+++ b/Engine/source/renderInstance/renderProbeMgr.h
@@ -290,6 +290,11 @@ private:
    /// </summary>
    bool mUseHDRCaptures;
 
+   /// <summary>
+   /// holds the normal render state for light fade so we can capture them before and restore them after baking
+   /// </summary>
+   S32 mRenderMaximumNumOfLights;
+   bool mRenderUseLightFade;
 protected:
    /// The current active light manager.
    static RenderProbeMgr* smProbeManager;
@@ -413,7 +418,8 @@ public:
    /// Takes a reflection probe and runs the cubemap bake process on it, outputting the resulting files to disk
    /// </summary>
    void bakeProbe(ReflectionProbe* probe);
-
+   void preBake();
+   void postBake();
    /// <summary>
    /// Runs the cubemap bake on all probes in the current scene
    /// </summary>


### PR DESCRIPTION
prebake removes them, postbake restores them to ap settings.
also went ahead and threw the probes::capturing val at it as well