### PR TITLE
Updates the behavior and layout of the ImageAsset, MaterialAsset and ShapeAsset inspector fields

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -475,73 +475,116 @@ GuiControl* GuiInspectorTypeImageAssetPtr::constructEditControl()
    if (retCtrl == NULL)
       return retCtrl;
 
-   retCtrl->getRenderTooltipDelegate().bind(this, &GuiInspectorTypeImageAssetPtr::renderTooltip);
+   // Change filespec
+   char szBuffer[512];
+
+   const char* previewImage;
 
    if (mInspector->getInspectObject() != nullptr)
    {
-      // Change filespec
-         char szBuffer[512];
       dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ImageAsset\", \"AssetBrowser.changeAsset\", %s, %s);",
          mInspector->getIdString(), mCaption);
       mBrowseButton->setField("Command", szBuffer);
 
       setDataField(StringTable->insert("targetObject"), NULL, mInspector->getInspectObject()->getIdString());
+
+      previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
    }
    else
    {
       //if we don't have a target object, we'll be manipulating the desination value directly
-      char szBuffer[512];
       dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ImageAsset\", \"AssetBrowser.changeAsset\", %s, \"%s\");",
          mInspector->getIdString(), mVariableName);
       mBrowseButton->setField("Command", szBuffer);
+
+      previewImage = Con::getVariable(mVariableName);
    }
 
-   mImageEdButton = NULL;
-   // Create "Open in ImageEditor" button
-   /*mImageEdButton = new GuiBitmapButtonCtrl();
+   mLabel = new GuiTextCtrl();
+   mLabel->registerObject();
+   mLabel->setControlProfile(mProfile);
+   mLabel->setText(mCaption);
+   addObject(mLabel);
 
-   char bitmapName[512] = "ToolsModule:GameTSCtrl_image";
-   mImageEdButton->setBitmap(StringTable->insert(bitmapName));
-   mImageEdButton->setHidden(true);
+   //
+   GuiTextEditCtrl* editTextCtrl = static_cast<GuiTextEditCtrl*>(retCtrl);
+   GuiControlProfile* toolEditProfile;
+   if (Sim::findObject("ToolsGuiTextEditProfile", toolEditProfile))
+      editTextCtrl->setControlProfile(toolEditProfile);
 
-   mImageEdButton->setDataField(StringTable->insert("Profile"), NULL, "GuiButtonProfile");
-   mImageEdButton->setDataField(StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile");
-   mImageEdButton->setDataField(StringTable->insert("hovertime"), NULL, "1000");
-   mImageEdButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this file in the Image Editor");
+   GuiControlProfile* toolDefaultProfile = nullptr;
+   Sim::findObject("ToolsGuiDefaultProfile", toolDefaultProfile);
 
-   mImageEdButton->registerObject();
-   addObject(mImageEdButton);*/
+   //
+   mPreviewImage = new GuiBitmapCtrl();
+   mPreviewImage->registerObject();
+
+   if (toolDefaultProfile)
+      mPreviewImage->setControlProfile(toolDefaultProfile);
+
+   updatePreviewImage();
+
+   addObject(mPreviewImage);
+
+   //
+   mPreviewBorderButton = new GuiBitmapButtonCtrl();
+   mPreviewBorderButton->registerObject();
+
+   if (toolDefaultProfile)
+      mPreviewBorderButton->setControlProfile(toolDefaultProfile);
+
+   mPreviewBorderButton->_setBitmap(StringTable->insert("ToolsModule:cubemapBtnBorder_n_image"));
+
+   mPreviewBorderButton->setField("Command", szBuffer); //clicking the preview does the same thing as the edit button, for simplicity
+   addObject(mPreviewBorderButton);
+
+   //
+   // Create "Open in Editor" button
+   mEditButton = new GuiBitmapButtonCtrl();
+
+   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.editAsset(%d.getText());", retCtrl->getId());
+   mEditButton->setField("Command", szBuffer);
+
+   mEditButton->setText("Edit");
+   mEditButton->setSizing(horizResizeLeft, vertResizeAspectTop);
+
+   mEditButton->setDataField(StringTable->insert("Profile"), NULL, "ToolsGuiButtonProfile");
+   mEditButton->setDataField(StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile");
+   mEditButton->setDataField(StringTable->insert("hovertime"), NULL, "1000");
+   mEditButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this asset in the Material Editor");
+
+   mEditButton->registerObject();
+   addObject(mEditButton);
+
+   //
+   mUseHeightOverride = true;
+   mHeightOverride = 72;
 
    return retCtrl;
 }
 
 bool GuiInspectorTypeImageAssetPtr::updateRects()
 {
+   S32 rowSize = 18;
    S32 dividerPos, dividerMargin;
    mInspector->getDivider(dividerPos, dividerMargin);
    Point2I fieldExtent = getExtent();
    Point2I fieldPos = getPosition();
 
-   mCaptionRect.set(0, 0, fieldExtent.x - dividerPos - dividerMargin, fieldExtent.y);
-   mEditCtrlRect.set(fieldExtent.x - dividerPos + dividerMargin, 1, dividerPos - dividerMargin - 34, fieldExtent.y);
+   mEditCtrlRect.set(0, 0, fieldExtent.x, fieldExtent.y);
+   mLabel->resize(Point2I(mProfile->mTextOffset.x, 0), Point2I(fieldExtent.x, rowSize));
 
-   bool resized = mEdit->resize(mEditCtrlRect.point, mEditCtrlRect.extent);
-   if (mImageEdButton != NULL)
-   {
-      RectI shapeEdRect(fieldExtent.x - 16, 2, 14, fieldExtent.y - 4);
-      resized |= mImageEdButton->resize(shapeEdRect.point, shapeEdRect.extent);
-   }
+   RectI previewRect = RectI(Point2I(mProfile->mTextOffset.x, rowSize), Point2I(50, 50));
+   mPreviewBorderButton->resize(previewRect.point, previewRect.extent);
+   mPreviewImage->resize(previewRect.point, previewRect.extent);
 
-   if (mBrowseButton != NULL)
-   {
-      if(mImageEdButton != NULL)
-         mBrowseRect.set(fieldExtent.x - 32, 2, 14, fieldExtent.y - 4);
-      else
-         mBrowseRect.set(fieldExtent.x - 16, 2, 14, fieldExtent.y - 4);
-      resized |= mBrowseButton->resize(mBrowseRect.point, mBrowseRect.extent);
-   }
+   mEdit->resize(Point2I(previewRect.point.x + previewRect.extent.x + 10, rowSize * 1.5), Point2I(200, rowSize));
 
-   return resized;
+   mEditButton->resize(Point2I(fieldExtent.x - 100, fieldExtent.y - rowSize), Point2I(100, rowSize));
+
+   mBrowseButton->setHidden(true);
+
+   return true;
 }
 
 bool GuiInspectorTypeImageAssetPtr::renderTooltip(const Point2I& hoverPos, const Point2I& cursorPos, const char* tipText)
