### PR TITLE
Misc fixes for options and key remapping

### DIFF
--- a/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
@@ -817,16 +817,9 @@ void GuiGameSettingsCtrl::clickKeybind(S32 xPos)
    S32 columnSplit = mColumnSplit;
 
    S32 height = getHeight();
+   S32 width = getWidth();
 
-   Point2I button;
-   button.x = columnSplit + (columnSplit / 2.5)/* + (optionWidth / 2)*/;
-   button.y = 0;
-
-   Point2I buttonSize;
-   buttonSize.x = height;
-   buttonSize.y = height;
-
-   RectI rect(button, buttonSize);
+   RectI rect(Point2I::Zero, Point2I(width, height));
 
    onChange_callback();
 

--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
@@ -828,7 +828,7 @@ function OptionsMenuSettingsList::addOptionRow(%this, %label, %targetPrefVar, %o
       %enabled = true;
       
    %optionsRowSize = 30;
-   %optionColumnWidth = %this.extent.x * 0.3;//todo, calculate off longest option text?
+   %optionColumnWidth = %this.extent.x * 0.5;//todo, calculate off longest option text?
       
    %option = new GuiGameSettingsCtrl() { 
       class = "MenuOptionsButton";
@@ -936,7 +936,7 @@ function OptionsMenuSettingsList::addSliderRow(%this, %label, %targetPrefVar, %i
       %enabled = true;
       
    %optionsRowSize = 30;
-   %optionColumnWidth = %this.extent.x - 450;//todo, calculate off longest option text?
+   %optionColumnWidth = %this.extent.x * 0.5;//todo, calculate off longest option text?
       
    %option = new GuiGameSettingsCtrl() { 
       class = "MenuOptionsButton";
@@ -965,7 +965,7 @@ function OptionsMenuSettingsList::addKeybindRow(%this, %label, %bitmapName, %cal
       %enabled = true;
       
    %optionsRowSize = 40;
-   %optionColumnWidth = %this.extent.x - 450;
+   %optionColumnWidth = %this.extent.x * 0.5;//todo, calculate off longest option text?
       
    %option = new GuiGameSettingsCtrl() { 
       class = "MenuOptionsButton";

--- a/Templates/BaseGame/game/data/UI/guis/remapDlg.gui
+++ b/Templates/BaseGame/game/data/UI/guis/remapDlg.gui
@@ -1,121 +1,77 @@
 //--- OBJECT WRITE BEGIN ---
 $guiContent = new GuiControl(RemapDlg) {
-   position = "0 0";
    extent = "1024 768";
    minExtent = "8 8";
-   horizSizing = "right";
-   vertSizing = "bottom";
    profile = "GuiDefaultProfile";
-   visible = "1";
-   active = "1";
    tooltipProfile = "GuiToolTipProfile";
-   hovertime = "1000";
    isContainer = "1";
-   canSave = "1";
    canSaveDynamicFields = "1";
       helpTag = "0";
 
    new GuiContainer(RemapPanel) {
-      margin = "0 0 0 0";
-      padding = "0 0 0 0";
-      anchorTop = "1";
-      anchorBottom = "0";
-      anchorLeft = "1";
-      anchorRight = "0";
-      position = "162 352";
-      extent = "700 64";
-      minExtent = "8 2";
+      position = "162 332";
+      extent = "700 104";
       horizSizing = "center";
       vertSizing = "center";
       profile = "GuiDefaultProfile";
-      visible = "1";
-      active = "1";
       tooltipProfile = "GuiToolTipProfile";
-      hovertime = "1000";
-      isContainer = "1";
-      canSave = "1";
-      canSaveDynamicFields = "0";
 
       new GuiInputCtrl(OptRemapInputCtrl) {
-         lockMouse = "0";
          position = "480 0";
-         extent = "64 64";
+         extent = "64 104";
          minExtent = "8 8";
          horizSizing = "width";
          vertSizing = "height";
          profile = "GuiInputCtrlProfile";
-         visible = "1";
-         active = "1";
          tooltipProfile = "GuiToolTipProfile";
-         hovertime = "1000";
-         isContainer = "0";
-         canSave = "1";
-         canSaveDynamicFields = "0";
       };
-      new GuiChunkedBitmapCtrl() {
-         bitmapAsset = "UI:hudfill_image";
-         useVariable = "0";
-         tile = "0";
-         position = "0 0";
-         extent = "700 64";
-         minExtent = "8 2";
-         horizSizing = "right";
-         vertSizing = "bottom";
+      new GuiControl(RemapBoxCtrl) {
+         position = "-1 1";
+         extent = "701 102";
+         horizSizing = "center";
+         vertSizing = "center";
          profile = "GuiDefaultProfile";
-         visible = "1";
-         active = "1";
          tooltipProfile = "GuiToolTipProfile";
-         hovertime = "1000";
-         isContainer = "0";
-         canSave = "1";
-         canSaveDynamicFields = "0";
-      };
-      new GuiTextCtrl() {
-         text = "Press escape to cancel";
-         maxLength = "255";
-         margin = "0 0 0 0";
-         padding = "0 0 0 0";
-         anchorTop = "1";
-         anchorBottom = "0";
-         anchorLeft = "1";
-         anchorRight = "0";
-         position = "247 34";
-         extent = "242 20";
-         minExtent = "8 8";
-         horizSizing = "width";
-         vertSizing = "height";
-         profile = "GuiMenuButtonProfile";
-         visible = "1";
-         active = "1";
-         tooltipProfile = "GuiToolTipProfile";
-         hovertime = "1000";
          isContainer = "1";
-         canSave = "1";
-         canSaveDynamicFields = "0";
-      };
-      new GuiTextCtrl() {
-         text = "Re-bind \"\" to...";
-         maxLength = "255";
-         margin = "0 0 0 0";
-         padding = "0 0 0 0";
-         anchorTop = "1";
-         anchorBottom = "0";
-         anchorLeft = "1";
-         anchorRight = "0";
-         position = "177 8";
-         extent = "384 20";
-         minExtent = "8 8";
-         horizSizing = "width";
-         vertSizing = "height";
-         profile = "GuiMenuButtonProfile";
-         visible = "1";
-         active = "1";
-         tooltipProfile = "GuiToolTipProfile";
-         hovertime = "1000";
-         isContainer = "1";
-         internalName = "OptRemapText";
-         canSave = "1";
-         canSaveDynamicFields = "0";
+
+         new GuiBitmapBarCtrl() {
+            BitmapAsset = "UI:panel_image";
+            extent = "701 40";
+            horizSizing = "width";
+            profile = "GuiDefaultProfile";
+            tooltipProfile = "GuiToolTipProfile";
+         };
+         new GuiBitmapBarCtrl() {
+            BitmapAsset = "UI:panel_low_image";
+            position = "0 40";
+            extent = "701 341";
+            horizSizing = "width";
+            profile = "GuiDefaultProfile";
+            tooltipProfile = "GuiToolTipProfile";
+         };
+         new GuiTextCtrl() {
+            text = "Press escape to cancel";
+            maxLength = "255";
+            position = "260 67";
+            extent = "181 23";
+            minExtent = "8 8";
+            horizSizing = "width";
+            vertSizing = "height";
+            profile = "MenuMLSubHeaderTextCenter";
+            tooltipProfile = "GuiToolTipProfile";
+         };
+         new GuiTextCtrl() {
+            text = "Re-bind \"Forward\" to...";
+            maxLength = "255";
+            position = "259 40";
+            extent = "184 23";
+            minExtent = "8 8";
+            horizSizing = "center";
+            vertSizing = "height";
+            profile = "MenuMLSubHeaderTextCenter";
+            tooltipProfile = "GuiToolTipProfile";
+            internalName = "OptRemapText";
+         };
       };
    };
 };

--- a/Templates/BaseGame/game/data/UI/scripts/controlsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/controlsMenu.tscript
@@ -205,12 +205,13 @@ function controlSetChanged()
    fillRemapList();
 }
 
-function doKeyRemap( %rowIndex )
+function doKeyRemap( %row )
 {
+   %rowIndex = %row.getParent().getObjectIndex(%row);
    %rowIndex--; //Offset the rowIndex to account for controlset option
    %name = $RemapName[%rowIndex];
 
-	RemapDlg-->OptRemapText.setValue( "Re-bind \"" @ %name @ "\" to..." );
+	RemapDlg-->OptRemapText.text = "Re-bind \"" @ %name @ "\" to..." ;
 	OptRemapInputCtrl.index = %rowIndex;
 	Canvas.pushDialog( RemapDlg );
 	
@@ -223,7 +224,7 @@ function doKeyRemap( %rowIndex )
 function ControlsMenuRebindButton::onClick(%this)
 {
    %name = $RemapName[%this.keybindIndex];
-   RemapDlg-->OptRemapText.setValue( "Re-bind \"" @ %name @ "\" to..." );
+   RemapDlg-->OptRemapText.text = "Re-bind \"" @ %name @ "\" to..." ;
    
    OptRemapInputCtrl.index = %this.keybindIndex;
    OptRemapInputCtrl.optionIndex = %this.optionIndex;
@@ -305,16 +306,12 @@ function OptRemapInputCtrl::onInputEvent( %this, %device, %action )
    %prevCmdName = $RemapName[%prevMapIndex];
    Canvas.pushDialog( RemapConfirmDlg );
    
-   RemapConfirmationText.setText("\"" @ %mapName @ "\" is already bound to \""
-      @ %prevCmdName @ "\"! Do you wish to replace this mapping?");
-   RemapConfirmationYesButton.command = "redoMapping(" @ %device @ ", " @ %actionMap @ ", \"" @ %action @ "\", \"" @
+   %remapWarnText = "\"" @ %mapName @ "\" is already bound to \"" @ %prevCmdName @ "\"! Do you wish to replace this mapping?";
+   %doRemapCommand = "redoMapping(" @ %device @ ", " @ %actionMap @ ", \"" @ %action @ "\", \"" @
                               %cmd @ "\", " @ %prevMapIndex @ ", " @ %this.index @ "); Canvas.popDialog();";
-   RemapConfirmationNoButton.command = "Canvas.popDialog();";
+   %cancelCommand = "Canvas.popDialog();";
    
-   /*MessageBoxYesNo( "Warning",
-      "\"" @ %mapName @ "\" is already bound to \""
-      @ %prevCmdName @ "\"!\nDo you wish to replace this mapping?",
-       %callback, "" );*/
+   MessageBoxYesNo( "Key already in use", %remapWarnText, %doRemapCommand, %cancelCommand );
 }
 
 function findRemapCmdIndex( %command )

--- a/Templates/BaseGame/game/data/UI/scripts/profiles.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/profiles.tscript
@@ -78,6 +78,11 @@ new GuiControlProfile(MenuMLSubHeaderText)
    autoSizeHeight = true;  
 };
 
+new GuiControlProfile(MenuMLSubHeaderTextCenter : MenuMLSubHeaderText)
+{
+   justify = "center";
+};
+
 if( !isObject( GuiMenuButtonProfile ) )
 new GuiControlProfile( GuiMenuButtonProfile )
 {


### PR DESCRIPTION
- Fixes handling of click/activation events on keybind options ctrls so clicking on it at all activates it, instead of needing to click on the button image specifically
- Adjust the scaling of the options rows to be a consistent 50/50 divide between the options name and the actual options values to make the layout and scaling consistent Fixes key remapping behavior to work properly
- Added SubHeader text gui profile that is centered
- Made the remapping gui control be stylistically consistent to messageboxes