### PR TITLE
ligh shader final review

### DIFF
--- a/Templates/BaseGame/game/core/lighting/scripts/advancedLighting_Shaders.tscript
+++ b/Templates/BaseGame/game/core/lighting/scripts/advancedLighting_Shaders.tscript
@@ -43,10 +43,10 @@ singleton GFXStateBlockData( AL_VectorLightState )
 
    samplersDefined = true;
    samplerStates[0] = SamplerClampPoint;  // G-buffer
-   mSamplerNames[0] = "deferredBuffer";
    samplerStates[1] = SamplerClampPoint;  // Shadow Map (Do not change this to linear, as all cards can not filter equally.)
-   mSamplerNames[1] = "shadowMap";
-   samplerStates[2] = SamplerWrapPoint;   // Random Direction Map
+   samplerStates[3] = SamplerWrapPoint;   // gTapRotationTex Random Direction Map
+   samplerStates[4] = SamplerClampPoint;   // colorBuffer
+   samplerStates[5] = SamplerClampPoint;   // matInfoBuffer
    
    cullDefined = true;
    cullMode = GFXCullNone;
@@ -68,9 +68,8 @@ singleton shaderData( AL_VectorLightShader )
    samplerNames[0] = "$deferredBuffer";
    samplerNames[1] = "$shadowMap";
    samplerNames[2] = "$gTapRotationTex";
-   samplerNames[3] = "$lightBuffer";
-   samplerNames[4] = "$colorBuffer";
-   samplerNames[5] = "$matInfoBuffer";  
+   samplerNames[3] = "$colorBuffer";
+   samplerNames[4] = "$matInfoBuffer";  
    
    pixVersion = 3.0;
 };
@@ -82,7 +81,6 @@ singleton CustomMaterial( AL_VectorLightMaterial )
    
    sampler["deferredBuffer"] = "#deferred";
    sampler["shadowMap"] = "$dynamiclight";
-   sampler["lightBuffer"] = "#specularLighting";
    sampler["colorBuffer"] = "#color";
    sampler["matInfoBuffer"] = "#matinfo";
    
@@ -115,11 +113,11 @@ singleton GFXStateBlockData( AL_ConvexLightState )
 
    samplersDefined = true;
    samplerStates[0] = SamplerClampPoint;  // G-buffer
-   mSamplerNames[0] = "deferredBuffer";
    samplerStates[1] = SamplerClampPoint;  // Shadow Map (Do not use linear, these are perspective projections)
-   mSamplerNames[1] = "shadowMap";
-   samplerStates[3] = SamplerClampLinear; // Cookie Map   
-   samplerStates[4] = SamplerWrapPoint;   // Random Direction Map
+   samplerStates[2] = SamplerWrapPoint;   // gTapRotationTex Random Direction Map
+   samplerStates[3] = SamplerClampPoint;  // colorBuffer
+   samplerStates[4] = SamplerClampPoint;  // matInfoBuffer
+   samplerStates[5] = SamplerClampLinear; // Cookie Map
    
    cullDefined = true;
    cullMode = GFXCullCW;
@@ -140,11 +138,10 @@ singleton shaderData( AL_PointLightShader )
 
    samplerNames[0] = "$deferredBuffer";
    samplerNames[1] = "$shadowMap";
-   samplerNames[2] = "$cookieMap";
-   samplerNames[3] = "$gTapRotationTex";
-   samplerNames[4] = "$lightBuffer";
-   samplerNames[5] = "$colorBuffer";
-   samplerNames[6] = "$matInfoBuffer";
+   samplerNames[2] = "$gTapRotationTex";
+   samplerNames[3] = "$colorBuffer";
+   samplerNames[4] = "$matInfoBuffer";
+   samplerNames[5] = "$cookieMap";
    
    pixVersion = 3.0;
 };
@@ -157,7 +154,6 @@ singleton CustomMaterial( AL_PointLightMaterial )
    sampler["deferredBuffer"] = "#deferred";
    sampler["shadowMap"] = "$dynamiclight";
    sampler["cookieMap"] = "$dynamiclightmask";
-   sampler["lightBuffer"] = "#specularLighting";
    sampler["colorBuffer"] = "#color";
    sampler["matInfoBuffer"] = "#matinfo";
    
@@ -177,11 +173,10 @@ singleton shaderData( AL_SpotLightShader )
    
    samplerNames[0] = "$deferredBuffer";
    samplerNames[1] = "$shadowMap";
