### PR TITLE
Fix height blending detail color doubling w/ no normalmap

### DIFF
--- a/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
+++ b/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
@@ -587,11 +587,12 @@ void TerrainDetailMapFeatGLSL::processPix(   Vector<ShaderComponent*> &component
          meta->addStatement(new GenOp("   @ = lerp( @, tGetMatrix3Row(@, 2), @ ) );\r\n", gbNormal, gbNormal, viewToTangent, detailBlend));
       }
 
-      ShaderFeature::OutputTarget target = (fd.features[MFT_isDeferred]) ? RenderTarget1 : DefaultTarget;
-
-      Var* outColor = (Var*)LangElement::find(getOutputTargetVarName(target));
-
-      meta->addStatement(new GenOp("      @ += @ * @;\r\n", outColor, detailColor, detailBlend));
+      if (!fd.features.hasFeature(MFT_TerrainHeightBlend)) // this is only for lerp blending
+      {
+         ShaderFeature::OutputTarget target = (fd.features[MFT_isDeferred]) ? RenderTarget1 : DefaultTarget;
+         Var* outColor = (Var*)LangElement::find(getOutputTargetVarName(target));
+         meta->addStatement(new GenOp("      @ += @ * @;\r\n", outColor, detailColor, detailBlend));
+      }
    }
 
    output = meta;

--- a/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
+++ b/Engine/source/terrain/hlsl/terrFeatureHLSL.cpp
@@ -649,11 +649,12 @@ void TerrainDetailMapFeatHLSL::processPix(   Vector<ShaderComponent*> &component
          meta->addStatement(new GenOp("   @ = lerp( @, @[2], @ );\r\n", gbNormal, gbNormal, viewToTangent, detailBlend));
       }
 
-      ShaderFeature::OutputTarget target = (fd.features[MFT_isDeferred]) ? RenderTarget1 : DefaultTarget;
-
-      Var* outColor = (Var*)LangElement::find(getOutputTargetVarName(target));
-
-      meta->addStatement(new GenOp("      @ += @ * @;\r\n", outColor, detailColor, detailBlend));
+      if (!fd.features.hasFeature(MFT_TerrainHeightBlend))
+      {
+         ShaderFeature::OutputTarget target = (fd.features[MFT_isDeferred]) ? RenderTarget1 : DefaultTarget;
+         Var* outColor = (Var*)LangElement::find(getOutputTargetVarName(target));
+         meta->addStatement(new GenOp("      @ += @ * @;\r\n", outColor, detailColor, detailBlend));
+      }
    }
 
    output = meta;


### PR DESCRIPTION
Fixes a minor error where the detail layer can be applied to the output color twice if there is no normal map. This is only seen when a terrain cell has only 1 layer, and that layer has no normal map.

The shader code in question is now only generated if the height blending feature is not present (output color should not be modified here if the blend feature is present, blend code will handle this even if only 1 layer is present).