### PR TITLE
(Obj spawning) Only project to farplane to avoid hang/crash w/ high fardist

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/creatorObj.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/creatorObj.tscript
@@ -33,7 +33,7 @@ function AssetBrowser::onCreatorEditorDropped(%this, %assetDef, %position)
 {
    if(EditorIsActive())
    {
-   %targetPosition = EWorldEditor.unproject(%position SPC 1000);
+   %targetPosition = EWorldEditor.unproject(%position SPC 1);
    %camPos = LocalClientConnection.camera.getPosition();
    %rayResult = containerRayCast(%camPos, %targetPosition, -1);
    

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/datablockObjects.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/datablockObjects.tscript
@@ -167,7 +167,7 @@ function AssetBrowser::deleteDatablock(%this, %folderPath)
 
 function AssetBrowser::onDatablockEditorDropped(%this, %assetDef, %position)
 {
-   %targetPosition = EWorldEditor.unproject(%position SPC 1000);
+   %targetPosition = EWorldEditor.unproject(%position SPC 1);
    %camPos = LocalClientConnection.camera.getPosition();
    %rayResult = containerRayCast(%camPos, %targetPosition, -1);
    

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/gameObject.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/gameObject.tscript
@@ -116,7 +116,7 @@ function AssetBrowser::onGameObjectAssetEditorDropped(%this, %assetDef, %positio
 {
    //echo("DROPPED A SHAPE ON THE EDITOR WINDOW!"); 
 
-   %targetPosition = EWorldEditor.unproject(%position SPC 1000);
+   %targetPosition = EWorldEditor.unproject(%position SPC 1);
    %camPos = LocalClientConnection.camera.getPosition();
    %rayResult = containerRayCast(%camPos, %targetPosition, -1);
    

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
@@ -554,7 +554,7 @@ function AssetBrowser::onMaterialAssetEditorDropped(%this, %assetDef, %position)
    //first, see if we hit a static shape
    %mask = $TypeMasks::StaticObjectType | $TypeMasks::StaticShapeObjectType | $TypeMasks::TerrainObjectType;
    
-   %targetPosition = EWorldEditor.unproject(%position SPC 1000);
+   %targetPosition = EWorldEditor.unproject(%position SPC 1);
    %camPos = LocalClientConnection.camera.getPosition();
    %rayResult = materialRayCast(%camPos, %targetPosition, -1, 0, false);
    

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/prefab.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/prefab.tscript
@@ -34,7 +34,7 @@ function AssetBrowser::onPrefabEditorDropped(%this, %assetDef, %position)
 {
    //echo("DROPPED A SHAPE ON THE EDITOR WINDOW!"); 
 
-   %targetPosition = EWorldEditor.unproject(%position SPC 1000);
+   %targetPosition = EWorldEditor.unproject(%position SPC 1);
    %camPos = LocalClientConnection.camera.getPosition();
    %rayResult = containerRayCast(%camPos, %targetPosition, -1);
    

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/sound.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/sound.tscript
@@ -57,7 +57,7 @@ function AssetBrowser::buildSoundAssetPreview(%this, %assetDef, %previewData)
 
 function AssetBrowser::onSoundAssetEditorDropped(%this, %assetDef, %position)
 {
-   %targetPosition = EWorldEditor.unproject(%position SPC 1000);
+   %targetPosition = EWorldEditor.unproject(%position SPC 1);
    %camPos = LocalClientConnection.camera.getPosition();
    %rayResult = containerRayCast(%camPos, %targetPosition, -1);
    


### PR DESCRIPTION
Unproject depth (z coord on input) is normalized, 0=nearclip, 1= fardist

This is the lazy fix; Just project to 1.0 depth (fardist)... You could also limit the raycast that follows to some specific length (like the intended 1000m), but this is probably already fine unless the render dist is something crazy like 9 billion meters.