### PR TITLE
Fix some compiler warnings on macos

### DIFF
--- a/Engine/source/T3D/assets/SoundAsset.h
+++ b/Engine/source/T3D/assets/SoundAsset.h
@@ -159,7 +159,7 @@ DefineConsoleType(TypeSoundAssetId, String)
    AssetPtr<SoundAsset> m##name##Asset = NULL;\
    SFXProfile* m##name##Profile = NULL;\
    SFXDescription* m##name##Desc = NULL;\
-   SimObjectId m##name##SFXId = NULL;\
+   SimObjectId m##name##SFXId = 0;\
 public: \
    const StringTableEntry get##name##File() const { return m##name##Name; }\
    void set##name##File(const FileName &_in) { m##name##Name = StringTable->insert(_in.c_str());}\

--- a/Engine/source/platform/platformIntrinsics.gcc.h
+++ b/Engine/source/platform/platformIntrinsics.gcc.h
@@ -27,6 +27,8 @@
 /// Compiler intrinsics for GCC.
 
 #ifdef TORQUE_OS_MAC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <libkern/OSAtomic.h>
 #endif
 
@@ -84,5 +86,9 @@ inline U32 dAtomicRead( volatile U32 &ref )
       return OSAtomicAdd32( 0, (int32_t* ) &ref);
    #endif
 }
+
+#ifdef TORQUE_OS_MAC
+#pragma GCC diagnostic pop
+#endif
 
 #endif // _TORQUE_PLATFORM_PLATFORMINTRINSICS_GCC_H_


### PR DESCRIPTION
Here are two small patches to fix some warnings in headers included by > 500 files, when building for macOS. Brief summary:

SoundAsset.h was assigning NULL to an integer variable, changed to 0
platformIntrinsics.gcc.h is using the deprecated OSAtomic functions. macOS recommends porting everything to std::atomic, but that isn't easily source compatible with the current usage, so this just hides the firehose of warnings for now :)
