### PR TITLE
get probes displaying with low Texture quality

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Cubemap.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Cubemap.cpp
@@ -396,19 +396,8 @@ void GFXD3D11CubemapArray::init(GFXCubemapHandle *cubemaps, const U32 cubemapCou
    AssertFatal(cubemaps, "GFXD3D11CubemapArray::initStatic - Got null GFXCubemapHandle!");
    AssertFatal(*cubemaps, "GFXD3D11CubemapArray::initStatic - Got empty cubemap!");
 
-   U32 downscalePower = GFXTextureManager::smTextureReductionLevel;
-   U32 scaledSize = cubemaps[0]->getSize();
-
-   if (downscalePower != 0)
-   {
-      // Otherwise apply the appropriate scale...
-      scaledSize >>= downscalePower;
-   }
-
-   //all cubemaps must be the same size,format and number of mipmaps. Grab the details from the first cubemap
-   mSize = scaledSize;
+   setCubeTexSize(cubemaps);
    mFormat = cubemaps[0]->getFormat();
-   mMipMapLevels = cubemaps[0]->getMipMapLevels() - downscalePower;
    mNumCubemaps = cubemapCount;
 
    //create texture object
@@ -475,16 +464,7 @@ void GFXD3D11CubemapArray::init(GFXCubemapHandle *cubemaps, const U32 cubemapCou
 //Just allocate the cubemap array but we don't upload any data
 void GFXD3D11CubemapArray::init(const U32 cubemapCount, const U32 cubemapFaceSize, const GFXFormat format)
 {
-   U32 downscalePower = GFXTextureManager::smTextureReductionLevel;
-   U32 scaledSize = cubemapFaceSize;
-
-   if (downscalePower != 0)
-   {
-      scaledSize >>= downscalePower;
-   }
-
-   mSize = scaledSize;
-   mMipMapLevels = ImageUtil::getMaxMipCount(cubemapFaceSize, cubemapFaceSize) - downscalePower;
+   setCubeTexSize(cubemapFaceSize);
    mNumCubemaps = cubemapCount;
    mFormat = format;
 

--- a/Engine/source/gfx/gfxCubemap.cpp
+++ b/Engine/source/gfx/gfxCubemap.cpp
@@ -24,6 +24,7 @@
 #include "gfx/gfxDevice.h"
 #include "gfx/bitmap/gBitmap.h"
 #include "gfx/gfxTextureManager.h"
+#include "gfx/bitmap/imageUtils.h"
 
 
 GFXCubemap::GFXCubemap()
@@ -138,3 +139,33 @@ const String GFXCubemapArray::describeSelf() const
    return String();
 }
 
+
+void GFXCubemapArray::setCubeTexSize(GFXCubemapHandle* cubemaps)
+{
+   U32 downscalePower = 0;// GFXTextureManager::smTextureReductionLevel;
+   U32 scaledSize = cubemaps[0]->getSize();
+
+   if (downscalePower != 0)
+   {
+      // Otherwise apply the appropriate scale...
+      scaledSize >>= downscalePower;
+   }
+
+   //all cubemaps must be the same size,format and number of mipmaps. Grab the details from the first cubemap
+   mSize = scaledSize;
+   mMipMapLevels = cubemaps[0]->getMipMapLevels() - downscalePower;
+}
+
+void GFXCubemapArray::setCubeTexSize(U32 cubemapFaceSize)
+{
+   U32 downscalePower = 0;// GFXTextureManager::smTextureReductionLevel;
+   U32 scaledSize = cubemapFaceSize;
+
+   if (downscalePower != 0)
+   {
+      scaledSize >>= downscalePower;
+   }
+
+   mSize = scaledSize;
+   mMipMapLevels = ImageUtil::getMaxMipCount(cubemapFaceSize, cubemapFaceSize) - downscalePower;
+}

--- a/Engine/source/gfx/gfxCubemap.h
+++ b/Engine/source/gfx/gfxCubemap.h
@@ -127,7 +127,10 @@ protected:
 public:
    GFXCubemapArray() :mNumCubemaps(0), mSize(0), mMipMapLevels(0), mFormat(GFXFormat_FIRST) {}
    virtual ~GFXCubemapArray() {};
+
    /// Initialize from an array of cubemaps
+   void setCubeTexSize(GFXCubemapHandle* cubemaps);
+   void setCubeTexSize(const U32 cubemapFaceSize);
    virtual void init(GFXCubemapHandle *cubemaps, const U32 cubemapCount) = 0;
    /// Initialize cubemapCount number of blank cubemaps in the array
    virtual void init(const U32 cubemapCount, const U32 cubemapFaceSize, const GFXFormat format) = 0;

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -100,7 +100,7 @@ GFXTextureManager::~GFXTextureManager()
 
 U32 GFXTextureManager::getTextureDownscalePower( GFXTextureProfile *profile )
 {
-   if ( !profile || profile->canDownscale() )
+   if ( profile && profile->canDownscale() )
       return smTextureReductionLevel;
 
    return 0;

--- a/Engine/source/gfx/gl/gfxGLCubemap.cpp
+++ b/Engine/source/gfx/gl/gfxGLCubemap.cpp
@@ -322,19 +322,8 @@ void GFXGLCubemapArray::init(GFXCubemapHandle *cubemaps, const U32 cubemapCount)
    AssertFatal(cubemaps, "GFXGLCubemapArray- Got null GFXCubemapHandle!");
    AssertFatal(*cubemaps, "GFXGLCubemapArray - Got empty cubemap!");
 
-   U32 downscalePower = GFXTextureManager::smTextureReductionLevel;
-   U32 scaledSize = cubemaps[0]->getSize();
-
-   if (downscalePower != 0)
-   {
-      // Otherwise apply the appropriate scale...
-      scaledSize >>= downscalePower;
-   }
-
-   //all cubemaps must be the same size,format and number of mipmaps. Grab the details from the first cubemap
-   mSize = scaledSize;
+   setCubeTexSize(cubemaps);
    mFormat = cubemaps[0]->getFormat();
-   mMipMapLevels = cubemaps[0]->getMipMapLevels() - downscalePower;
    mNumCubemaps = cubemapCount;
    const bool isCompressed = ImageUtil::isCompressedFormat(mFormat);
 
@@ -379,19 +368,8 @@ void GFXGLCubemapArray::init(GFXCubemapHandle *cubemaps, const U32 cubemapCount)
 //Just allocate the cubemap array but we don't upload any data
 void GFXGLCubemapArray::init(const U32 cubemapCount, const U32 cubemapFaceSize, const GFXFormat format)
 {
-   U32 downscalePower = GFXTextureManager::smTextureReductionLevel;
-   U32 scaledSize = cubemapFaceSize;
-
-   if (downscalePower != 0)
-   {
-      // Otherwise apply the appropriate scale...
-      scaledSize >>= downscalePower;
-   }
-
-   //all cubemaps must be the same size,format and number of mipmaps. Grab the details from the first cubemap
-   mSize = scaledSize;
+   setCubeTexSize(cubemapCount);
    mFormat = format;
-   mMipMapLevels = ImageUtil::getMaxMipCount(scaledSize, scaledSize);
    mNumCubemaps = cubemapCount;
    const bool isCompressed = ImageUtil::isCompressedFormat(mFormat);
 

--- a/Engine/source/renderInstance/renderProbeMgr.h
+++ b/Engine/source/renderInstance/renderProbeMgr.h
@@ -402,7 +402,7 @@ public:
    /// </summary>
    /// <returns>the PostEffect object</returns>
    PostEffect* getProbeArrayEffect();
-
+   U32 getProbeTexSize();
    /// <summary>
    /// Finds the associated cubemap array slot for the incoming ProbeInfo and updates the array's texture(s) from it
    /// </summary>


### PR DESCRIPTION
refactored detection of texture sizes for cubemaps removed the assumption that if we give U32 GFXTextureManager::getTextureDownscalePower( GFXTextureProfile *profile ) no profile, it should go right ahead and downscale anyway sniped the downscaling strings in the resulting U32 getProbeTexSize(); and void setCubeTexSize(const U32 cubemapFaceSize); until sucj time as we can properly follow up all possible combinations of shiping in one scale, and a customer choosing to use lower resolution textures as the current result is a hard shutoff entirely