### PR TITLE
probe code review

### DIFF
--- a/Engine/source/T3D/objectTypes.h
+++ b/Engine/source/T3D/objectTypes.h
@@ -228,8 +228,8 @@ enum SceneObjectTypeMasks : U32
    OUTDOOR_OBJECT_TYPEMASK = (   TerrainObjectType |
                                  EnvironmentObjectType ),
 
-   SKYLIGHT_CAPTURE_TYPEMASK = (EnvironmentObjectType),
-   REFLECTION_PROBE_CAPTURE_TYPEMASK = (StaticObjectType | StaticShapeObjectType | LightObjectType)
+   SKYLIGHT_CAPTURE_TYPEMASK = (OUTDOOR_OBJECT_TYPEMASK) & ~(PhysicalZoneObjectType | MarkerObjectType | TriggerObjectType),
+   REFLECTION_PROBE_CAPTURE_TYPEMASK = (SKYLIGHT_CAPTURE_TYPEMASK | StaticObjectType | StaticShapeObjectType | LightObjectType)
 };
 
 #endif

--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -560,8 +560,8 @@ void RenderProbeMgr::bakeProbe(ReflectionProbe* probe)
    ReflectorDesc reflDesc;
    reflDesc.texSize = resolution;
    reflDesc.farDist = farPlane;
-   reflDesc.detailAdjust = 1;
-   reflDesc.objectTypeMask = probe->mProbeShapeType == ReflectionProbe::ProbeInfo::Skylight ? SKYLIGHT_CAPTURE_TYPEMASK : REFLECTION_PROBE_CAPTURE_TYPEMASK;
+   reflDesc.detailAdjust = (F32)resolution;
+   reflDesc.objectTypeMask = probe->mCaptureMask;
 
    CubeReflector cubeRefl;
    cubeRefl.registerReflector(probe, &reflDesc);


### PR DESCRIPTION
amend capture mask so that skylight et al gets terrain, but skips editor-only renders