### PR TITLE
spawnsphere %this tracking

### DIFF
--- a/Engine/source/T3D/missionMarker.cpp
+++ b/Engine/source/T3D/missionMarker.cpp
@@ -377,8 +377,9 @@ bool SpawnSphere::onAdd()
 
 SimObject* SpawnSphere::spawnObject(String additionalProps)
 {
+   String command = String("%this = ") + getIdString() + ";" + mSpawnScript;
    SimObject* spawnObject = Sim::spawnObject(mSpawnClass, mSpawnDataBlock, mSpawnName,
-                                             mSpawnProperties + " " + additionalProps, mSpawnScript);
+                                             mSpawnProperties + " " + additionalProps, command);
 
    // If we have a spawnObject add it to the MissionCleanup group
    if (spawnObject)


### PR DESCRIPTION
fill out a %this var for sawnobjects prior to running the spawnscript command to give it acess to the spawner instance in addition to the spawned instance