### PR TITLE
fix smaa backbuffer  colorspace

### DIFF
--- a/Templates/BaseGame/game/core/postFX/scripts/SMAA/BBtoGamma.hlsl
+++ b/Templates/BaseGame/game/core/postFX/scripts/SMAA/BBtoGamma.hlsl
@@ -19,25 +19,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
-#include "core/rendering/shaders/shaderModel.hlsl"
 #include "core/rendering/shaders/torque.hlsl"
-#include "SMAA_Params.hlsl"
-    
-                                                                         
-TORQUE_UNIFORM_SAMPLER2D(sceneTex, 0);
-TORQUE_UNIFORM_SAMPLER2D(blendTex, 1);
+#include "core/rendering/shaders/postFX/postFx.hlsl"
 
-struct v_NHBlend
+TORQUE_UNIFORM_SAMPLER2D(backBuffer, 0);
+
+float4 main(PFXVertToPix IN) : TORQUE_TARGET0
 {
-   float4 hpos    : TORQUE_POSITION;
-   float2 uv0     : TEXCOORD0;
-   float4 offset  : TEXCOORD1;
-};
-
-            
-float4 main( v_NHBlend IN ) : TORQUE_TARGET0
-{   
-    //return float4(TORQUE_TEX2D(blendTex, IN.uv0));
-   return toLinear(SMAANeighborhoodBlendingPS(IN.uv0, IN.offset, texture_sceneTex, texture_blendTex));
-} 
-
+   return toGamma(TORQUE_TEX2D(backBuffer, IN.uv0));  
+}

--- a/Templates/BaseGame/game/core/postFX/scripts/SMAA/SMAAPostFX.tscript
+++ b/Templates/BaseGame/game/core/postFX/scripts/SMAA/SMAAPostFX.tscript
@@ -103,23 +103,59 @@ singleton ShaderData( SMAA_Neighbor_H_Shader )
    pixVersion = 3.0;
 };
 
+singleton GFXStateBlockData( BBtoGamma_StateBlock )
+{
+   zDefined = true;
+   zEnable = false;
+   zWriteEnable = false;
+      
+   samplersDefined = true;
+   samplerStates[0] = SamplerClampLinear;
+};
+
+singleton ShaderData( BBtoGammaShader )
+{
+   DXVertexShaderFile 	= $Core::CommonShaderPath @ "/postFX/postFxV.hlsl";
+   DXPixelShaderFile 	= "./BBtoGamma.hlsl";   
+   OGLVertexShaderFile  = $Core::CommonShaderPath @ "/postFX/gl/postFxV.glsl";
+   OGLPixelShaderFile   = "./gl/BBtoGamma.glsl";
+   
+   samplerNames[0] = "$backBuffer";
+   
+   pixVersion = 3.0;
+};
+
 singleton PostEffect( SMAAPostFX )
 {
-   enabled = false;
-   
+   enabled = false;   
    allowReflectPass = false;
-   renderTime = "PFXAfterDiffuse";
-   
+   renderTime = "PFXBeforeBin";
+   renderBin = "EditorBin";
    texture[0] = "$backBuffer";
-   texture[1] = "#deferred";
-
-   target = "#edgesPass";
+   target = "#BBtoGamma";
+   renderPriority = 1; 
    targetClear = PFXTargetClear_OnDraw;
    targetClearColor = "0 0 0 0";
+   shader = BBtoGammaShader;
+   stateBlock = BBtoGamma_StateBlock;
    
-   shader = SMAA_Edge_D_Shader;
-   stateBlock = SMAA_Edge_D_StateBlock;
+   singleton PostEffect()
+   {
+      enabled = false;
    
+      allowReflectPass = false;
+      renderTime = "PFXAfterDiffuse";
+   
+      texture[0] = "#BBtoGamma";
+      texture[1] = "#deferred";
+
+      target = "#edgesPass";
+      targetClear = PFXTargetClear_OnDraw;
+      targetClearColor = "0 0 0 0";
+   
+      shader = SMAA_Edge_D_Shader;
+      stateBlock = SMAA_Edge_D_StateBlock;
+   }; 
    singleton PostEffect()
    {
       internalName = "Edge Pass";
@@ -141,7 +177,7 @@ singleton PostEffect( SMAAPostFX )
    {
       internalName = "BlendPass";
 	  
-      texture[0] = "$backBuffer";
+      texture[0] = "#BBtoGamma";
 	  texture[1] = "#blendPass";
 	  
 	  target = "$backBuffer";

--- a/Templates/BaseGame/game/core/postFX/scripts/SMAA/gl/BBtoGamma.glsl
+++ b/Templates/BaseGame/game/core/postFX/scripts/SMAA/gl/BBtoGamma.glsl
@@ -19,25 +19,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
-#include "core/rendering/shaders/shaderModel.hlsl"
-#include "core/rendering/shaders/torque.hlsl"
-#include "SMAA_Params.hlsl"
-    
-                                                                         
-TORQUE_UNIFORM_SAMPLER2D(sceneTex, 0);
-TORQUE_UNIFORM_SAMPLER2D(blendTex, 1);
+#include "core/rendering/shaders/gl/torque.glsl"
+#include "core/rendering/shaders/postFX/gl/postFx.glsl"
 
-struct v_NHBlend
+uniform sampler2D backBuffer; 
+out vec4 OUT_col;
+
+void main()
 {
-   float4 hpos    : TORQUE_POSITION;
-   float2 uv0     : TEXCOORD0;
-   float4 offset  : TEXCOORD1;
-};
-
-            
-float4 main( v_NHBlend IN ) : TORQUE_TARGET0
-{   
-    //return float4(TORQUE_TEX2D(blendTex, IN.uv0));
-   return toLinear(SMAANeighborhoodBlendingPS(IN.uv0, IN.offset, texture_sceneTex, texture_blendTex));
-} 
-
+   OUT_col= toGamma(texture(backBuffer, uv0));  
+}

--- a/Templates/BaseGame/game/core/postFX/scripts/SMAA/gl/SMAA_Neighbor_H_Blending_P.glsl
+++ b/Templates/BaseGame/game/core/postFX/scripts/SMAA/gl/SMAA_Neighbor_H_Blending_P.glsl
@@ -20,7 +20,7 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 #include "core/rendering/shaders/gl/hlslCompat.glsl"
-
+#include "core/rendering/shaders/gl/torque.glsl"
 
 #include "SMAA_Params.glsl"
 #define SMAA_INCLUDE_VS 0
@@ -41,6 +41,6 @@ out vec4 OUT_col;
 void main() 
 {                                    
    //OUT_col =  vec4(texture(blendTex, uv0.xy));     
-  OUT_col= SMAANeighborhoodBlendingPS(uv0, offset, sceneTex, blendTex);
+  OUT_col= toLinear(SMAANeighborhoodBlendingPS(uv0, offset, sceneTex, blendTex));
 } 
 


### PR DESCRIPTION
as we do not at time of writing have a specifier for what colorspace to load a backbuffer in, we leverage the old toGamma and toLinear macros to upshift the backbuffer for lumina edge detection via a clone