### PR TITLE
Tweak to the linux platform CICD testing

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Setup Environment
       run:   |
              if [ "$RUNNER_OS" == "Linux" ]; then
+                  sudo apt-get update \
                   sudo apt-get install -y \
                     build-essential \
                     nasm \


### PR DESCRIPTION
Tweak to the linux platform CICD testing to force it to run apt-get update before installing additional packages, which in theory will reduce the incidence rate of failing to spool up.