### PR TITLE
Key rebinding script fixes

### DIFF
--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
@@ -193,7 +193,7 @@ function OptionsMenu::apply(%this)
          if(%actionMap == GlobalActionMap.getId())
             continue;
          
-         %actionMapName = %actionMap.humanReadableName $= "" ? %actionMap.getName() : %actionMap.humanReadableName;
+         %actionMapName = %actionMap.getName();
          if(%actionMapName $= %targetVar)
          {
             %hasKeybindChanges = true;
@@ -959,7 +959,7 @@ function OptionsMenuSettingsList::addSliderRow(%this, %label, %targetPrefVar, %i
    %this.add(%option);
 }
 
-function OptionsMenuSettingsList::addKeybindRow(%this, %label, %bitmapName, %callback, %enabled, %description)
+function OptionsMenuSettingsList::addKeybindRow(%this, %label, %bitmapName, %callback, %enabled, %description, %remapIndex)
 {
    if(%enabled $= "")
       %enabled = true;
@@ -977,6 +977,8 @@ function OptionsMenuSettingsList::addKeybindRow(%this, %label, %bitmapName, %cal
       columnSplit = %optionColumnWidth;
       useMouseEvents = true;
    };
+   
+   %option.remapIndex = %remapIndex;
    
    %option.setKeybindSetting(%label, %bitmapName, %callback, %enabled, %description);
 

--- a/Templates/BaseGame/game/data/UI/scripts/controlsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/controlsMenu.tscript
@@ -192,7 +192,7 @@ function fillRemapList()
       
       %buttonImageAsset = getButtonBitmap(%device, getField(%keyMap, 1));
       
-      OptionsMenuSettingsList.addKeybindRow(getField(%keyMap, 0), %buttonImageAsset, "doKeyRemap", true, %description);
+      OptionsMenuSettingsList.addKeybindRow(getField(%keyMap, 0), %buttonImageAsset, "doKeyRemap", true, %description, %i);
    }
 
    //OptionsMenuSettingsList.refresh();
@@ -207,8 +207,7 @@ function controlSetChanged()
 
 function doKeyRemap( %row )
 {
-   %rowIndex = %row.getParent().getObjectIndex(%row);
-   %rowIndex--; //Offset the rowIndex to account for controlset option
+   %rowIndex = %row.remapIndex;
    %name = $RemapName[%rowIndex];
 
 	RemapDlg-->OptRemapText.text = "Re-bind \"" @ %name @ "\" to..." ;


### PR DESCRIPTION
Fixes two issues:
-Bindings after the first page were not pointing to the correct remapping entries when actually remapping. Were populating the name and button image correctly, but first item on every page pointed to first item on first page. Attached remap array index to the binding row buttons when they're created.
-Keybinds were never being saved to file if your action maps all had long-form ("human readable") names defined. The unapplied changes entries always use the actionmap's script object name, but the apply function was testing against human readable names if they existed.