### PR TITLE
Make sure there's a default cam for editors

### DIFF
--- a/Templates/BaseGame/game/core/utility/scripts/gameObjectManagement.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/gameObjectManagement.tscript
@@ -80,8 +80,10 @@ function spawnGameObject(%name, %addToScene)
 
 function GameBaseData::onNewDataBlock(%this, %obj)
 {
-    %this.onRemove(%obj);
-    %this.onAdd(%obj);
+   if(%this.isMethod("onRemove"))
+      %this.onRemove(%obj);
+   if(%this.isMethod("onAdd"))
+      %this.onAdd(%obj);
 }
 
 function saveGameObject(%name, %tamlPath, %scriptPath)

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/cameraCommands.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/cameraCommands.ed.tscript
@@ -47,6 +47,15 @@ function serverCmdToggleCamera(%client)
 {
    if (%client.getControlObject() == %client.player)
    {
+      if (!isObject(%client.camera))
+      {
+         %client.camera = spawnObject("Camera", Observer);
+         MissionCleanup.add( %client.camera );
+         %client.camera.scopeToClient(%client);
+         
+         %client.camera.setPosition(%client.player.getPosition());
+      }
+      
       %client.camera.setVelocity("0 0 0");
       %control = %client.camera;
    }


### PR DESCRIPTION
Ensures that if no client camera is defined when attempting to swap into an editor camera mode, it makes one so that the normal editor camera modes can work as expected

Adds sanity check to default onNewDatablock function on the GameDatablock namespace in case the onAdd or onRemove functions aren't defined, we don't spam the console