### PR TITLE
tag the terrain material diffuse tool label with more context

### DIFF
--- a/Templates/BaseGame/game/tools/worldEditor/gui/guiTerrainMaterialDlg.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/guiTerrainMaterialDlg.ed.gui
@@ -195,7 +195,7 @@ $guiContent = new GuiControl(TerrainMaterialDlg,EditorGuiGroup) {
                tooltip = "Change the Active Diffuse Map for this layer";
             };
             new GuiTextCtrl() {
-               text = "Diffuse";
+               text = "Diffuse (Overlay)";
                position = "56 -3";
                extent = "39 18";
                profile = "EditorTextProfile";


### PR DESCRIPTION
the name alone doesn't make it clear that that texture is stretched over the whole map and sampled to create the _basetex.dds files