@@ -615,6 +658,69 @@ bool GuiInspectorTypeImageAssetPtr::renderTooltip(const Point2I& hoverPos, const
    GFX->setClipRect(oldClip);
 
    return true;
+}
+
+void GuiInspectorTypeImageAssetPtr::updateValue()
+{
+   Parent::updateValue();
+
+   updatePreviewImage();
+}
+
+void GuiInspectorTypeImageAssetPtr::updatePreviewImage()
+{
+   const char* previewImage;
+   if (mInspector->getInspectObject() != nullptr)
+      previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
+   else
+      previewImage = Con::getVariable(mVariableName);
+
+   String imgPreviewAssetId = String(previewImage) + "_PreviewImage";
+   imgPreviewAssetId.replace(":", "_");
+   imgPreviewAssetId = "ToolsModule:" + imgPreviewAssetId;
+   if (AssetDatabase.isDeclaredAsset(imgPreviewAssetId.c_str()))
+   {
+      mPreviewImage->setBitmap(StringTable->insert(imgPreviewAssetId.c_str()));
+   }
+   else
+   {
+      if (AssetDatabase.isDeclaredAsset(previewImage))
+      {
+         ImageAsset* imgAsset = AssetDatabase.acquireAsset<ImageAsset>(previewImage);
+         if (imgAsset && imgAsset->isAssetValid())
+         {
+            mPreviewImage->_setBitmap(imgAsset->getAssetId());
+         }
+      }
+   }
+
+   if (mPreviewImage->getBitmapAsset().isNull())
+      mPreviewImage->_setBitmap(StringTable->insert("ToolsModule:genericAssetIcon_image"));
+}
+
+void GuiInspectorTypeImageAssetPtr::setPreviewImage(StringTableEntry assetId)
+{
+   String imgPreviewAssetId = String(assetId) + "_PreviewImage";
+   imgPreviewAssetId.replace(":", "_");
+   imgPreviewAssetId = "ToolsModule:" + imgPreviewAssetId;
+   if (AssetDatabase.isDeclaredAsset(imgPreviewAssetId.c_str()))
+   {
+      mPreviewImage->setBitmap(StringTable->insert(imgPreviewAssetId.c_str()));
+   }
+   else
+   {
+      if (AssetDatabase.isDeclaredAsset(assetId))
+      {
+         ImageAsset* imgAsset = AssetDatabase.acquireAsset<ImageAsset>(assetId);
+         if (imgAsset && imgAsset->isAssetValid())
+         {
+            mPreviewImage->_setBitmap(imgAsset->getAssetId());
+         }
+      }
+   }
+
+   if (mPreviewImage->getBitmapAsset().isNull())
+      mPreviewImage->_setBitmap(StringTable->insert("ToolsModule:genericAssetIcon_image"));
 }
 
 IMPLEMENT_CONOBJECT(GuiInspectorTypeImageAssetId);

--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -475,6 +475,8 @@ GuiControl* GuiInspectorTypeImageAssetPtr::constructEditControl()
    if (retCtrl == NULL)
       return retCtrl;
 
+   retCtrl->getRenderTooltipDelegate().bind(this, &GuiInspectorTypeImageAssetPtr::renderTooltip);
+
    // Change filespec
    char szBuffer[512];
 

--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -542,7 +542,7 @@ GuiControl* GuiInspectorTypeImageAssetPtr::constructEditControl()
 
    //
    // Create "Open in Editor" button
-   mEditButton = new GuiBitmapButtonCtrl();
+   /*mEditButton = new GuiBitmapButtonCtrl();
 
    dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.editAsset(%d.getText());", retCtrl->getId());
    mEditButton->setField("Command", szBuffer);
@@ -553,10 +553,10 @@ GuiControl* GuiInspectorTypeImageAssetPtr::constructEditControl()
    mEditButton->setDataField(StringTable->insert("Profile"), NULL, "ToolsGuiButtonProfile");
    mEditButton->setDataField(StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile");
    mEditButton->setDataField(StringTable->insert("hovertime"), NULL, "1000");
-   mEditButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this asset in the Material Editor");
+   mEditButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this asset in the Image Editor");
 
    mEditButton->registerObject();
-   addObject(mEditButton);
+   addObject(mEditButton);*/
 
    //
    mUseHeightOverride = true;
@@ -580,9 +580,10 @@ bool GuiInspectorTypeImageAssetPtr::updateRects()
    mPreviewBorderButton->resize(previewRect.point, previewRect.extent);
    mPreviewImage->resize(previewRect.point, previewRect.extent);
 
-   mEdit->resize(Point2I(previewRect.point.x + previewRect.extent.x + 10, rowSize * 1.5), Point2I(200, rowSize));
+   S32 editPos = previewRect.point.x + previewRect.extent.x + 10;
+   mEdit->resize(Point2I(editPos, rowSize * 1.5), Point2I(fieldExtent.x - editPos - 5, rowSize));
 