-   samplerNames[2] = "$cookieMap";
-   samplerNames[3] = "$gTapRotationTex";
-   samplerNames[4] = "$lightBuffer";
-   samplerNames[5] = "$colorBuffer";
-   samplerNames[6] = "$matInfoBuffer";
+   samplerNames[2] = "$gTapRotationTex";
+   samplerNames[3] = "$colorBuffer";
+   samplerNames[4] = "$matInfoBuffer";
+   samplerNames[5] = "$cookieMap";
 
    pixVersion = 3.0;
 };
@@ -194,7 +189,6 @@ singleton CustomMaterial( AL_SpotLightMaterial )
    sampler["deferredBuffer"] = "#deferred";
    sampler["shadowMap"] = "$dynamiclight";
    sampler["cookieMap"] = "$dynamiclightmask";
-   sampler["lightBuffer"] = "#specularLighting";
    sampler["colorBuffer"] = "#color";
    sampler["matInfoBuffer"] = "#matinfo";
    

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/pointLightP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/pointLightP.glsl
@@ -26,7 +26,6 @@
 #include "farFrustumQuad.glsl"
 #include "../../../gl/lighting.glsl"
 #include "../../shadowMap/shadowMapIO_GLSL.h"
-#include "softShadow.glsl"
 #include "../../../gl/torque.glsl"
 #line 31
 
@@ -35,12 +34,6 @@ in vec4 ssPos;
 in vec4 vsEyeDir;
 in vec4 color;
 
-#ifdef USE_COOKIE_TEX
-
-/// The texture for cookie rendering.
-uniform samplerCube cookieMap;
-
-#endif
 
 
 #ifdef SHADOW_CUBE
@@ -106,16 +99,19 @@ uniform samplerCube cookieMap;
 #endif
 
 uniform sampler2D deferredBuffer;
-
 #ifdef SHADOW_CUBE
 	uniform samplerCube shadowMap;
 #else
 	uniform sampler2D shadowMap;
 #endif
-
-uniform sampler2D lightBuffer;
+//contains gTapRotationTex sampler 
+#include "softShadow.glsl"
 uniform sampler2D colorBuffer;
 uniform sampler2D matInfoBuffer;
+#ifdef USE_COOKIE_TEX
+/// The texture for cookie rendering.
+uniform samplerCube cookieMap;
+#endif
 
 uniform vec4 rtParams0;
 

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/spotLightP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/spotLightP.glsl
@@ -24,7 +24,6 @@
 #include "farFrustumQuad.glsl"
 #include "../../shadowMap/shadowMapIO_GLSL.h"
 #include "shadergen:/autogenConditioners.h"
-#include "softShadow.glsl"
 #include "../../../gl/lighting.glsl"
 #include "../../../gl/torque.glsl"
 
@@ -33,17 +32,16 @@ in vec4 ssPos;
 in vec4 vsEyeDir;
 in vec4 color;
 
-#ifdef USE_COOKIE_TEX
-
-/// The texture for cookie rendering.
-uniform sampler2D cookieMap;
-
-#endif
-
 uniform sampler2D deferredBuffer;
 uniform sampler2D shadowMap;
+//contains gTapRotationTex sampler 
+#include "softShadow.glsl"
 uniform sampler2D colorBuffer;
 uniform sampler2D matInfoBuffer;
+#ifdef USE_COOKIE_TEX
+/// The texture for cookie rendering.
+uniform sampler2D cookieMap;
+#endif
 
 uniform vec4 rtParams0;
 

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/vectorLightP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/vectorLightP.glsl
@@ -26,7 +26,6 @@
 #include "../../../gl/torque.glsl"
 #include "../../../gl/lighting.glsl"
 #include "../../shadowMap/shadowMapIO_GLSL.h"
-#include "softShadow.glsl"
 #line 30
 in vec4 hpos;
 in vec2 uv0;
@@ -35,6 +34,8 @@ in vec3 vsEyeRay;
 
 uniform sampler2D deferredBuffer;
 uniform sampler2D shadowMap;
+//contains gTapRotationTex sampler 
+#include "softShadow.glsl"
 
 uniform sampler2D colorBuffer;
 uniform sampler2D matInfoBuffer;             

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/pointLightP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/pointLightP.hlsl
@@ -25,7 +25,6 @@
 #include "farFrustumQuad.hlsl"
 #include "../../lighting.hlsl"
 #include "../shadowMap/shadowMapIO_HLSL.h"
-#include "softShadow.hlsl"
 #include "../../torque.hlsl"
 
 struct ConvexConnectP
@@ -35,14 +34,6 @@ struct ConvexConnectP
    float4 ssPos : TEXCOORD1;
    float4 vsEyeDir : TEXCOORD2;
 };
