### PR TITLE
fix getDirectoryList

### DIFF
--- a/Engine/source/console/fileSystemFunctions.cpp
+++ b/Engine/source/console/fileSystemFunctions.cpp
@@ -489,9 +489,7 @@ DefineEngineFunction(getDirectoryList, String, ( const char* path, S32 depth ), 
    // Append a trailing backslash if it's not present already.
    if (fullpath[dStrlen(fullpath) - 1] != '/')
    {
-      S32 pos = dStrlen(fullpath);
-      fullpath[pos - 1] = '/';
-      fullpath[pos] = '\0';
+      dStrcat(fullpath, "/\0", 1024);
    }
 
    // Dump the directories.


### PR DESCRIPTION
used dStrcat (note: not dStrncat, so there the buffer destination size *is* the third var)