### PR TITLE
Enables terrain macro maps, adds height blend "hardness" setting

### DIFF
--- a/Engine/source/terrain/glsl/terrFeatureGLSL.h
+++ b/Engine/source/terrain/glsl/terrFeatureGLSL.h
@@ -45,6 +45,7 @@ public:
    Var* _getInMacroCoord(Vector<ShaderComponent*> &componentList );
 
    Var* _getDetailMapSampler();
+   Var* _getMacroMapSampler();
    Var* _getNormalMapSampler();
    Var* _getOrmMapSampler();
 

--- a/Engine/source/terrain/hlsl/terrFeatureHLSL.h
+++ b/Engine/source/terrain/hlsl/terrFeatureHLSL.h
@@ -47,6 +47,8 @@ public:
 
    Var* _getDetailMapSampler();
    Var* _getDetailMapArray();
+   Var* _getMacroMapSampler();
+   Var* _getMacroMapArray();
    Var* _getNormalMapSampler();
    Var* _getNormalMapArray();
    Var* _getOrmMapSampler();

--- a/Engine/source/terrain/terrCellMaterial.h
+++ b/Engine/source/terrain/terrCellMaterial.h
@@ -59,7 +59,7 @@ protected:
    public:
 
       MaterialInfo()
-         :mat(NULL), layerId(0), mBlendDepthConst(NULL), mBlendContrastConst(NULL)
+         :mat(NULL), layerId(0), mBlendDepthConst(NULL), mBlendContrastConst(NULL), mBlendHardnessConst(NULL)
       {
       }
 
@@ -71,6 +71,7 @@ protected:
       U32 layerId;
       GFXShaderConstHandle *mBlendDepthConst;
       GFXShaderConstHandle *mBlendContrastConst;
+      GFXShaderConstHandle* mBlendHardnessConst;
    };
 
    ///
@@ -119,6 +120,7 @@ protected:
    GFXShaderConstHandle *mOrmTexArrayConst;
 
    GFXShaderConstHandle* mBlendDepthConst;
+   GFXShaderConstHandle* mBlendHeightFloorConst;
 
    TerrainBlock *mTerrain;
 

--- a/Engine/source/terrain/terrMaterial.cpp
+++ b/Engine/source/terrain/terrMaterial.cpp
@@ -25,6 +25,7 @@
 #include "console/consoleTypes.h"
 #include "gfx/gfxTextureManager.h"
 #include "gfx/bitmap/gBitmap.h"
+#include "console/typeValidators.h"
 
 #ifdef TORQUE_TOOLS
 #include "console/persistenceManager.h"
@@ -76,6 +77,7 @@ TerrainMaterial::TerrainMaterial()
       mParallaxScale( 0.0f ),
       mBlendDepth( 0.0f ),
       mBlendContrast( 1.0f ),
