### PR TITLE
shift the probe file colorspace to gamma

### DIFF
--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/irradianceP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/irradianceP.glsl
@@ -56,5 +56,5 @@ void main()
     }
     irradiance = M_PI_F * irradiance * (1.0 / float(nrSamples));
     
-    OUT_col =  vec4(irradiance, 1.0);
+    OUT_col =  vec4(toGamma(irradiance), 1.0);
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/prefilterP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/prefilterP.glsl
@@ -84,13 +84,13 @@ vec3 ImportanceSampleGGX(vec2 Xi, vec3 N)
 	return normalize(sampleVec);
 }
 
-vec4 prefilterEnvMap(vec3 R)
+vec3 prefilterEnvMap(vec3 R)
 {
     int sampleCount = resolution*2;
 	vec3 N = R;
 	vec3 V = R;
 	float totalWeight = 0.0;
-	vec4 prefilteredColor = vec4(0.0, 0.0, 0.0, 0.0);
+	vec3 prefilteredColor = vec3(0.0, 0.0, 0.0);
 
 	for (int i = 0; i < sampleCount; ++i)
 	{
@@ -112,7 +112,7 @@ vec4 prefilterEnvMap(vec3 R)
 
 				float mipLevel = roughness == 0.0 ? 0.0 : 0.5 * log2(saSample / saTexel);
 
-				prefilteredColor += texture(environmentMap, L, mipLevel) * NdotL;				
+				prefilteredColor += texture(environmentMap, L, mipLevel).rgb * NdotL;				
 
 				totalWeight += NdotL;
 			}
@@ -126,6 +126,5 @@ out vec4 OUT_col;
 void main()
 {   
 	vec3 N = getCubeDir(face, uv0);
-	OUT_col = prefilterEnvMap(N);
-	OUT_col.a = 1;
+	OUT_col = vec4(toGamma(prefilterEnvMap(N)),1);
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/irradianceP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/irradianceP.hlsl
@@ -59,5 +59,5 @@ float4 main(ConnectData IN) : TORQUE_TARGET0
     }
     irradiance = M_PI_F * irradiance * (1.0 / float(nrSamples));
     
-    return float4(irradiance, 1.0);
+    return float4(toGamma(irradiance), 1.0);
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/prefilterP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/prefilterP.hlsl
@@ -126,5 +126,5 @@ float4 prefilterEnvMap(float3 R)
 float4 main(ConnectData IN) : TORQUE_TARGET0
 {
 	float3 N = getCubeDir(face, IN.uv);
-	return float4(prefilterEnvMap(N).rgb,1.0);
+	return float4(toGamma(prefilterEnvMap(N).rgb),1.0);
 }


### PR DESCRIPTION
seems the math is mangling for the capture to irradiance and prefilter hard files. as a temporary measure till we can better dig, shifting the result via toGamma