### PR TITLE
adds a mechanism to inject additional steps into mission loading

### DIFF
--- a/Templates/BaseGame/game/core/clientServer/Core_ClientServer.tscript
+++ b/Templates/BaseGame/game/core/clientServer/Core_ClientServer.tscript
@@ -39,6 +39,32 @@ function Core_ClientServerListener::onMapLoadComplete(%this)
     }
 }
 
+function Core_ClientServerListener::onmapLoadFail(%this, %isFine)
+{   
+    if (%isFine) 
+    {
+        %this.onMapLoadComplete();
+        return;
+    }
+    
+    $moduleLoadedFailed++;
+    echo("onmapLoadFail!");
+    if ($moduleLoadedFailed>1) return; // yeah, we know
+        
+    $Server::LoadFailMsg = "Failed to load map!";
+    // Inform clients that are already connected
+    
+    for (%clientIndex = 0; %clientIndex < ClientGroup.getCount(); %clientIndex++)
+    {
+        %cl = ClientGroup.getObject( %clientIndex );
+        %cl.onConnectionDropped($Server::LoadFailMsg);
+        %cl.endMission();
+        %cl.resetGhosting();
+        %cl.clearPaths();
+    }
+    destroyServer();
+}
+
 function Core_ClientServer::onCreate( %this )
 {
    echo("\n--------- Initializing Directory: scripts ---------");
@@ -61,8 +87,10 @@ function Core_ClientServer::onCreate( %this )
       initClient();
    }
    %this.GetEventManager().registerEvent("mapLoadComplete");
+   %this.GetEventManager().registerEvent("mapLoadFail");
    %this.listener = new ScriptMsgListener() {class = Core_ClientServerListener;}; 
    %this.GetEventManager().subscribe( %this.listener, "mapLoadComplete" ); 
+   %this.GetEventManager().subscribe( %this.listener, "mapLoadFail" ); 
 }
 
 function Core_ClientServer::onDestroy( %this )

--- a/Templates/BaseGame/game/core/clientServer/Core_ClientServer.tscript
+++ b/Templates/BaseGame/game/core/clientServer/Core_ClientServer.tscript
@@ -12,6 +12,33 @@
 // When a local game is started - a listen server - via calling StartGame() a server is created and then the client is
 // connected to it via createAndConnectToLocalServer().
 
+function Core_ClientServer::onLoadMap(%this)
+{
+    %this.finishMapLoad();
+}
+
+function Core_ClientServer::finishMapLoad()
+{
+    Core_ClientServer.GetEventManager().postEvent( "mapLoadComplete" );
+}
+
+function Core_ClientServerListener::onMapLoadComplete(%this)
+{
+    $moduleLoadedDone++;
+    %numModsNeedingLoaded = 0;
+    %modulesList = ModuleDatabase.findModules();
+    for(%i=0; %i < getWordCount(%modulesList); %i++)
+    {
+        %module = getWord(%modulesList, %i);
+        if (%module.ModuleId.isMethod("finishMapLoad"))
+            %numModsNeedingLoaded++;
+    }
+    if ($moduleLoadedDone == %numModsNeedingLoaded)
+    {
+        loadMissionStage3();  
+    }
+}
+
 function Core_ClientServer::onCreate( %this )
 {
    echo("\n--------- Initializing Directory: scripts ---------");
@@ -33,6 +60,9 @@ function Core_ClientServer::onCreate( %this )
    {
       initClient();
    }
+   %this.GetEventManager().registerEvent("mapLoadComplete");
+   %this.listener = new ScriptMsgListener() {class = Core_ClientServerListener;}; 
+   %this.GetEventManager().subscribe( %this.listener, "mapLoadComplete" ); 
 }
 
 function Core_ClientServer::onDestroy( %this )

--- a/Templates/BaseGame/game/core/clientServer/Core_ClientServer.tscript
+++ b/Templates/BaseGame/game/core/clientServer/Core_ClientServer.tscript
@@ -12,19 +12,30 @@
 // When a local game is started - a listen server - via calling StartGame() a server is created and then the client is
 // connected to it via createAndConnectToLocalServer().
 
+function Core_ClientServer::clearLoadStatus()
+{
+   Core_ClientServer.moduleLoadedDone = 0;
+   Core_ClientServer.moduleLoadedFailed = 0;
+}
 function Core_ClientServer::onLoadMap(%this)
 {
     %this.finishMapLoad();
 }
 
