### PR TITLE
setControllingClient augs for the vehicle chain

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -1572,7 +1572,7 @@ void ShapeBase::setControllingClient( GameConnection* client )
          
          gSFX3DWorld->setListener( NULL );
       }
-      else if( client && client->isConnectionToServer() && !getControllingObject() )
+      else if( client && client->isConnectionToServer() && (getControllingObject() != this) )
       {
          // We're on the local client and not controlled by another object, so make
          // us the current SFX listener.

--- a/Engine/source/T3D/vehicles/vehicle.cpp
+++ b/Engine/source/T3D/vehicles/vehicle.cpp
@@ -1376,6 +1376,10 @@ void Vehicle::unpackUpdate(NetConnection *con, BitStream *stream)
    setEnergyLevel(stream->readFloat(8) * mDataBlock->maxEnergy);
 }
 
+void Vehicle::setControllingClient(GameConnection* client)
+{
+   ShapeBase::setControllingClient(client);
+}
 
 //----------------------------------------------------------------------------
 

--- a/Engine/source/T3D/vehicles/vehicle.h
+++ b/Engine/source/T3D/vehicles/vehicle.h
@@ -171,6 +171,7 @@ class Vehicle : public RigidShape
    void readPacketData (GameConnection * conn, BitStream *stream);
    U32  packUpdate  (NetConnection *conn, U32 mask, BitStream *stream);
    void unpackUpdate(NetConnection *conn,           BitStream *stream);
+   void setControllingClient(GameConnection* connection);
 
    void updateLiftoffDust( F32 dt );
    void updateDamageSmoke( F32 dt );


### PR DESCRIPTION
add a setControllingClient method to vehicles referencing the shapebase class direct.

fix shapebase::setControllingClient swap getControllingObject() test