### PR TITLE
Project importer: Fix handling of filenames starting with ./

### DIFF
--- a/Templates/BaseGame/game/tools/projectImporter/scripts/projectImporter.tscript
+++ b/Templates/BaseGame/game/tools/projectImporter/scripts/projectImporter.tscript
@@ -863,6 +863,7 @@ function sanitizeFilename(%file)
       %targetFilename = %targetPath @ "/" @ %targetName @ %targetExt;
    }
    
+   %targetFilename = strReplace(%targetFilename, "//", "/");
    /*if(!isFile(%targetFilename))
    {
       %bitmapFile = %targetPath @ "/" @ %targetName @ "_n" @ %targetExt;


### PR DESCRIPTION
Restores a line for removing double slashes that got caught in a comment block, was preventing filenames starting with ./ from being replaced with asset names in scripts.