-function Core_ClientServer::finishMapLoad()
+function Core_ClientServer::finishMapLoad(%this)
 {
     Core_ClientServer.GetEventManager().postEvent( "mapLoadComplete" );
 }
 
+function Core_ClientServer::FailMapLoad(%this, %moduleName, %isFine)
+{    
+    Core_ClientServer.failedModuleName = %moduleName;
+    Core_ClientServer.GetEventManager().postEvent( "mapLoadFail", %isFine );
+}
+
 function Core_ClientServerListener::onMapLoadComplete(%this)
 {
-    $moduleLoadedDone++;
+    Core_ClientServer.moduleLoadedDone++;
     %numModsNeedingLoaded = 0;
     %modulesList = ModuleDatabase.findModules();
     for(%i=0; %i < getWordCount(%modulesList); %i++)
@@ -33,7 +44,7 @@ function Core_ClientServerListener::onMapLoadComplete(%this)
         if (%module.ModuleId.isMethod("finishMapLoad"))
             %numModsNeedingLoaded++;
     }
-    if ($moduleLoadedDone == %numModsNeedingLoaded)
+    if (Core_ClientServer.moduleLoadedDone == %numModsNeedingLoaded)
     {
         loadMissionStage3();  
     }
@@ -47,11 +58,11 @@ function Core_ClientServerListener::onmapLoadFail(%this, %isFine)
         return;
     }
     
-    $moduleLoadedFailed++;
-    echo("onmapLoadFail!");
-    if ($moduleLoadedFailed>1) return; // yeah, we know
+    Core_ClientServer.moduleLoadedFailed++;
+    if (Core_ClientServer.moduleLoadedFailed>1) return; // yeah, we know
         
-    $Server::LoadFailMsg = "Failed to load map!";
+    $Server::LoadFailMsg = Core_ClientServer.failedModuleName @" failed to load mission specific data!";
+    error($Server::LoadFailMsg);
     // Inform clients that are already connected
     
     for (%clientIndex = 0; %clientIndex < ClientGroup.getCount(); %clientIndex++)

--- a/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.tscript
@@ -126,8 +126,7 @@ function loadMissionStage2()
    // Set mission name.
    if( isObject( theLevelInfo ) )
       $Server::MissionName = theLevelInfo.levelName;
-   $moduleLoadedDone = 0;
-   $moduleLoadedFailed = 0;
+   Core_ClientServer.clearLoadStatus();
    callOnModules("onLoadMap");
 
 }

--- a/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.tscript
@@ -127,6 +127,7 @@ function loadMissionStage2()
    if( isObject( theLevelInfo ) )
       $Server::MissionName = theLevelInfo.levelName;
    $moduleLoadedDone = 0;
+   $moduleLoadedFailed = 0;
    callOnModules("onLoadMap");
 
 }

--- a/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.tscript
@@ -126,7 +126,14 @@ function loadMissionStage2()
    // Set mission name.
    if( isObject( theLevelInfo ) )
       $Server::MissionName = theLevelInfo.levelName;
+   $moduleLoadedDone = 0;
+   callOnModules("onLoadMap");
 
+}
+
+function loadMissionStage3() 
+{
+   echo("*** Stage 3 load");
    
    %hasGameMode = callGamemodeFunction("onCreateGame");
    
@@ -143,8 +150,8 @@ function loadMissionStage2()
 
    // Go ahead and launch the game
    %hasGameMode = callGamemodeFunction("onMissionStart");
+   
 }
-
 function endMission()
 {
    if (!isObject( getScene(0) ))

--- a/Templates/BaseGame/game/core/utility/scripts/module.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/module.tscript
@@ -317,3 +317,10 @@ function SimSet::unQueueExec(%scopeSet, %execFilePath)
       %execFileList.echo();
 }
 
+function SimSet::GetEventManager(%this)
+{
+   if( !isObject( %this.eventManager ) )
+      %this.eventManager = new EventManager() { queue = "ModuleEventManager"; };
+      
+   return %this.eventManager;
+}


### PR DESCRIPTION
leverages the EventManager and ScriptMsgListener() classes to set up a third mission load stage triggered by the following flow: 
function <module>::onLoadMap(%this) starts an execution chain that leads to <module>::finishMapLoad().
each  <module>::finishMapLoad() MUST contain the line
     Core_ClientServer.GetEventManager().postEvent( "mapLoadComplete" );
once all have called back that they have finished their tasks, players finish loading into a hosted mission