### PR TITLE
better callback filtering for getMethodSigs

### DIFF
--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -2662,7 +2662,7 @@ DefineEngineMethod( SimObject, dumpMethods, ArrayObject*, (),,
    return dictionary;
 }
 
-DefineEngineMethod(SimObject, getMethodSigs, ArrayObject*, (), ,
+DefineEngineMethod(SimObject, getMethodSigs, ArrayObject*, (bool commands), (false),
    "List the methods defined on this object.\n\n"
    "Each description is a newline-separated vector with the following elements:\n"
    "- method prototype string.\n"
@@ -2682,9 +2682,16 @@ DefineEngineMethod(SimObject, getMethodSigs, ArrayObject*, (), ,
    {
       Namespace::Entry* e = *j;
 
-      if (e->mType != Namespace::Entry::ScriptCallbackType)
-         continue;
-
+      if (commands)
+      {
+         if ((e->mType < Namespace::Entry::ConsoleFunctionType))
+            continue;
+      }
+      else
+      {
+         if ((e->mType > Namespace::Entry::ScriptCallbackType))
+            continue;
+      }
       StringBuilder str;
       str.append("function ");
       str.append(ns->getName());


### PR DESCRIPTION
add a bool filter to getMethodSigs so it can also return script commands

example code reminder note:

//MainMenuGui.getPrototypeList();
//MainMenuGui.getPrototypeDef("onAdd");
function simObject::getPrototypeList(%this)
{
      %methodArray = %this.getMethodSigs();
      %methodCount = %methodArray.count();
      for (%i=0;%i<%methodCount;%i++)
      {
         %methodDef = getRecord(%methodArray.getValue(%i),0);
         %methodName = strreplace(%methodDef,"::"," ");
         %methodName = getWord(strreplace(%methodName,"("," "),2);
         warn(%methodName);
      }
}

function simObject::getPrototypeDef(%this, %funcName) {
      %methodArray = %this.getMethodSigs();
      %methodCount = %methodArray.count();
      for (%i=0;%i<%methodCount;%i++)
      {
         %methodDef = %methodArray.getValue(%i);
         %methodName = strreplace(%methodDef,"::"," ");
         %methodName = getWord(strreplace(%methodName,"("," "),2);
         if (%funcName $= %methodName)
            warn(%methodDef);
      }
}