+      mBlendHardness( 0.0f ),
       mIsSRGB(false),
       mInvertRoughness(false)
 {
@@ -89,6 +91,8 @@ TerrainMaterial::TerrainMaterial()
 TerrainMaterial::~TerrainMaterial()
 {
 }
+
+FRangeValidator hardnessValidator(0.0f, 0.999f);
 
 void TerrainMaterial::initPersistFields()
 {
@@ -105,6 +109,9 @@ void TerrainMaterial::initPersistFields()
 
    addField("blendHeightContrast", TypeF32, Offset(mBlendContrast, TerrainMaterial), "A fixed value to add while blending using heightmap-based blending."
       "Higher numbers = larger blend radius.");
+
+   addFieldV("blendHeightHardness", TypeF32, Offset(mBlendHardness, TerrainMaterial), &hardnessValidator, "How sharply this layer blends with other textures."
+      "0->1, soft->hard.");
 
    INITPERSISTFIELD_IMAGEASSET(DetailMap, TerrainMaterial, "Raises and lowers the RGB result of the Base Albedo up close.");
    addField( "detailSize", TypeF32, Offset( mDetailSize, TerrainMaterial ), "Used to scale the detail map to the material square" );

--- a/Engine/source/terrain/terrMaterial.h
+++ b/Engine/source/terrain/terrMaterial.h
@@ -97,6 +97,8 @@ protected:
 
    F32 mBlendContrast;
 
+   F32 mBlendHardness;
+
 public:
 
    TerrainMaterial();
@@ -137,6 +139,8 @@ public:
    F32 getBlendDepth() const { return mBlendDepth; }
 
    F32 getBlendContrast() const { return mBlendContrast; }
+
+   F32 getBlendHardness() const { return mBlendHardness; }
 
    bool getIsSRGB() const { return mIsSRGB; }
 

--- a/Templates/BaseGame/game/tools/worldEditor/gui/guiTerrainMaterialDlg.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/guiTerrainMaterialDlg.ed.gui
@@ -394,7 +394,7 @@ $guiContent = new GuiControl(TerrainMaterialDlg,EditorGuiGroup) {
          };
          new GuiContainer(NormalMapContainer) {
             position = "6 205";
-                  extent = "261 100";
+                  extent = "261 120";
             horizSizing = "width";
             profile = "ToolsGuiDefaultProfile";
             tooltipProfile = "ToolsGuiToolTipProfile";
@@ -527,17 +527,45 @@ $guiContent = new GuiControl(TerrainMaterialDlg,EditorGuiGroup) {
                isContainer = "0";
                internalName = "blendHeightContrastTextEditCtrl";
             };
+            new GuiTextEditCtrl(TerrainMaterialDlgBlendHeightHardnessTextEdit) {
+               text = "0";
+               anchorTop = "0";
+               anchorLeft = "0";
+               position = "1 99";
+               extent = "35 18";
+               profile = "ToolsGuiTextEditProfile";
+               tooltipProfile = "ToolsGuiToolTipProfile";
+               isContainer = "0";
+               internalName = "blendHeightHardnessTextEditCtrl";
+            };
+            new GuiTextCtrl() {
+               text = "Blend Hardness";
+               position = "115 101";
+               extent = "76 15";
+               profile = "ToolsGuiTextProfile";
+               tooltipProfile = "ToolsGuiToolTipProfile";
+            };
+            new GuiSliderCtrl(TerrainMaterialDlgBlendHeightHardnessSlider) {
+               range = "0 0.999";
+               ticks = "0";
+               value = "0";
+               position = "39 101";
+               extent = "70 14";
+               profile = "ToolsGuiSliderProfile";
+               tooltipProfile = "ToolsGuiToolTipProfile";
+               internalName = "blendHeightHardnessSliderCtrl";
+            };
          };
          new GuiBitmapCtrl() {
-                  BitmapAsset = "ToolsModule:separator_v_image";
-            position = "6 307";
-                  extent = "266 2";
+            BitmapAsset = "ToolsModule:separator_v_image";
+            position = "6 323";
+            extent = "266 2";
             horizSizing = "width";
             profile = "ToolsGuiDefaultProfile";
                tooltipProfile = "ToolsGuiToolTipProfile";
             };
          new GuiContainer(ORMConfigMapContainer) {
-            position = "6 314";
+                  position = "6 330";
                   extent = "261 64";
                horizSizing = "width";
                profile = "ToolsGuiDefaultProfile";
@@ -615,14 +643,14 @@ $guiContent = new GuiControl(TerrainMaterialDlg,EditorGuiGroup) {
          };
          new GuiBitmapCtrl() {
                   BitmapAsset = "ToolsModule:separator_v_image";
-            position = "6 381";
+                  position = "6 397";
                   extent = "266 2";
             horizSizing = "width";
             profile = "ToolsGuiDefaultProfile";
             tooltipProfile = "ToolsGuiToolTipProfile";
          };
          new GuiContainer(MacroMapContainer) {
-            position = "6 388";
+                  position = "6 404";
                   extent = "261 72";
             horizSizing = "width";
             profile = "ToolsGuiDefaultProfile";
@@ -746,7 +774,7 @@ $guiContent = new GuiControl(TerrainMaterialDlg,EditorGuiGroup) {
             };
          };
                new GuiContainer(TerrainEffectsContainer) {
-                  position = "6 460";
+                  position = "6 476";
                   extent = "265 97";
                   horizSizing = "width";
                   profile = "ToolsGuiDefaultProfile";

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/interfaces/terrainMaterialDlg.ed.tscript
@@ -477,6 +477,10 @@ function TerrainMaterialDlg::setActiveMaterial( %this, %mat )
       %this-->blendHeightContrastTextEditCtrl.setText( %blendHeightContrast );
       %this-->blendHeightContrastSliderCtrl.setValue( %mat.blendHeightContrast );
 
+		%blendHeightHardness = mFloor(%mat.blendHeightHardness * 1000)/1000;
+		%this-->blendHeightHardnessTextEditCtrl.setText( %blendHeightHardness );
+		%this-->blendHeightHardnessSliderCtrl.setValue( %mat.blendHeightHardness );
+
       %this-->macroSizeCtrl.setText( %mat.macroSize );
       %this-->macroStrengthCtrl.setText( %mat.macroStrength );
       %this-->macroDistanceCtrl.setText( %mat.macroDistance );      
@@ -686,6 +690,7 @@ function TerrainMaterialDlg::saveDirtyMaterial( %this, %materialAssetId )
    %parallaxScale = %this-->parallaxScaleCtrl.getText();
    %blendHeightBase = %this-->blendHeightBaseTextEditCtrl.getText();
    %blendHeightContrast = %this-->blendHeightContrastTextEditCtrl.getText();
+	%blendHeightHardness = %this-->blendHeightHardnessTextEditCtrl.getText();
 
    %macroSize = %this-->macroSizeCtrl.getText();      
    %macroStrength = %this-->macroStrengthCtrl.getText();
@@ -725,6 +730,7 @@ function TerrainMaterialDlg::saveDirtyMaterial( %this, %materialAssetId )
          %mat.parallaxScale == %parallaxScale &&
          %mat.blendHeightBase == %blendHeightBase &&
          %mat.blendHeightContrast == %blendHeightContrast &&
+			%mat.blendHeightHardness == %blendHeightHardness &&
          %mat.isSRGB == %isSRGB &&         
          %mat.invertRoughness == %invertRoughness &&
          %fxMat.effectColor[0] == %effectColor0 &&
@@ -772,6 +778,7 @@ function TerrainMaterialDlg::saveDirtyMaterial( %this, %materialAssetId )
    %mat.parallaxScale = %parallaxScale;
    %mat.blendHeightBase = %blendHeightBase;
    %mat.blendHeightContrast = %blendHeightContrast;
+	%mat.blendHeightHardness = %blendHeightHardness;
    %mat.isSRGB = %isSRGB;
    %mat.invertRoughness = %invertRoughness;
    
@@ -861,6 +868,7 @@ function TerrainMaterialDlg::snapshotMaterials( %this )
          parallaxScale = %mat.parallaxScale;
          blendHeightBase = %mat.blendHeightBase;
          blendHeightContrast = %mat.blendHeightContrast;
+			blendHeightHardness = %mat.blendHeightHardness;
          isSRGB = %mat.isSRGB;
          invertRoughness = %mat.invertRoughness;
       };
@@ -901,6 +909,7 @@ function TerrainMaterialDlg::restoreMaterials( %this )
       %mat.parallaxScale = %obj.parallaxScale;
       %mat.blendHeightBase = %obj.blendHeightBase;
       %mat.blendHeightContrast = %obj.blendHeightContrast;
+		%mat.blendHeightHardness = %obj.blendHeightHardness;
       %mat.isSRGB = %obj.isSRGB;
       %mat.invertRoughness = %obj.invertRoughness;
    }
@@ -968,6 +977,25 @@ function TerrainMaterialDlgBlendHeightContrastTextEdit::onValidate(%this)
 {
    TerrainMaterialDlgBlendHeightContrastSlider.setValue(%this.getText());
    TerrainMaterialDlg.activeMat.blendHeightContrast = %this.getText();
+   TerrainMaterialDlg.matDirty = true;
+}
+
+function TerrainMaterialDlgBlendHeightHardnessSlider::onMouseDragged(%this)
+{
+   %value = mClamp(%this.value, 0.0, 0.999);
+	%value = mFloor(%value * 1000)/1000;
+   TerrainMaterialDlgBlendHeightHardnessTextEdit.setText(%value);
+   TerrainMaterialDlg.activeMat.blendHeightHardness = %value;
+   TerrainMaterialDlg.matDirty = true;
+}
+
+function TerrainMaterialDlgBlendHeightHardnessTextEdit::onValidate(%this)
+{
+	%value = mClamp(%this.getText(), 0.0, 0.999);
+	%value = mFloor(%value * 1000)/1000;
+	%this.setText(%value);
+   TerrainMaterialDlgBlendHeightHardnessSlider.setValue(%value);
+   TerrainMaterialDlg.activeMat.blendHeightHardness = %value;
    TerrainMaterialDlg.matDirty = true;
 }
 


### PR DESCRIPTION
-Enables macro maps. These are optional, and layers with and without macros can be used together. These are diffuse-only tiled textures that are used similarly to detail maps, but at a longer range and generally higher scale to add mid-range detail. They do not currently use normal or ORM maps, or respond to parallax (same behavior as 3.x)
-Updates macro code to follow the design of detail map code (arrays for layer info, texture resource counter incrementation adjusted for deferred).
-Adds a "blend hardness" variable to terrain materials, and adds controls for this variable to the terrain mat editor. Controls how quickly the detail and macro textures fade away when blending with an adjacent layer. A value of 0 produces the previous stock behavior (soft blend biased by heightmap). Higher values create faster transitions, still biased by heightmap. For extremely sharp transitions, both adjacent layers should be set to high hardness. See this example video: https://www.youtube.com/watch?v=li_56CzSSBQ