### PR TITLE
misc fixes

### DIFF
--- a/Engine/source/T3D/assets/SoundAsset.h
+++ b/Engine/source/T3D/assets/SoundAsset.h
@@ -486,15 +486,15 @@ if (m##name##AssetId[index] != StringTable->EmptyString())\
       const char* enumString = castConsoleTypeToString(static_cast<enumType>(itter));\
       if (enumString && enumString[0])\
       {\
-         addField(assetEnumNameConcat(enumString, File), TypeSoundFilename, Offset(m##name##Name[0], consoleClass) + sizeof(m##name##Name[0])*i, assetText(name, docs), AbstractClassRep::FIELD_HideInInspectors); \
-         addField(assetEnumNameConcat(enumString, Asset), TypeSoundAssetId, Offset(m##name##AssetId[0], consoleClass) + sizeof(m##name##AssetId[0])*i, assetText(name, asset reference.));\
+         addField(assetEnumNameConcat(enumString, File), TypeSoundFilename, Offset(m##name##Name[i], consoleClass), assetText(name, docs), AbstractClassRep::FIELD_HideInInspectors); \
+         addField(assetEnumNameConcat(enumString, Asset), TypeSoundAssetId, Offset(m##name##AssetId[i], consoleClass), assetText(name, asset reference.));\
       }\
    }
 
 #define PACKDATA_SOUNDASSET_ARRAY(name, index)\
-   if (stream->writeFlag(m##name##Asset[index].notNull()))\
+   if (stream->writeFlag(AssetDatabase.isDeclaredAsset(m##name##AssetId[index])))\
    {\
-      stream->writeString(m##name##Asset[index].getAssetId());\
+      stream->writeString(m##name##AssetId[index]);\
    }\
    else\
    {\

--- a/Engine/source/T3D/fx/lightning.cpp
+++ b/Engine/source/T3D/fx/lightning.cpp
@@ -242,7 +242,7 @@ LightningData::LightningData()
 
    for (S32 i = 0; i < MaxThunders; i++)
    {
-      INIT_ASSET_ARRAY(ThunderSound, i);
+      INIT_SOUNDASSET_ARRAY(ThunderSound, i);
    }
 
    for (S32 i = 0; i < MaxTextures; i++)
@@ -335,7 +335,7 @@ void LightningData::packData(BitStream* stream)
    U32 i;
    for (i = 0; i < MaxThunders; i++)
    {
-      PACKDATA_ASSET_ARRAY(ThunderSound, i);
+      PACKDATA_SOUNDASSET_ARRAY(ThunderSound, i);
    }
 
    stream->writeInt(mNumStrikeTextures, 4);
@@ -353,7 +353,7 @@ void LightningData::unpackData(BitStream* stream)
    U32 i;
    for (i = 0; i < MaxThunders; i++)
    {
-      UNPACKDATA_ASSET_ARRAY(ThunderSound, i);
+      UNPACKDATA_SOUNDASSET_ARRAY(ThunderSound, i);
    }
 
    mNumStrikeTextures = stream->readInt(4);

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -423,7 +423,7 @@ PlayerData::PlayerData()
    boxHeadFrontPercentage = 1;
 
    for (S32 i = 0; i < MaxSounds; i++)
-      INIT_ASSET_ARRAY(PlayerSound, i);
+      INIT_SOUNDASSET_ARRAY(PlayerSound, i);
 
    footPuffEmitter = NULL;
    footPuffID = 0;
@@ -469,17 +469,17 @@ bool PlayerData::preload(bool server, String &errorStr)
 {
    if(!Parent::preload(server, errorStr))
       return false;
-
-   for (U32 i = 0; i < MaxSounds; ++i)
-   {
-      _setPlayerSound(getPlayerSound(i), i);
-      if (getPlayerSound(i) != StringTable->EmptyString())
+   if (!server) {
+      for (U32 i = 0; i < MaxSounds; ++i)
       {
-         if (!getPlayerSoundProfile(i))
-            Con::errorf("PlayerData::Preload() - unable to find sfxProfile for asset %d %s", i, mPlayerSoundAssetId[i]);
+         _setPlayerSound(getPlayerSound(i), i);
+         if (getPlayerSound(i) != StringTable->EmptyString())
+         {
+            if (!getPlayerSoundProfile(i))
+               Con::errorf("PlayerData::Preload() - unable to find sfxProfile for asset %d %s", i, mPlayerSoundAssetId[i]);
+         }
       }
    }
-
    //
    runSurfaceCos = mCos(mDegToRad(runSurfaceAngle));
    jumpSurfaceCos = mCos(mDegToRad(jumpSurfaceAngle));
@@ -1271,7 +1271,7 @@ void PlayerData::packData(BitStream* stream)
    stream->write(minLateralImpactSpeed);
 
    for (U32 i = 0; i < MaxSounds; i++)
-      PACKDATA_ASSET_ARRAY(PlayerSound, i);
+      PACKDATA_SOUNDASSET_ARRAY(PlayerSound, i);
 
    mathWrite(*stream, boxSize);
    mathWrite(*stream, crouchBoxSize);
@@ -1452,7 +1452,7 @@ void PlayerData::unpackData(BitStream* stream)
    stream->read(&minLateralImpactSpeed);
 
    for (U32 i = 0; i < MaxSounds; i++)
-      UNPACKDATA_ASSET_ARRAY(PlayerSound, i);
+      UNPACKDATA_SOUNDASSET_ARRAY(PlayerSound, i);
 
    mathRead(*stream, &boxSize);
    mathRead(*stream, &crouchBoxSize);

--- a/Engine/source/T3D/rigidShape.h
+++ b/Engine/source/T3D/rigidShape.h
@@ -64,7 +64,6 @@ class RigidShapeData : public ShapeBaseData
    } body;
 
    DECLARE_SOUNDASSET_ARRAY(RigidShapeData, BodySounds, Body::Sounds::MaxSounds)
-   DECLARE_ASSET_ARRAY_SETGET(RigidShapeData, BodySounds);
 
    enum RigidShapeConsts
    {

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -1572,7 +1572,7 @@ void ShapeBase::setControllingClient( GameConnection* client )
          
          gSFX3DWorld->setListener( NULL );
       }
-      else if( client && client->isConnectionToServer() && !getControllingObject() )
+      else if( client && client->isConnectionToServer() && (getControllingObject() != this) )
       {
          // We're on the local client and not controlled by another object, so make
          // us the current SFX listener.

--- a/Engine/source/T3D/vehicles/flyingVehicle.cpp
+++ b/Engine/source/T3D/vehicles/flyingVehicle.cpp
@@ -116,7 +116,7 @@ FlyingVehicleData::FlyingVehicleData()
       jetEmitter[j] = 0;
 
    for (S32 i = 0; i < MaxSounds; i++)
-      INIT_ASSET_ARRAY(FlyingSounds, i);
+      INIT_SOUNDASSET_ARRAY(FlyingSounds, i);
 
    vertThrustMultiple = 1.0;
 }
@@ -241,7 +241,7 @@ void FlyingVehicleData::packData(BitStream* stream)
 
    for (S32 i = 0; i < MaxSounds; i++)
    {
-      PACKDATA_ASSET_ARRAY(FlyingSounds, i);
+      PACKDATA_SOUNDASSET_ARRAY(FlyingSounds, i);
    }
 
    for (S32 j = 0; j < MaxJetEmitters; j++)
@@ -276,7 +276,7 @@ void FlyingVehicleData::unpackData(BitStream* stream)
 
    for (S32 i = 0; i < MaxSounds; i++)
    {
-      UNPACKDATA_ASSET_ARRAY(FlyingSounds, i);
+      UNPACKDATA_SOUNDASSET_ARRAY(FlyingSounds, i);
    }
 
    for (S32 j = 0; j < MaxJetEmitters; j++) {

--- a/Engine/source/T3D/vehicles/hoverVehicle.cpp
+++ b/Engine/source/T3D/vehicles/hoverVehicle.cpp
@@ -73,9 +73,9 @@ DefineEnumType(hoverSoundsEnum);
 
 ImplementEnumType(hoverSoundsEnum, "enum types.\n"
    "@ingroup HoverVehicleData\n\n")
-   { HoverVehicleData::JetSound,       "JetSound", "..." },
-   { HoverVehicleData::EngineSound,    "EngineSound", "..." },
-   { HoverVehicleData::FloatSound,     "FloatSound", "..." },
+   { hoverSoundsEnum::JetSound,       "JetSound", "..." },
+   { hoverSoundsEnum::EngineSound,    "EngineSound", "..." },
+   { hoverSoundsEnum::FloatSound,     "FloatSound", "..." },
 EndImplementEnumType;
 
 namespace {
@@ -162,7 +162,7 @@ HoverVehicleData::HoverVehicleData()
       jetEmitter[j] = 0;
 
    for (S32 i = 0; i < MaxSounds; i++)
-      INIT_ASSET_ARRAY(HoverSounds, i);
+      INIT_SOUNDASSET_ARRAY(HoverSounds, i);
 }
 
 HoverVehicleData::~HoverVehicleData()
@@ -370,7 +370,7 @@ void HoverVehicleData::packData(BitStream* stream)
 
    for (S32 i = 0; i < MaxSounds; i++)
    {
-      PACKDATA_ASSET_ARRAY(HoverSounds, i);
+      PACKDATA_SOUNDASSET_ARRAY(HoverSounds, i);
    }
 
    for (S32 j = 0; j < MaxJetEmitters; j++)
@@ -419,7 +419,7 @@ void HoverVehicleData::unpackData(BitStream* stream)
 
    for (S32 i = 0; i < MaxSounds; i++)
    {
-      UNPACKDATA_ASSET_ARRAY(HoverSounds, i);
+      UNPACKDATA_SOUNDASSET_ARRAY(HoverSounds, i);
    }
 
    for (S32 j = 0; j < MaxJetEmitters; j++) {

--- a/Engine/source/T3D/vehicles/vehicle.h
+++ b/Engine/source/T3D/vehicles/vehicle.h
@@ -39,18 +39,6 @@ struct VehicleData : public RigidShapeData
 {
    typedef RigidShapeData Parent;
 
-   struct Body {
-      enum Sounds {
-         SoftImpactSound,
-         HardImpactSound,
-         MaxSounds,
-      };
-      F32 restitution;
-      F32 friction;
-   } body;
-
-   DECLARE_SOUNDASSET_ARRAY(VehicleData, VehicleBodySounds, Body::Sounds::MaxSounds)
-
    enum VehicleConsts
    {
       VC_NUM_DUST_EMITTERS = 1,
@@ -62,43 +50,10 @@ struct VehicleData : public RigidShapeData
       VC_BUBBLE_EMITTER = VC_NUM_DAMAGE_EMITTERS - VC_NUM_BUBBLE_EMITTERS,
    };
 
-  enum Sounds {
-      ExitWater,
-      ImpactSoft,
-      ImpactMedium,
-      ImpactHard,
-      Wake,
-      MaxSounds
-   };
-
-  DECLARE_SOUNDASSET_ARRAY(VehicleData, VehicleWaterSounds, Sounds::MaxSounds)
-
-   F32 exitSplashSoundVel;
-   F32 softSplashSoundVel;
-   F32 medSplashSoundVel;
-   F32 hardSplashSoundVel;
-
-   F32 minImpactSpeed;
-   F32 softImpactSpeed;
-   F32 hardImpactSpeed;
-   F32 minRollSpeed;
    F32 maxSteeringAngle;
 
    F32 collDamageThresholdVel;
    F32 collDamageMultiplier;
-
-   bool cameraRoll;           ///< Roll the 3rd party camera
-   F32 cameraLag;             ///< Amount of camera lag (lag += car velocity * lag)
-   F32 cameraDecay;           ///< Rate at which camera returns to target pos.
-   F32 cameraOffset;          ///< Vertical offset
-
-   F32 minDrag;
-   F32 maxDrag;
-   S32 integration;           ///< # of physics steps per tick
-   F32 collisionTol;          ///< Collision distance tolerance
-   F32 contactTol;            ///< Contact velocity tolerance
-   Point3F massCenter;        ///< Center of mass for rigid body
-   Point3F massBox;           ///< Size of inertial box
 
    F32 jetForce;
    F32 jetEnergyDrain;        ///< Energy drain/tick
@@ -108,21 +63,11 @@ struct VehicleData : public RigidShapeData
    F32 steeringReturnSpeedScale;
    bool powerSteering;
 
-   ParticleEmitterData * dustEmitter;
-   S32 dustID;
-   F32 triggerDustHeight;  ///< height vehicle has to be under to kick up dust
-   F32 dustHeight;         ///< dust height above ground
-
    ParticleEmitterData *   damageEmitterList[ VC_NUM_DAMAGE_EMITTERS ];
    Point3F damageEmitterOffset[ VC_NUM_DAMAGE_EMITTER_AREAS ];
    S32 damageEmitterIDList[ VC_NUM_DAMAGE_EMITTERS ];
    F32 damageLevelTolerance[ VC_NUM_DAMAGE_LEVELS ];
    F32 numDmgEmitterAreas;
-
-   ParticleEmitterData* splashEmitterList[VC_NUM_SPLASH_EMITTERS];
-   S32 splashEmitterIDList[VC_NUM_SPLASH_EMITTERS];
-   F32 splashFreqMod;
-   F32 splashVelEpsilon;
 
    bool enablePhysicsRep;
 
@@ -171,6 +116,7 @@ class Vehicle : public RigidShape
    void readPacketData (GameConnection * conn, BitStream *stream);
    U32  packUpdate  (NetConnection *conn, U32 mask, BitStream *stream);
    void unpackUpdate(NetConnection *conn,           BitStream *stream);
+   void setControllingClient(GameConnection* connection);
 
    void updateLiftoffDust( F32 dt );
    void updateDamageSmoke( F32 dt );

--- a/Engine/source/T3D/vehicles/wheeledVehicle.cpp
+++ b/Engine/source/T3D/vehicles/wheeledVehicle.cpp
@@ -289,15 +289,15 @@ ConsoleDocClass( WheeledVehicleData,
    "@ingroup Vehicles\n"
 );
 
-typedef WheeledVehicleData::Sounds wheelSoundsEnum;
-DefineEnumType(wheelSoundsEnum);
+typedef WheeledVehicleData::Sounds WheeledVehicleSoundsEnum;
+DefineEnumType(WheeledVehicleSoundsEnum);
 
-ImplementEnumType(wheelSoundsEnum, "enum types.\n"
+ImplementEnumType(WheeledVehicleSoundsEnum, "enum types.\n"
    "@ingroup WheeledVehicleData\n\n")
-   {WheeledVehicleData::JetSound,          "JetSound", "..." },
-   {WheeledVehicleData::EngineSound,       "EngineSound", "..." },
-   {WheeledVehicleData::SquealSound,       "SquealSound", "..." },
-   {WheeledVehicleData::WheelImpactSound,  "WheelImpactSound", "..." },
+   { WheeledVehicleSoundsEnum::JetSound,          "JetSound", "..." },
+   { WheeledVehicleSoundsEnum::EngineSound,       "EngineSound", "..." },
+   { WheeledVehicleSoundsEnum::SquealSound,       "SquealSound", "..." },
+   { WheeledVehicleSoundsEnum::WheelImpactSound,  "WheelImpactSound", "..." },
 EndImplementEnumType;
 
 WheeledVehicleData::WheeledVehicleData()
@@ -312,7 +312,7 @@ WheeledVehicleData::WheeledVehicleData()
    wheelCount = 0;
    dMemset(&wheel, 0, sizeof(wheel));
    for (S32 i = 0; i < MaxSounds; i++)
-      INIT_ASSET_ARRAY(WheeledVehicleSounds, i);
+      INIT_SOUNDASSET_ARRAY(WheeledVehicleSounds, i);
 }
 
 
@@ -448,7 +448,9 @@ bool WheeledVehicleData::mirrorWheel(Wheel* we)
 
 void WheeledVehicleData::initPersistFields()
 {
-   INITPERSISTFIELD_SOUNDASSET_ENUMED(WheeledVehicleSounds, wheelSoundsEnum, MaxSounds, WheeledVehicleData, "Sounds related to wheeled vehicle.");
+   addGroup("Sounds");
+   INITPERSISTFIELD_SOUNDASSET_ENUMED(WheeledVehicleSounds, WheeledVehicleSoundsEnum, MaxSounds, WheeledVehicleData, "Sounds related to wheeled vehicle.");
+   endGroup("Sounds");
 
    addField("tireEmitter",TYPEID< ParticleEmitterData >(), Offset(tireEmitter, WheeledVehicleData),
       "ParticleEmitterData datablock used to generate particles from each wheel "
@@ -483,7 +485,7 @@ void WheeledVehicleData::packData(BitStream* stream)
 
    for (S32 i = 0; i < MaxSounds; i++)
    {
-      PACKDATA_ASSET_ARRAY(WheeledVehicleSounds, i);
+      PACKDATA_SOUNDASSET_ARRAY(WheeledVehicleSounds, i);
    }
 
    stream->write(maxWheelSpeed);
@@ -502,7 +504,7 @@ void WheeledVehicleData::unpackData(BitStream* stream)
 
    for (S32 i = 0; i < MaxSounds; i++)
    {
-      UNPACKDATA_ASSET_ARRAY(WheeledVehicleSounds, i);
+      UNPACKDATA_SOUNDASSET_ARRAY(WheeledVehicleSounds, i);
    }
 
    stream->read(&maxWheelSpeed);

--- a/Engine/source/sfx/sfxPlayList.cpp
+++ b/Engine/source/sfx/sfxPlayList.cpp
@@ -221,7 +221,7 @@ SFXPlayList::SFXPlayList()
      mNumSlotsToPlay( NUM_SLOTS )
 {
    for (U32 i=0;i<NUM_SLOTS;i++)
-      INIT_ASSET_ARRAY(Track, i);
+      INIT_SOUNDASSET_ARRAY(Track, i);
 }
 
 //-----------------------------------------------------------------------------
@@ -429,7 +429,7 @@ void SFXPlayList::packData( BitStream* stream )
       stream->write( mSlots.mRepeatCount[ i ] );
       
    FOR_EACH_SLOT sfxWrite( stream, mSlots.mState[ i ] );
-   FOR_EACH_SLOT PACKDATA_ASSET_ARRAY(Track, i);
+   FOR_EACH_SLOT PACKDATA_SOUNDASSET_ARRAY(Track, i);
 }
 
 //-----------------------------------------------------------------------------
@@ -468,7 +468,7 @@ void SFXPlayList::unpackData( BitStream* stream )
    FOR_EACH_SLOT if(stream->readFlag()){ stream->read( &mSlots.mRepeatCount[ i ] );}
       
    FOR_EACH_SLOT sfxRead( stream, &mSlots.mState[ i ] );
-   FOR_EACH_SLOT UNPACKDATA_ASSET_ARRAY(Track, i);
+   FOR_EACH_SLOT UNPACKDATA_SOUNDASSET_ARRAY(Track, i);
    
    #undef FOR_EACH_SLOT
 }

--- a/Templates/BaseGame/game/core/utility/scripts/gameObjectManagement.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/gameObjectManagement.tscript
@@ -78,6 +78,12 @@ function spawnGameObject(%name, %addToScene)
 	return 0;
 }
 
+function GameBaseData::onNewDataBlock(%this, %obj)
+{
+    %this.onRemove(%obj);
+    %this.onAdd(%obj);
+}
+
 function saveGameObject(%name, %tamlPath, %scriptPath)
 {
 	%gameObjectAsset = findGameObject(%name);


### PR DESCRIPTION
utilize specialty case soundarray macros.
 slim duplicate entries in vehicle already hand;ed by rigidshape.
create a gamebasedata::onnewdatablock which calls onremove and onadd for the db for those classes like wheeledvehicle that expect mounting logic to occur