### PR TITLE
guiprofiles augs

### DIFF
--- a/Engine/source/gui/buttons/guiIconButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiIconButtonCtrl.cpp
@@ -223,7 +223,16 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
    bool depressed = mDepressed;
    
    ColorI fontColor   = mActive ? (highlight ? mProfile->mFontColorHL : mProfile->mFontColor) : mProfile->mFontColorNA;
-   
+   ColorI borderColor = mActive ? (highlight ? mProfile->mBorderColorHL : mProfile->mBorderColor) : mProfile->mBorderColorNA;
+   ColorI fillColor = mActive ? (highlight ? mProfile->mFillColorHL : mProfile->mFillColor) : mProfile->mFillColorNA;
+
+   if (mActive && (depressed || mStateOn))
+   {
+      fontColor = mProfile->mFontColorSEL;
+      fillColor = mProfile->mFillColorSEL;
+      borderColor = mProfile->mBorderColorSEL;
+   }
+
    RectI boundsRect(offset, getExtent());
 
    GFXDrawUtil *drawer = GFX->getDrawUtil();
@@ -235,7 +244,12 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
       if(mProfile->mUseBitmapArray && !mProfile->mBitmapArrayRects.empty())
          renderBitmapArray(boundsRect, statePressed);
       else
-         renderSlightlyLoweredBox(boundsRect, mProfile);
+      {
+         if (mProfile->mBorder != 0)
+            renderFilledBorder(boundsRect, borderColor, fillColor, mProfile->mBorderThickness);
+         else
+            GFX->getDrawUtil()->drawRectFill(boundsRect, mProfile->mFillColor);
+      }
    }
    else if(mHighlighted && mActive)
    {
@@ -248,9 +262,9 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
       else
       {
          if (mProfile->mBorder != 0)
-            renderFilledBorder(boundsRect, mProfile->mBorderColorHL, mProfile->mFillColorHL, mProfile->mBorderThickness);
+            renderFilledBorder(boundsRect, borderColor, fillColor, mProfile->mBorderThickness);
          else
-            GFX->getDrawUtil()->drawRectFill(boundsRect, mProfile->mFillColorHL);
+            GFX->getDrawUtil()->drawRectFill(boundsRect, mProfile->mFillColor);
       }
    }
    else
@@ -266,20 +280,10 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
       }
       else
       {
-         if (mActive)
-         {
-            if (mProfile->mBorder != 0)
-               renderFilledBorder(boundsRect, mProfile->mBorderColor, mProfile->mFillColor, mProfile->mBorderThickness);
-            else
-               GFX->getDrawUtil()->drawRectFill(boundsRect, mProfile->mFillColor);
-         }
+         if (mProfile->mBorder != 0)
+            renderFilledBorder(boundsRect, borderColor, fillColor, mProfile->mBorderThickness);
          else
-         {
-            if (mProfile->mBorder != 0)
-               renderFilledBorder(boundsRect, mProfile->mBorderColorNA, mProfile->mFillColorNA, mProfile->mBorderThickness);
-            else
-               GFX->getDrawUtil()->drawRectFill(boundsRect, mProfile->mFillColor);
-         }
+            GFX->getDrawUtil()->drawRectFill(boundsRect, mProfile->mFillColor);
       }
    }
 

--- a/Engine/source/gui/core/guiTypes.cpp
+++ b/Engine/source/gui/core/guiTypes.cpp
@@ -235,6 +235,7 @@ GuiControlProfile::GuiControlProfile(void) :
    mFontColor(mFontColors[BaseColor]),
    mFontColorHL(mFontColors[ColorHL]),
    mFontColorNA(mFontColors[ColorNA]),
+   mFontColorERR(mFontColors[ColorERR]),
    mFontColorSEL(mFontColors[ColorSEL]),
    mCursorColor(255,0,255,255),
    mTextOffset(0,0),
@@ -259,7 +260,7 @@ GuiControlProfile::GuiControlProfile(void) :
    mFontType = "Arial";
    mFontSize = 10;
 