-   mEditButton->resize(Point2I(fieldExtent.x - 100, fieldExtent.y - rowSize), Point2I(100, rowSize));
+   //mEditButton->resize(Point2I(fieldExtent.x - 105, previewRect.point.y + previewRect.extent.y - rowSize), Point2I(100, rowSize));
 
    mBrowseButton->setHidden(true);
 
@@ -677,6 +678,13 @@ void GuiInspectorTypeImageAssetPtr::updatePreviewImage()
    else
       previewImage = Con::getVariable(mVariableName);
 
+   //if what we're working with isn't even a valid asset, don't present like we found a good one
+   if (!AssetDatabase.isDeclaredAsset(previewImage))
+   {
+      mPreviewImage->_setBitmap(StringTable->EmptyString());
+      return;
+   }
+
    String imgPreviewAssetId = String(previewImage) + "_PreviewImage";
    imgPreviewAssetId.replace(":", "_");
    imgPreviewAssetId = "ToolsModule:" + imgPreviewAssetId;
@@ -702,6 +710,13 @@ void GuiInspectorTypeImageAssetPtr::updatePreviewImage()
 
 void GuiInspectorTypeImageAssetPtr::setPreviewImage(StringTableEntry assetId)
 {
+   //if what we're working with isn't even a valid asset, don't present like we found a good one
+   if (!AssetDatabase.isDeclaredAsset(assetId))
+   {
+      mPreviewImage->_setBitmap(StringTable->EmptyString());
+      return;
+   }
+
    String imgPreviewAssetId = String(assetId) + "_PreviewImage";
    imgPreviewAssetId.replace(":", "_");
    imgPreviewAssetId = "ToolsModule:" + imgPreviewAssetId;

--- a/Engine/source/T3D/assets/ImageAssetInspectors.h
+++ b/Engine/source/T3D/assets/ImageAssetInspectors.h
@@ -5,6 +5,7 @@
 #ifndef _GUI_INSPECTOR_TYPES_H_
 #include "gui/editor/guiInspectorTypes.h"
 #endif
+#include <gui/controls/guiBitmapCtrl.h>
 
 #ifdef TORQUE_TOOLS
 class GuiInspectorTypeImageAssetPtr : public GuiInspectorTypeFileName
@@ -12,7 +13,10 @@ class GuiInspectorTypeImageAssetPtr : public GuiInspectorTypeFileName
    typedef GuiInspectorTypeFileName Parent;
 public:
 
-   GuiBitmapButtonCtrl* mImageEdButton;
+   GuiTextCtrl* mLabel;
+   GuiBitmapButtonCtrl* mPreviewBorderButton;
+   GuiBitmapCtrl* mPreviewImage;
+   GuiButtonCtrl* mEditButton;
 
    DECLARE_CONOBJECT(GuiInspectorTypeImageAssetPtr);
    static void consoleInit();
@@ -20,6 +24,11 @@ public:
    virtual GuiControl* constructEditControl();
    virtual bool updateRects();
    bool renderTooltip(const Point2I& hoverPos, const Point2I& cursorPos, const char* tipText = NULL);
+
+   virtual void updateValue();
+
+   void updatePreviewImage();
+   void setPreviewImage(StringTableEntry assetId);
 };
 
 class GuiInspectorTypeImageAssetId : public GuiInspectorTypeImageAssetPtr

--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -480,6 +480,8 @@ GuiControl* GuiInspectorTypeMaterialAssetPtr::constructEditControl()
    // Change filespec
    char szBuffer[512];
 
+   const char* previewImage;
+
    if (mInspector->getInspectObject() != nullptr)
    {
       dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"MaterialAsset\", \"AssetBrowser.changeAsset\", %s, %s);",
@@ -487,6 +489,8 @@ GuiControl* GuiInspectorTypeMaterialAssetPtr::constructEditControl()
       mBrowseButton->setField("Command", szBuffer);
 
       setDataField(StringTable->insert("targetObject"), NULL, mInspector->getInspectObject()->getIdString());
+
+      previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
    }
    else
    {
@@ -494,18 +498,59 @@ GuiControl* GuiInspectorTypeMaterialAssetPtr::constructEditControl()
       dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"MaterialAsset\", \"AssetBrowser.changeAsset\", %s, \"%s\");",
          mInspector->getIdString(), mVariableName);
       mBrowseButton->setField("Command", szBuffer);
+
+      previewImage = Con::getVariable(mVariableName);
    }
 
+   mLabel = new GuiTextCtrl();
+   mLabel->registerObject();
+   mLabel->setControlProfile(mProfile);
+   mLabel->setText(mCaption);
+   addObject(mLabel);
+
+   //
+   GuiTextEditCtrl* editTextCtrl = static_cast<GuiTextEditCtrl*>(retCtrl);
+   GuiControlProfile* toolEditProfile;
+   if (Sim::findObject("ToolsGuiTextEditProfile", toolEditProfile))
+      editTextCtrl->setControlProfile(toolEditProfile);
+
+   GuiControlProfile* toolDefaultProfile = nullptr;
+   Sim::findObject("ToolsGuiDefaultProfile", toolDefaultProfile);
+
+   //
+   mPreviewImage = new GuiBitmapCtrl();
+   mPreviewImage->registerObject();
+
+   if(toolDefaultProfile)
+      mPreviewImage->setControlProfile(toolDefaultProfile);
+
+   updatePreviewImage();
+
+   addObject(mPreviewImage);
+
+   //
+   mPreviewBorderButton = new GuiBitmapButtonCtrl();
+   mPreviewBorderButton->registerObject();
+
+   if(toolDefaultProfile)
+      mPreviewBorderButton->setControlProfile(toolDefaultProfile);
+
+   mPreviewBorderButton->_setBitmap(StringTable->insert("ToolsModule:cubemapBtnBorder_n_image"));
+
+   mPreviewBorderButton->setField("Command", szBuffer); //clicking the preview does the same thing as the edit button, for simplicity
+   addObject(mPreviewBorderButton);
+
+   //
    // Create "Open in Editor" button
    mEditButton = new GuiBitmapButtonCtrl();
 
    dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.editAsset(%d.getText());", retCtrl->getId());
    mEditButton->setField("Command", szBuffer);
 