-
-#ifdef USE_COOKIE_TEX
-
-/// The texture for cookie rendering.
-TORQUE_UNIFORM_SAMPLERCUBE(cookieMap, 3);
-
-#endif
-
 
 #ifdef SHADOW_CUBE
 
@@ -107,16 +98,19 @@ TORQUE_UNIFORM_SAMPLERCUBE(cookieMap, 3);
 #endif
 
 TORQUE_UNIFORM_SAMPLER2D(deferredBuffer, 0);
-
 #ifdef SHADOW_CUBE
 TORQUE_UNIFORM_SAMPLERCUBE(shadowMap, 1);
 #else
 TORQUE_UNIFORM_SAMPLER2D(shadowMap, 1);
 #endif
-
-TORQUE_UNIFORM_SAMPLER2D(lightBuffer, 5);
-TORQUE_UNIFORM_SAMPLER2D(colorBuffer, 6);
-TORQUE_UNIFORM_SAMPLER2D(matInfoBuffer, 7);
+//contains gTapRotationTex sampler 
+#include "softShadow.hlsl"
+TORQUE_UNIFORM_SAMPLER2D(colorBuffer, 3);
+TORQUE_UNIFORM_SAMPLER2D(matInfoBuffer, 4);
+#ifdef USE_COOKIE_TEX
+/// The texture for cookie rendering.
+TORQUE_UNIFORM_SAMPLERCUBE(cookieMap, 5);
+#endif
 
 uniform float4 rtParams0;
 uniform float4 lightColor;

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/softShadow.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/softShadow.hlsl
@@ -70,7 +70,7 @@ static float2 sNonUniformTaps[NUM_PRE_TAPS] =
 
 /// The texture used to do per-pixel pseudorandom
 /// rotations of the filter taps.
-TORQUE_UNIFORM_SAMPLER2D(gTapRotationTex, 3);
+TORQUE_UNIFORM_SAMPLER2D(gTapRotationTex, 2);
 
 float softShadow_sampleTaps(  TORQUE_SAMPLER2D(shadowMap1),
                               float2 sinCos,

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/spotLightP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/spotLightP.hlsl
@@ -26,7 +26,6 @@
 #include "farFrustumQuad.hlsl"
 #include "../../lighting.hlsl"
 #include "../shadowMap/shadowMapIO_HLSL.h"
-#include "softShadow.hlsl"
 #include "../../torque.hlsl"
 
 struct ConvexConnectP
@@ -39,16 +38,15 @@ struct ConvexConnectP
 
 TORQUE_UNIFORM_SAMPLER2D(deferredBuffer, 0);
 TORQUE_UNIFORM_SAMPLER2D(shadowMap, 1);
-
+//contains gTapRotationTex sampler 
+#include "softShadow.hlsl"
+TORQUE_UNIFORM_SAMPLER2D(colorBuffer, 3);
+TORQUE_UNIFORM_SAMPLER2D(matInfoBuffer, 4);
 #ifdef USE_COOKIE_TEX
-
 /// The texture for cookie rendering.
-TORQUE_UNIFORM_SAMPLER2D(cookieMap, 2);
+TORQUE_UNIFORM_SAMPLER2D(cookieMap, 5);
 
 #endif
-TORQUE_UNIFORM_SAMPLER2D(colorBuffer, 5);
-TORQUE_UNIFORM_SAMPLER2D(matInfoBuffer, 6);
-
 uniform float4 rtParams0;
 
 uniform float  lightBrightness;

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/vectorLightP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/vectorLightP.hlsl
@@ -27,13 +27,14 @@
 #include "../../torque.hlsl"
 #include "../../lighting.hlsl"
 #include "../shadowMap/shadowMapIO_HLSL.h"
-#include "softShadow.hlsl"
 
 TORQUE_UNIFORM_SAMPLER2D(deferredBuffer, 0);
 TORQUE_UNIFORM_SAMPLER2D(shadowMap, 1);
 
-TORQUE_UNIFORM_SAMPLER2D(colorBuffer, 5);
-TORQUE_UNIFORM_SAMPLER2D(matInfoBuffer, 6);
+//contains gTapRotationTex sampler 
+#include "softShadow.hlsl"
+TORQUE_UNIFORM_SAMPLER2D(colorBuffer, 3);
+TORQUE_UNIFORM_SAMPLER2D(matInfoBuffer, 4);
 
 uniform float  lightBrightness;
 uniform float3 lightDirection;


### PR DESCRIPTION
1) prunes extraneous garbage variables from GFXStateBlockData 2) re-orgs texture slots for lights as follows to better support stateblock slots: 0-norm|depth buffer
1- shadowmap
2-taprotationtex
3-colorbuffer
4-maitinfobuffer
5-cookiemap (AL_ConvexLightState only)