-   for(U32 i = 0; i < 10; i++)
+   for(U32 i = 0; i < ColorMax; i++)
       mFontColors[i].set(255,0,255,255);
 
    mFontCharset = TGE_ANSI_CHARSET;
@@ -307,7 +308,7 @@ GuiControlProfile::GuiControlProfile(void) :
       mFontSize      = def->mFontSize;
       mFontCharset   = def->mFontCharset;
 
-      for(U32 i = 0; i < 10; i++)
+      for(U32 i = 0; i < ColorMax; i++)
          mFontColors[i] = def->mFontColors[i];
 		
       // default bitmap
@@ -375,8 +376,14 @@ void GuiControlProfile::initPersistFields()
          "Thickness of border in pixels." );
       addField("borderColor",   TypeColorI,     Offset(mBorderColor, GuiControlProfile),
          "Color to draw border with." );
-      addField("borderColorHL", TypeColorI,     Offset(mBorderColorHL, GuiControlProfile));
-      addField("borderColorNA", TypeColorI,     Offset(mBorderColorNA, GuiControlProfile));
+      addField("borderColorHL", TypeColorI,     Offset(mBorderColorHL, GuiControlProfile),
+         "Color to draw border with if highlighted.");
+      addField("borderColorNA", TypeColorI,     Offset(mBorderColorNA, GuiControlProfile),
+         "Color to draw border if disabled.");
+      addField("borderColorSEL", TypeColorI, Offset(mBorderColorSEL, GuiControlProfile),
+         "Color to draw border with if selected.");
+      addField("borderColorERR", TypeColorI, Offset(mBorderColorERR, GuiControlProfile),
+         "Color to draw border with if erroring.");
 
       addField("bevelColorHL", TypeColorI,     Offset(mBevelColorHL, GuiControlProfile));
       addField("bevelColorLL", TypeColorI,     Offset(mBevelColorLL, GuiControlProfile));
@@ -390,7 +397,7 @@ void GuiControlProfile::initPersistFields()
       addField("fontSize",             TypeS32,        Offset(mFontSize, GuiControlProfile),
          "Font size in points." );
       addField("fontCharset",          TYPEID< FontCharset >(),       Offset(mFontCharset, GuiControlProfile) );
-      addField("fontColors",           TypeColorI,     Offset(mFontColors, GuiControlProfile), 10,
+      addField("fontColors",           TypeColorI,     Offset(mFontColors, GuiControlProfile), ColorMax,
          "Font colors to use for different text types/states." );
       addField("fontColor",            TypeColorI,     Offset(mFontColors[BaseColor], GuiControlProfile),
          "Font color for normal text (same as fontColors[0])." );
@@ -404,6 +411,8 @@ void GuiControlProfile::initPersistFields()
          "Font color for links in text (same as fontColors[4])." );
       addField("fontColorLinkHL",      TypeColorI,     Offset(mFontColors[ColorUser1], GuiControlProfile),
          "Font color for highlighted links in text (same as fontColors[5])." );
+      addField("fontColorERR", TypeColorI, Offset(mFontColors[ColorERR], GuiControlProfile),
+         "Font color for links in text (same as fontColors[10]).");
             
       addField( "justify",       TYPEID< GuiControlProfile::AlignmentType >(),       Offset(mAlignment, GuiControlProfile),
          "Horizontal alignment for text." );

--- a/Engine/source/gui/core/guiTypes.h
+++ b/Engine/source/gui/core/guiTypes.h
@@ -404,6 +404,8 @@ public:
    ColorI mBorderColor;                            ///< Border color, used to draw a border around the bounds if border is enabled
    ColorI mBorderColorHL;                          ///< Used instead of mBorderColor when the object is highlighted
    ColorI mBorderColorNA;                          ///< Used instead of mBorderColor when the object is not active or disabled
+   ColorI mBorderColorERR;                         ///< Used instead of mBorderColor if the object has an error or is invalid
+   ColorI mBorderColorSEL;                         ///< Used instead of mBorderColor if the object is selected
 
    ColorI mBevelColorHL;                          ///< Used for the high-light part of the bevel
    ColorI mBevelColorLL;                          ///< Used for the low-light part of the bevel
