### PR TITLE
Prevent double onAdd script call for GameBase objs

### DIFF
--- a/Templates/BaseGame/game/core/utility/scripts/gameObjectManagement.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/gameObjectManagement.tscript
@@ -80,10 +80,15 @@ function spawnGameObject(%name, %addToScene)
 
 function GameBaseData::onNewDataBlock(%this, %obj)
 {
-   if(%this.isMethod("onRemove"))
-      %this.onRemove(%obj);
-   if(%this.isMethod("onAdd"))
-      %this.onAdd(%obj);
+   if (%obj.firstDataCheck)
+   {
+      if(%this.isMethod("onRemove"))
+         %this.onRemove(%obj);
+      if(%this.isMethod("onAdd"))
+         %this.onAdd(%obj);
+   }
+   else
+      %obj.firstDataCheck = true;
 }
 
 function saveGameObject(%name, %tamlPath, %scriptPath)


### PR DESCRIPTION
Adds a check to skip this the first time onNewDataBlock is called (when the object is created) to prevent double-calling onAdd