### PR TITLE
Mac OpenAL 1.1

### DIFF
--- a/Engine/source/sfx/openal/sfxALDevice.cpp
+++ b/Engine/source/sfx/openal/sfxALDevice.cpp
@@ -69,7 +69,38 @@ S32 SFXALDevice::getMaxSources()
    ALCint nummono;
    mOpenAL.alcGetIntegerv(mDevice, ALC_MONO_SOURCES, 1, &nummono);
    
+   if(nummono == 0)
+      nummono = getMaxSourcesOld();
+   
    return nummono;
+}
+
+S32 SFXALDevice::getMaxSourcesOld()
+{
+   ALuint uiSource[256];
+   S32 sourceCount = 0;
+   
+   // clear errors.
+   mOpenAL.alGetError();
+   
+   for(sourceCount = 0; sourceCount < 256; sourceCount++)
+   {
+      mOpenAL.alGenSources(1,&uiSource[sourceCount]);
+      if(mOpenAL.alGetError() != AL_NO_ERROR)
+         break;
+   }
+   
+   mOpenAL.alDeleteSources(sourceCount, uiSource);
+   if(mOpenAL.alGetError() != AL_NO_ERROR)
+   {
+      for(U32 i = 0; i < 256; i++)
+      {
+         mOpenAL.alDeleteSources(1,&uiSource[i]);
+      }
+   }
+   
+   return sourceCount;
+   
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/sfx/openal/sfxALDevice.h
+++ b/Engine/source/sfx/openal/sfxALDevice.h
@@ -57,6 +57,9 @@ class SFXALDevice : public SFXDevice
       void printHRTFInfo(ALCdevice* device);
       void getEFXInfo(ALCdevice* device);
       S32 getMaxSources();
+   
+      // Compatibility with pre openal 1.2
+      S32 getMaxSourcesOld();
 
       SFXALDevice(   SFXProvider *provider,
                      const OPENALFNTABLE &openal, 


### PR DESCRIPTION
Added compatibility function to return max sources the old way.

If openal 1.2 method returns 0 it will do it the old way.