-   char bitmapName[512] = "ToolsModule:material_editor_n_image";
-   mEditButton->setBitmap(StringTable->insert(bitmapName));
+   mEditButton->setText("Edit");
+   mEditButton->setSizing(horizResizeLeft, vertResizeAspectTop);
 
-   mEditButton->setDataField(StringTable->insert("Profile"), NULL, "GuiButtonProfile");
+   mEditButton->setDataField(StringTable->insert("Profile"), NULL, "ToolsGuiButtonProfile");
    mEditButton->setDataField(StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile");
    mEditButton->setDataField(StringTable->insert("hovertime"), NULL, "1000");
    mEditButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this asset in the Material Editor");
@@ -513,33 +558,98 @@ GuiControl* GuiInspectorTypeMaterialAssetPtr::constructEditControl()
    mEditButton->registerObject();
    addObject(mEditButton);
 
+   //
+   mUseHeightOverride = true;
+   mHeightOverride = 72;
+
    return retCtrl;
 }
 
 bool GuiInspectorTypeMaterialAssetPtr::updateRects()
 {
+   S32 rowSize = 18;
    S32 dividerPos, dividerMargin;
    mInspector->getDivider(dividerPos, dividerMargin);
    Point2I fieldExtent = getExtent();
    Point2I fieldPos = getPosition();
 
-   mCaptionRect.set(0, 0, fieldExtent.x - dividerPos - dividerMargin, fieldExtent.y);
-   mEditCtrlRect.set(fieldExtent.x - dividerPos + dividerMargin, 1, dividerPos - dividerMargin - 34, fieldExtent.y);
+   mEditCtrlRect.set(0, 0, fieldExtent.x, fieldExtent.y);
+   mLabel->resize(Point2I(mProfile->mTextOffset.x, 0), Point2I(fieldExtent.x, rowSize));
 
-   bool resized = mEdit->resize(mEditCtrlRect.point, mEditCtrlRect.extent);
-   if (mBrowseButton != NULL)
+   RectI previewRect = RectI(Point2I(mProfile->mTextOffset.x, rowSize), Point2I(50, 50));
+   mPreviewBorderButton->resize(previewRect.point, previewRect.extent);
+   mPreviewImage->resize(previewRect.point, previewRect.extent);
+
+   mEdit->resize(Point2I(previewRect.point.x + previewRect.extent.x + 10, rowSize * 1.5), Point2I(200, rowSize));
+
+   mEditButton->resize(Point2I(fieldExtent.x - 100, fieldExtent.y - rowSize), Point2I(100, rowSize));
+
+   mBrowseButton->setHidden(true);
+
+   return true;
+}
+
+void GuiInspectorTypeMaterialAssetPtr::updateValue()
+{
+   Parent::updateValue();
+
+   updatePreviewImage();
+}
+
+void GuiInspectorTypeMaterialAssetPtr::updatePreviewImage()
+{
+   const char* previewImage;
+   if (mInspector->getInspectObject() != nullptr)
+      previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
+   else
+      previewImage = Con::getVariable(mVariableName);
+
+   String matPreviewAssetId = String(previewImage) + "_PreviewImage";
+   matPreviewAssetId.replace(":", "_");
+   matPreviewAssetId = "ToolsModule:" + matPreviewAssetId;
+   if (AssetDatabase.isDeclaredAsset(matPreviewAssetId.c_str()))
    {
-      mBrowseRect.set(fieldExtent.x - 32, 2, 14, fieldExtent.y - 4);
-      resized |= mBrowseButton->resize(mBrowseRect.point, mBrowseRect.extent);
+      mPreviewImage->setBitmap(StringTable->insert(matPreviewAssetId.c_str()));
+   }
+   else
+   {
+      if (AssetDatabase.isDeclaredAsset(previewImage))
+      {
+         MaterialAsset* matAsset = AssetDatabase.acquireAsset<MaterialAsset>(previewImage);
+         if (matAsset && matAsset->getMaterialDefinition())
+         {
+            mPreviewImage->_setBitmap(matAsset->getMaterialDefinition()->mDiffuseMapAssetId[0]);
+         }
+      }
    }
 
-   if (mEditButton != NULL)
+   if (mPreviewImage->getBitmapAsset().isNull())
+      mPreviewImage->_setBitmap(StringTable->insert("ToolsModule:genericAssetIcon_image"));
+}
+
+void GuiInspectorTypeMaterialAssetPtr::setPreviewImage(StringTableEntry assetId)
+{
+   String matPreviewAssetId = String(assetId) + "_PreviewImage";
+   matPreviewAssetId.replace(":", "_");
+   matPreviewAssetId = "ToolsModule:" + matPreviewAssetId;
+   if (AssetDatabase.isDeclaredAsset(matPreviewAssetId.c_str()))
    {
-      RectI shapeEdRect(fieldExtent.x - 16, 2, 14, fieldExtent.y - 4);
-      resized |= mEditButton->resize(shapeEdRect.point, shapeEdRect.extent);
+      mPreviewImage->setBitmap(StringTable->insert(matPreviewAssetId.c_str()));
+   }
+   else
+   {
+      if (AssetDatabase.isDeclaredAsset(assetId))
+      {
+         MaterialAsset* matAsset = AssetDatabase.acquireAsset<MaterialAsset>(assetId);
+         if (matAsset && matAsset->getMaterialDefinition())
+         {
+            mPreviewImage->_setBitmap(matAsset->getMaterialDefinition()->mDiffuseMapAssetId[0]);
+         }
+      }
    }
 
-   return resized;
+   if (mPreviewImage->getBitmapAsset().isNull())
+      mPreviewImage->_setBitmap(StringTable->insert("ToolsModule:genericAssetIcon_image"));
 }
 
 IMPLEMENT_CONOBJECT(GuiInspectorTypeMaterialAssetId);

