### PR TITLE
soundasset sourcegroup fallback

### DIFF
--- a/Engine/source/T3D/assets/SoundAsset.cpp
+++ b/Engine/source/T3D/assets/SoundAsset.cpp
@@ -225,6 +225,8 @@ bool SoundAsset::loadSound()
       }
       else
       {// = new SFXProfile(mProfileDesc, mSoundFile, mPreload);
+         if (mProfileDesc.mSourceGroup == NULL)
+            mProfileDesc.mSourceGroup = dynamic_cast<SFXSource*>(Sim::findObject("AudioChannelMaster"));
          mSFXProfile.setDescription(&mProfileDesc);
          mSFXProfile.setSoundFileName(mSoundPath);
          mSFXProfile.setPreload(mPreload);

--- a/Templates/BaseGame/game/data/UI/UI.tscript
+++ b/Templates/BaseGame/game/data/UI/UI.tscript
@@ -30,7 +30,7 @@ function UI::initClient(%this)
 {
    //Load UI stuff
    //we need to load this because some of the menu profiles use the sounds here
-   //%this.queueExec("./datablocks/guiSounds");
+   %this.queueExec("./datablocks/guiSounds");
    
    //Profiles
    %this.queueExec("./scripts/profiles");

--- a/Templates/BaseGame/game/data/UI/sounds/buttonClick.asset.taml
+++ b/Templates/BaseGame/game/data/UI/sounds/buttonClick.asset.taml
@@ -1,1 +1,4 @@
-<SoundAsset canSave="true" canSaveDynamicFields="true" AssetName="buttonClick" soundFile="@assetFile=buttonClick.wav" PitchAdjust="1" VolumeAdjust="1" is3D="false" isLooping="false" isStreaming="false" useHardware="false" minDistance="1" maxDistance="100" coneInsideAngle="360" coneOutsideAngle="360" coneOutsideVolume="1" rolloffFactor="-1" scatterDistance="0 0 0"/>
+<SoundAsset
+    AssetName="buttonClick"
+    soundFile="@assetFile=buttonClick.wav"
+    sourceGroup="AudioChannelGui"/>

--- a/Templates/BaseGame/game/data/UI/sounds/buttonHover.asset.taml
+++ b/Templates/BaseGame/game/data/UI/sounds/buttonHover.asset.taml
@@ -1,1 +1,6 @@
-<SoundAsset canSave="true" canSaveDynamicFields="true" AssetName="buttonHover" soundFile="@assetFile=buttonHover.wav" PitchAdjust="1" VolumeAdjust="1" is3D="false" isLooping="false" isStreaming="false" useHardware="true" minDistance="1" maxDistance="120" coneInsideAngle="360" coneOutsideAngle="360" coneOutsideVolume="1" rolloffFactor="-1" scatterDistance="0 0 0"/>
+<SoundAsset
+    AssetName="buttonHover"
+    soundFile="@assetFile=buttonHover.wav"
+    useHardware="true"
+    maxDistance="120"
+    sourceGroup="AudioChannelGui"/>


### PR DESCRIPTION
ensure if there's no assigned sourcegroup, we at least point at "AudioChannelMaster" so overall sound volume can have it's say
turn on button hover and click profiles by unremming the file
assign hoverasset and buttonclick assets to audioChannelGUI
todo: sort volume hooks for non-AudioChannelMaster
long term: resolve the requirement that gui profiles need direct sound profiles instead of the capacity to take assets