@@ -422,11 +424,14 @@ public:
       ColorUser3,
       ColorUser4,
       ColorUser5,
+      ColorERR,
+      ColorMax
    };
-   ColorI  mFontColors[10];                        ///< Array of font colors used for drawText with escape characters for changing color mid-string
+   ColorI  mFontColors[ColorMax];                        ///< Array of font colors used for drawText with escape characters for changing color mid-string
    ColorI& mFontColor;                             ///< Main font color
    ColorI& mFontColorHL;                           ///< Highlighted font color
    ColorI& mFontColorNA;                           ///< Font color when object is not active/disabled
+   ColorI& mFontColorERR;                          ///< Font color when object is in error
    ColorI& mFontColorSEL;                          ///< Font color when object/text is selected
    FontCharset mFontCharset;                       ///< Font character set
 

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/profiles.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/profiles.tscript
@@ -1,109 +1,64 @@
-singleton GuiControlProfile(AssetBrowserPreviewImageAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserProtoProfile : ToolsGuiDefaultProfile)
 {
    fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
    fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
+   fillColorSEL = EditorSettings.value("Theme/fieldBGSELColor");
+   fillColorERR = "128 0 0 255";
    border = true;
    borderColor   = "230 126 0 255";
+   borderColorHL   = "128 128 128 255";
+   borderColorSEL   = "230 230 230 255";
+   borderColorERR   = "255 0 0 255";
    borderColorNA = "230 126 0 255";
-   borderThickness = 5;
+   borderThickness = 3;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewMaterialAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewImageAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
+   borderColor   = "230 126 0 255";
+};
+
+singleton GuiControlProfile(AssetBrowserPreviewMaterialAsset : AssetBrowserProtoProfile)
+{
    borderColor   = "0 100 0 255";
-   borderColorNA = "0 100 0 255";
-   borderThickness = 5;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewShapeAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewShapeAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
    borderColor   = "0 0 200 255";
-   borderColorNA = "0 0 200 255";
-   borderThickness = 5;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewShapeAnimationAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewShapeAnimationAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
    borderColor   = "0 0 200 255";
-   borderColorNA = "0 0 200 255";
-   borderThickness = 5;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewSoundAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewSoundAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
    borderColor   = "75 101 135 255";
-   borderColorNA = "75 101 135 255";
-   borderThickness = 5;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewTerrainAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewTerrainAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
    borderColor   = "200 198 198 255";
-   borderColorNA = "200 198 198 255";
-   borderThickness = 5;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewTerrainMaterialAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewTerrainMaterialAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
    borderColor   = "200 198 198 255";
-   borderColorNA = "200 198 198 255";
-   borderThickness = 5;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewStateMachineAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewStateMachineAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
    borderColor   = "0 76 135 255";
-   borderColorNA = "0 76 135 255";
-   borderThickness = 5;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewGUIAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewGUIAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
    borderColor   = "17 5 44 255";
-   borderColorNA = "17 5 44 255";
-   borderThickness = 5;
 };
 
-singleton GuiControlProfile(AssetBrowserPreviewLevelAsset : ToolsGuiDefaultProfile)
+singleton GuiControlProfile(AssetBrowserPreviewLevelAsset : AssetBrowserProtoProfile)
 {
-   fillcolor = EditorSettings.value("Theme/windowBackgroundColor");
-   fillColorHL = EditorSettings.value("Theme/fieldBGHLColor");
-   
-   border = true;
    borderColor   = "0 208 186 255";
-   borderColorNA = "0 208 186 255";
-   borderThickness = 5;
 };


### PR DESCRIPTION
guiprofiles now have additional options: borderSEL and borderERR in keeping with the fillcolor variants. fontColors now also takes an optional ERR entry on the backend, though that remains unleveraged at time of writing. guiiconbuttonctrl now uses the expanded list in conjunction with renderFilledBorder asset browser profiles now contain a AssetBrowserProtoProfile that type-profiles derive from for consistency in border selection, highlight, (and down the line error)  colors and border thickness while maintaining type-sepcific border color entries for general display