--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -580,9 +580,10 @@ bool GuiInspectorTypeMaterialAssetPtr::updateRects()
    mPreviewBorderButton->resize(previewRect.point, previewRect.extent);
    mPreviewImage->resize(previewRect.point, previewRect.extent);
 
-   mEdit->resize(Point2I(previewRect.point.x + previewRect.extent.x + 10, rowSize * 1.5), Point2I(200, rowSize));
+   S32 editPos = previewRect.point.x + previewRect.extent.x + 10;
+   mEdit->resize(Point2I(editPos, rowSize * 1.5), Point2I(fieldExtent.x - editPos - 5, rowSize));
 
-   mEditButton->resize(Point2I(fieldExtent.x - 100, fieldExtent.y - rowSize), Point2I(100, rowSize));
+   mEditButton->resize(Point2I(fieldExtent.x - 105, previewRect.point.y + previewRect.extent.y - rowSize), Point2I(100, rowSize));
 
    mBrowseButton->setHidden(true);
 
@@ -603,6 +604,13 @@ void GuiInspectorTypeMaterialAssetPtr::updatePreviewImage()
       previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
    else
       previewImage = Con::getVariable(mVariableName);
+
+   //if what we're working with isn't even a valid asset, don't present like we found a good one
+   if (!AssetDatabase.isDeclaredAsset(previewImage))
+   {
+      mPreviewImage->_setBitmap(StringTable->EmptyString());
+      return;
+   }
 
    String matPreviewAssetId = String(previewImage) + "_PreviewImage";
    matPreviewAssetId.replace(":", "_");
