### PR TITLE
minor cleanups

### DIFF
--- a/Engine/source/gfx/bitmap/ddsFile.cpp
+++ b/Engine/source/gfx/bitmap/ddsFile.cpp
@@ -123,7 +123,7 @@ U32 DDSFile::getSurfaceSize( U32 height, U32 width, U32 mipLevel ) const
    if(mFlags.test(CompressedData))
    {
       // From the directX docs:
-      // max(1, width ÷ 4) x max(1, height ÷ 4) x 8(DXT1) or 16(DXT2-5)
+      // max(1, width / 4) x max(1, height / 4) x 8(DXT1) or 16(DXT2-5)
 
       U32 sizeMultiple = 0;
 
@@ -178,7 +178,7 @@ U32 DDSFile::getSizeInBytes( GFXFormat format, U32 height, U32 width, U32 mipLev
       "DDSFile::getSizeInBytes - Must be a Block Compression format!" );
 
    // From the directX docs:
-   // max(1, width ÷ 4) x max(1, height ÷ 4) x 8(DXT1) or 16(DXT2-5)
+   // max(1, width / 4) x max(1, height / 4) x 8(DXT1) or 16(DXT2-5)
 
    U32 sizeMultiple = 0;
    if ( format == GFXFormatBC1 || format == GFXFormatBC1_SRGB || format == GFXFormatBC4)

--- a/Tools/CMake/basics.cmake
+++ b/Tools/CMake/basics.cmake
@@ -348,7 +348,7 @@ macro(finishLibrary)
         add_library("${PROJECT_NAME}" SHARED ${${PROJECT_NAME}_files})
     endif()
 
-    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
     # omg - only use the first folder ... otherwise we get lots of header name collisions
     #foreach(dir ${${PROJECT_NAME}_paths})


### PR DESCRIPTION
a) dds remline format fix
b) set basics cmake finishLibrary macro to use the same cxx_std_20 flag as is used in finishExecutable