### PR TITLE
Fullscreen 'Fix' and Bloom Pref

### DIFF
--- a/Templates/BaseGame/game/core/gui/scripts/canvas.tscript
+++ b/Templates/BaseGame/game/core/gui/scripts/canvas.tscript
@@ -54,7 +54,10 @@ $WORD::FULLSCREEN = 2;
 $WORD::BITDEPTH = 3;
 $WORD::REFRESH = 4;
 $WORD::AA = 5;
-$Video::ModeTags = "Windowed\tBorderless\tFullscreen";
+if($platform $= "windows")
+   $Video::ModeTags = "Windowed\tBorderless";
+else
+   $Video::ModeTags = "Windowed\tBorderless\tFullscreen";
 $Video::ModeWindowed = 0;
 $Video::ModeBorderless = 1;
 $Video::ModeFullscreen = 2;

--- a/Templates/BaseGame/game/core/postFX/scripts/HDR/HDRPostFX.tscript
+++ b/Templates/BaseGame/game/core/postFX/scripts/HDR/HDRPostFX.tscript
@@ -294,7 +294,7 @@ function HDRPostFX::setShaderConsts( %this )
    
    // /----- BLOOM CONSTS -----/
    %bloom = %this->hdrbloom;
-   %bloom.skip = !$PostFX::HDRPostFX::enableBloom;
+   %bloom.skip = (!$PostFX::HDRPostFX::enableBloom || !$pref::PostFX::EnableHDRBloom);
 
    %bloom.setShaderConst("$threshold", $PostFX::HDRPostFX::threshold);
 
@@ -305,7 +305,7 @@ function HDRPostFX::setShaderConsts( %this )
    }
 
    %strength = $PostFX::HDRPostFX::intensity;
-   if (!$PostFX::HDRPostFX::enableBloom)
+   if (!$PostFX::HDRPostFX::enableBloom || !$pref::PostFX::EnableHDRBloom)
       %strength = 0.0;
    
    %bloomFinal = %this->hdrbloom_end;

--- a/Templates/BaseGame/game/core/rendering/scripts/graphicsOptions.tscript
+++ b/Templates/BaseGame/game/core/rendering/scripts/graphicsOptions.tscript
@@ -599,6 +599,7 @@ new SimGroup( ShaderQualityGroup )
       
       key["$pref::Video::disablePixSpecular"] = false;
       key["$pref::Video::disableNormalmapping"] = false;
+      key["$pref::PostFX::EnableHDRBloom"] = true;
    };
    new ArrayObject()
    {
@@ -609,6 +610,7 @@ new SimGroup( ShaderQualityGroup )
       
       key["$pref::Video::disablePixSpecular"] = true;
       key["$pref::Video::disableNormalmapping"] = true;
+      key["$pref::PostFX::EnableHDRBloom"] = false;
    };
 };
 

--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
@@ -538,6 +538,12 @@ function updateGraphicsSettings()
       DecalLifetimeGroup.applySetting($pref::Graphics::DecalLifetime);
    if($pref::Graphics::GroundCoverDensity !$= getCurrentQualityLevel(GroundCoverDensityGroup))
       GroundCoverDensityGroup.applySetting($pref::Graphics::GroundCoverDensity);
+   if($pref::Graphics::ShaderQuality !$= getCurrentQualityLevel(ShaderQualityGroup))
+   {
+      ShaderQualityGroup.applySetting($pref::Graphics::ShaderQuality);
+      //this has ties into postFX behaviors, so we'll force an update to it here
+      updatePostFXSettings();
+   }
 }
 
 function updateDisplaySettings()

--- a/Templates/BaseGame/game/data/defaults.tscript
+++ b/Templates/BaseGame/game/data/defaults.tscript
@@ -208,3 +208,5 @@ $pref::PostFX::EnableVignette = 1;
 $pref::PostFX::EnableLightRays = 1;
 $pref::PostFX::EnableHDR = 1;
 $pref::PostFX::EnableSSAO = 1;
+
+$pref::PostFX::EnableHDRBloom = 1;


### PR DESCRIPTION
Temp disables fullscreen on Windows platform due to various system behavioral issues with it

Integrates the HDR's bloom toggle into the Shader Quality setting