@@ -629,6 +637,13 @@ void GuiInspectorTypeMaterialAssetPtr::updatePreviewImage()
 
 void GuiInspectorTypeMaterialAssetPtr::setPreviewImage(StringTableEntry assetId)
 {
+   //if what we're working with isn't even a valid asset, don't present like we found a good one
+   if (!AssetDatabase.isDeclaredAsset(assetId))
+   {
+      mPreviewImage->_setBitmap(StringTable->EmptyString());
+      return;
+   }
+
    String matPreviewAssetId = String(assetId) + "_PreviewImage";
    matPreviewAssetId.replace(":", "_");
    matPreviewAssetId = "ToolsModule:" + matPreviewAssetId;

--- a/Engine/source/T3D/assets/MaterialAsset.h
+++ b/Engine/source/T3D/assets/MaterialAsset.h
@@ -57,6 +57,7 @@
 #include "materials/customMaterialDefinition.h"
 #include "materials/materialManager.h"
 #include "assetMacroHelpers.h"
+#include <gui/controls/guiBitmapCtrl.h>
 
 //-----------------------------------------------------------------------------
 class MaterialAsset : public AssetBase
@@ -140,13 +141,21 @@ class GuiInspectorTypeMaterialAssetPtr : public GuiInspectorTypeFileName
    typedef GuiInspectorTypeFileName Parent;
 public:
 
-   GuiBitmapButtonCtrl* mEditButton;
+   GuiTextCtrl* mLabel;
+   GuiBitmapButtonCtrl* mPreviewBorderButton;
+   GuiBitmapCtrl* mPreviewImage;
+   GuiButtonCtrl* mEditButton;
 
    DECLARE_CONOBJECT(GuiInspectorTypeMaterialAssetPtr);
    static void consoleInit();
 
    virtual GuiControl* constructEditControl();
    virtual bool updateRects();
+
+   virtual void updateValue();
+
+   void updatePreviewImage();
+   void setPreviewImage(StringTableEntry assetId);
 };
 
 class GuiInspectorTypeMaterialAssetId : public GuiInspectorTypeMaterialAssetPtr

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -825,7 +825,7 @@ GuiControl* GuiInspectorTypeShapeAssetPtr::constructEditControl()
    mEditButton->setDataField(StringTable->insert("Profile"), NULL, "ToolsGuiButtonProfile");
    mEditButton->setDataField(StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile");
    mEditButton->setDataField(StringTable->insert("hovertime"), NULL, "1000");
-   mEditButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this asset in the Material Editor");
+   mEditButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this asset in the Shape Editor");
 
    mEditButton->registerObject();
    addObject(mEditButton);
@@ -852,9 +852,10 @@ bool GuiInspectorTypeShapeAssetPtr::updateRects()
    mPreviewBorderButton->resize(previewRect.point, previewRect.extent);
    mPreviewImage->resize(previewRect.point, previewRect.extent);
 
-   mEdit->resize(Point2I(previewRect.point.x + previewRect.extent.x + 10, rowSize * 1.5), Point2I(200, rowSize));
+   S32 editPos = previewRect.point.x + previewRect.extent.x + 10;
+   mEdit->resize(Point2I(editPos, rowSize * 1.5), Point2I(fieldExtent.x - editPos - 5, rowSize));
 
-   mEditButton->resize(Point2I(fieldExtent.x - 100, fieldExtent.y - rowSize), Point2I(100, rowSize));
+   mEditButton->resize(Point2I(fieldExtent.x - 105, previewRect.point.y + previewRect.extent.y - rowSize), Point2I(100, rowSize));
 
    mBrowseButton->setHidden(true);
 
@@ -876,6 +877,13 @@ void GuiInspectorTypeShapeAssetPtr::updatePreviewImage()
    else
       previewImage = Con::getVariable(mVariableName);
 
+   //if what we're working with isn't even a valid asset, don't present like we found a good one
+   if (!AssetDatabase.isDeclaredAsset(previewImage))
+   {
+      mPreviewImage->_setBitmap(StringTable->EmptyString());
+      return;
+   }
+
    String shpPreviewAssetId = String(previewImage) + "_PreviewImage";
    shpPreviewAssetId.replace(":", "_");
    shpPreviewAssetId = "ToolsModule:" + shpPreviewAssetId;
@@ -890,6 +898,13 @@ void GuiInspectorTypeShapeAssetPtr::updatePreviewImage()
 
 void GuiInspectorTypeShapeAssetPtr::setPreviewImage(StringTableEntry assetId)
 {
+   //if what we're working with isn't even a valid asset, don't present like we found a good one
+   if (!AssetDatabase.isDeclaredAsset(assetId))
+   {
+      mPreviewImage->_setBitmap(StringTable->EmptyString());
+      return;
+   }
+
    String shpPreviewAssetId = String(assetId) + "_PreviewImage";
    shpPreviewAssetId.replace(":", "_");
    shpPreviewAssetId = "ToolsModule:" + shpPreviewAssetId;

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -745,12 +745,15 @@ void GuiInspectorTypeShapeAssetPtr::consoleInit()
 GuiControl* GuiInspectorTypeShapeAssetPtr::constructEditControl()
 {
    // Create base filename edit controls
-   GuiControl *retCtrl = Parent::constructEditControl();
+   GuiControl* retCtrl = Parent::constructEditControl();
    if (retCtrl == NULL)
       return retCtrl;
 
    // Change filespec
    char szBuffer[512];
+
+   const char* previewImage;
+
    if (mInspector->getInspectObject() != nullptr)
    {
       dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ShapeAsset\", \"AssetBrowser.changeAsset\", %s, %s);",
@@ -758,6 +761,8 @@ GuiControl* GuiInspectorTypeShapeAssetPtr::constructEditControl()
       mBrowseButton->setField("Command", szBuffer);
 
       setDataField(StringTable->insert("targetObject"), NULL, mInspector->getInspectObject()->getIdString());
+
+      previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
    }
    else
    {
@@ -765,52 +770,136 @@ GuiControl* GuiInspectorTypeShapeAssetPtr::constructEditControl()
       dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ShapeAsset\", \"AssetBrowser.changeAsset\", %s, \"%s\");",
          mInspector->getIdString(), mVariableName);
       mBrowseButton->setField("Command", szBuffer);
+
+      previewImage = Con::getVariable(mVariableName);
    }
 
-   // Create "Open in ShapeEditor" button
-   mShapeEdButton = new GuiBitmapButtonCtrl();
+   mLabel = new GuiTextCtrl();
+   mLabel->registerObject();
+   mLabel->setControlProfile(mProfile);
+   mLabel->setText(mCaption);
+   addObject(mLabel);
+
+   //
+   GuiTextEditCtrl* editTextCtrl = static_cast<GuiTextEditCtrl*>(retCtrl);
+   GuiControlProfile* toolEditProfile;
+   if (Sim::findObject("ToolsGuiTextEditProfile", toolEditProfile))
+      editTextCtrl->setControlProfile(toolEditProfile);
+
+   GuiControlProfile* toolDefaultProfile = nullptr;
+   Sim::findObject("ToolsGuiDefaultProfile", toolDefaultProfile);
+
+   //
+   mPreviewImage = new GuiBitmapCtrl();
+   mPreviewImage->registerObject();
+
+   if (toolDefaultProfile)
+      mPreviewImage->setControlProfile(toolDefaultProfile);
+
+   updatePreviewImage();
+
+   addObject(mPreviewImage);
+
+   //
+   mPreviewBorderButton = new GuiBitmapButtonCtrl();
+   mPreviewBorderButton->registerObject();
+
+   if (toolDefaultProfile)
+      mPreviewBorderButton->setControlProfile(toolDefaultProfile);
+
+   mPreviewBorderButton->_setBitmap(StringTable->insert("ToolsModule:cubemapBtnBorder_n_image"));
+
+   mPreviewBorderButton->setField("Command", szBuffer); //clicking the preview does the same thing as the edit button, for simplicity
+   addObject(mPreviewBorderButton);
+
+   //
+   // Create "Open in Editor" button
+   mEditButton = new GuiBitmapButtonCtrl();
 
    dSprintf(szBuffer, sizeof(szBuffer), "ShapeEditorPlugin.openShapeAssetId(%d.getText());", retCtrl->getId());
-   mShapeEdButton->setField("Command", szBuffer);
+   mEditButton->setField("Command", szBuffer);
 
-   char bitmapName[512] = "ToolsModule:shape_editor_n_image";
-   mShapeEdButton->setBitmap(StringTable->insert(bitmapName));
+   mEditButton->setText("Edit");
+   mEditButton->setSizing(horizResizeLeft, vertResizeAspectTop);
 
-   mShapeEdButton->setDataField(StringTable->insert("Profile"), NULL, "GuiButtonProfile");
-   mShapeEdButton->setDataField(StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile");
-   mShapeEdButton->setDataField(StringTable->insert("hovertime"), NULL, "1000");
-   mShapeEdButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this file in the Shape Editor");
+   mEditButton->setDataField(StringTable->insert("Profile"), NULL, "ToolsGuiButtonProfile");
+   mEditButton->setDataField(StringTable->insert("tooltipprofile"), NULL, "GuiToolTipProfile");
+   mEditButton->setDataField(StringTable->insert("hovertime"), NULL, "1000");
+   mEditButton->setDataField(StringTable->insert("tooltip"), NULL, "Open this asset in the Material Editor");
 
-   mShapeEdButton->registerObject();
-   addObject(mShapeEdButton);
+   mEditButton->registerObject();
+   addObject(mEditButton);
+
+   //
+   mUseHeightOverride = true;
+   mHeightOverride = 72;
 
    return retCtrl;
 }
 
 bool GuiInspectorTypeShapeAssetPtr::updateRects()
 {
+   S32 rowSize = 18;
    S32 dividerPos, dividerMargin;
    mInspector->getDivider(dividerPos, dividerMargin);
    Point2I fieldExtent = getExtent();
    Point2I fieldPos = getPosition();
 
-   mCaptionRect.set(0, 0, fieldExtent.x - dividerPos - dividerMargin, fieldExtent.y);
-   mEditCtrlRect.set(fieldExtent.x - dividerPos + dividerMargin, 1, dividerPos - dividerMargin - 34, fieldExtent.y);
+   mEditCtrlRect.set(0, 0, fieldExtent.x, fieldExtent.y);
+   mLabel->resize(Point2I(mProfile->mTextOffset.x, 0), Point2I(fieldExtent.x, rowSize));
 
-   bool resized = mEdit->resize(mEditCtrlRect.point, mEditCtrlRect.extent);
-   if (mBrowseButton != NULL)
+   RectI previewRect = RectI(Point2I(mProfile->mTextOffset.x, rowSize), Point2I(50, 50));
+   mPreviewBorderButton->resize(previewRect.point, previewRect.extent);
+   mPreviewImage->resize(previewRect.point, previewRect.extent);
+
+   mEdit->resize(Point2I(previewRect.point.x + previewRect.extent.x + 10, rowSize * 1.5), Point2I(200, rowSize));
+
+   mEditButton->resize(Point2I(fieldExtent.x - 100, fieldExtent.y - rowSize), Point2I(100, rowSize));
+
+   mBrowseButton->setHidden(true);
+
+   return true;
+}
+
+void GuiInspectorTypeShapeAssetPtr::updateValue()
+{
+   Parent::updateValue();
+
+   updatePreviewImage();
+}
+
+void GuiInspectorTypeShapeAssetPtr::updatePreviewImage()
+{
+   const char* previewImage;
+   if (mInspector->getInspectObject() != nullptr)
+      previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
+   else
+      previewImage = Con::getVariable(mVariableName);
+
+   String shpPreviewAssetId = String(previewImage) + "_PreviewImage";
+   shpPreviewAssetId.replace(":", "_");
+   shpPreviewAssetId = "ToolsModule:" + shpPreviewAssetId;
+   if (AssetDatabase.isDeclaredAsset(shpPreviewAssetId.c_str()))
    {
-      mBrowseRect.set(fieldExtent.x - 32, 2, 14, fieldExtent.y - 4);
-      resized |= mBrowseButton->resize(mBrowseRect.point, mBrowseRect.extent);
+      mPreviewImage->setBitmap(StringTable->insert(shpPreviewAssetId.c_str()));
    }
 
-   if (mShapeEdButton != NULL)
+   if (mPreviewImage->getBitmapAsset().isNull())
+      mPreviewImage->_setBitmap(StringTable->insert("ToolsModule:genericAssetIcon_image"));
+}
+
+void GuiInspectorTypeShapeAssetPtr::setPreviewImage(StringTableEntry assetId)
+{
+   String shpPreviewAssetId = String(assetId) + "_PreviewImage";
+   shpPreviewAssetId.replace(":", "_");
+   shpPreviewAssetId = "ToolsModule:" + shpPreviewAssetId;
+   if (AssetDatabase.isDeclaredAsset(shpPreviewAssetId.c_str()))
    {
-      RectI shapeEdRect(fieldExtent.x - 16, 2, 14, fieldExtent.y - 4);
-      resized |= mShapeEdButton->resize(shapeEdRect.point, shapeEdRect.extent);
+      mPreviewImage->setBitmap(StringTable->insert(shpPreviewAssetId.c_str()));
    }
 
-   return resized;
+   if (mPreviewImage->getBitmapAsset().isNull())
+      mPreviewImage->_setBitmap(StringTable->insert("ToolsModule:genericAssetIcon_image"));
 }
 
 IMPLEMENT_CONOBJECT(GuiInspectorTypeShapeAssetId);

--- a/Engine/source/T3D/assets/ShapeAsset.h
+++ b/Engine/source/T3D/assets/ShapeAsset.h
@@ -221,13 +221,21 @@ class GuiInspectorTypeShapeAssetPtr : public GuiInspectorTypeFileName
    typedef GuiInspectorTypeFileName Parent;
 public:
 
-   GuiBitmapButtonCtrl* mShapeEdButton;
+   GuiTextCtrl* mLabel;
+   GuiBitmapButtonCtrl* mPreviewBorderButton;
+   GuiBitmapCtrl* mPreviewImage;
+   GuiButtonCtrl* mEditButton;
 
    DECLARE_CONOBJECT(GuiInspectorTypeShapeAssetPtr);
    static void consoleInit();
 
    virtual GuiControl* constructEditControl();
    virtual bool updateRects();
+
+   virtual void updateValue();
+
+   void updatePreviewImage();
+   void setPreviewImage(StringTableEntry assetId);
 };
 
 class GuiInspectorTypeShapeAssetId : public GuiInspectorTypeShapeAssetPtr

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -1638,7 +1638,7 @@ void TSStatic::getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList)
 #ifdef TORQUE_TOOLS
 void TSStatic::onInspect(GuiInspector* inspector)
 {
-   if (mShapeAsset == nullptr)
+   //if (mShapeAsset == nullptr)
       return;
 
    //Put the GameObject group before everything that'd be gameobject-effecting, for orginazational purposes

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -411,8 +411,8 @@ bool TSStatic::_createShape()
    resetWorldBox();
 
    mShapeInstance = new TSShapeInstance(mShape, isClientObject());
-   if (isClientObject())
-      mShapeInstance->cloneMaterialList();
+   mShapeInstance->resetMaterialList();
+   mShapeInstance->cloneMaterialList();
 
    if (isGhost())
    {
@@ -1649,28 +1649,18 @@ void TSStatic::onInspect(GuiInspector* inspector)
    GuiControl* stack = dynamic_cast<GuiControl*>(materialGroup->findObjectByInternalName(StringTable->insert("Stack")));
 
    //Do this on both the server and client
-   S32 materialCount = mShapeAsset->getShape()->materialList->getMaterialNameList().size(); //mMeshAsset->getMaterialCount();
+   TSMaterialList* matList = mShapeInstance->getMaterialList();
+   Vector<String> matListNames = matList->getMaterialNameList();
+   S32 materialCount = matListNames.size();
 
    if (isServerObject())
    {
-      //we need to update the editor
-      /*for (U32 i = 0; i < mFields.size(); i++)
-      {
-         //find any with the materialslot title and clear them out
-         if (FindMatch::isMatch("MaterialSlot*", mFields[i].mFieldName, false))
-         {
-            setDataField(mFields[i].mFieldName, NULL, "");
-            mFields.erase(i);
-            continue;
-         }
-      }*/
-
       //next, get a listing of our materials in the shape, and build our field list for them
       char matFieldName[128];
 
       for (U32 i = 0; i < materialCount; i++)
       {
-         StringTableEntry materialname = StringTable->insert(mShapeAsset->getShape()->materialList->getMaterialName(i).c_str());
+         StringTableEntry materialname = StringTable->insert(mShapeInstance->getMaterialList()->getMaterialName(i).c_str());
 
          AssetPtr<MaterialAsset> matAsset;
          if(MaterialAsset::getAssetByMaterialName(materialname, &matAsset) == MaterialAsset::Ok)
@@ -1693,6 +1683,9 @@ void TSStatic::onInspect(GuiInspector* inspector)
             if (fieldGui->registerObject())
             {
                StringTableEntry fieldValue = matAsset->getAssetId();
+
+               GuiInspectorTypeMaterialAssetPtr* matFieldPtr = dynamic_cast<GuiInspectorTypeMaterialAssetPtr*>(fieldGui);
+               matFieldPtr->setPreviewImage(fieldValue);
 
                //Check if we'd already actually changed it, and display the modified value
                for (U32 c = 0; c < mChangingMaterials.size(); c++)

--- a/Engine/source/gui/controls/guiBitmapCtrl.cpp
+++ b/Engine/source/gui/controls/guiBitmapCtrl.cpp
@@ -126,9 +126,6 @@ void GuiBitmapCtrl::inspectPostApply()
 
 void GuiBitmapCtrl::setBitmap( const char *name, bool resize )
 {
-   if ( !isAwake() )
-      return;
-
    _setBitmap(StringTable->insert(name));
 
    if (mBitmap && resize)

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
@@ -336,17 +336,14 @@ function GuiInspectorTypeImageAssetPtr::onControlDropped( %this, %payload, %posi
       return;
 
    %assetType = %payload.assetType;
+   %module = %payload.moduleName;
+   %assetName = %payload.assetName;
    
    if(%assetType $= "ImageAsset")
    {
-      %module = %payload.moduleName;
-      %asset = %payload.assetName;
-      
-      %oldValue = %this.targetObject.bitmapAsset;
-      %arrayIndex = "";
-      
-      %targetObject = %this.targetObject;
-      %targetObject.bitmapAsset = %module @ ":" @ %asset; 
+      %cmd = %this @ ".apply(\""@ %module @ ":" @ %assetName @ "\");";
+      echo("Changing asset via the " @ %cmd @ " command");
+      eval(%cmd);
    }
    
    EWorldEditor.isDirty = true;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
@@ -342,7 +342,6 @@ function GuiInspectorTypeImageAssetPtr::onControlDropped( %this, %payload, %posi
    if(%assetType $= "ImageAsset")
    {
       %cmd = %this @ ".apply(\""@ %module @ ":" @ %assetName @ "\");";
-      echo("Changing asset via the " @ %cmd @ " command");
       eval(%cmd);
    }
    

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
@@ -595,7 +595,6 @@ function GuiInspectorTypeMaterialAssetPtr::onControlDropped( %this, %payload, %p
    if(%assetType $= "MaterialAsset")
    {
       %cmd = %this @ ".apply(\""@ %module @ ":" @ %assetName @ "\");";
-      echo("Changing asset via the " @ %cmd @ " command");
       eval(%cmd);
    }
    

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
@@ -411,18 +411,14 @@ function GuiInspectorTypeShapeAssetPtr::onControlDropped( %this, %payload, %posi
       return;
 
    %assetType = %payload.assetType;
+   %module = %payload.moduleName;
+   %assetName = %payload.assetName;
    
    if(%assetType $= "ShapeAsset")
    {
-      %module = %payload.moduleName;
-      %asset = %payload.assetName;
-      
-      %oldValue = %this.targetObject.shapeAsset;
-      %arrayIndex = "";
-      
-      %targetObject = %this.targetObject;
-      %targetObject.shapeAsset = %module @ ":" @ %asset;
-
+      %cmd = %this @ ".apply(\""@ %module @ ":" @ %assetName @ "\");";
+      echo("Changing asset via the " @ %cmd @ " command");
+      eval(%cmd);
    }
    
    EWorldEditor.isDirty = true;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
@@ -417,7 +417,6 @@ function GuiInspectorTypeShapeAssetPtr::onControlDropped( %this, %payload, %posi
    if(%assetType $= "ShapeAsset")
    {
       %cmd = %this @ ".apply(\""@ %module @ ":" @ %assetName @ "\");";
-      echo("Changing asset via the " @ %cmd @ " command");
       eval(%cmd);
    }
    

--- a/Templates/BaseGame/game/tools/gui/profiles.ed.tscript
+++ b/Templates/BaseGame/game/tools/gui/profiles.ed.tscript
@@ -305,7 +305,7 @@ new GuiControlProfile( ToolsGuiTextEditProfile )
    border = -2; // fix to display textEdit img
    //borderWidth = "1";  // fix to display textEdit img
    //borderColor = "100 100 100";
-   fillColor = EditorSettings.value("Theme/fieldBGColor");
+   fillColor = EditorSettings.value("Theme/dividerDarkColor");
    fillColorHL = "75 75 75 255";
    fillColorSEL = EditorSettings.value("Theme/fieldBGSELColor");
    


### PR DESCRIPTION
Updates the behavior and layout of the ImageAsset, MaterialAsset and ShapeAsset inspector field types to be clearer, with previews and obvious edit buttons

Also fixes drag-n-drop behavior from the AB into the image and shape fields to ensure they update as expected.