### PR TITLE
misc warn fixes

### DIFF
--- a/Engine/source/console/compiledEval.cpp
+++ b/Engine/source/console/compiledEval.cpp
@@ -564,9 +564,9 @@ TORQUE_NOINLINE void doSlowIntegerOp()
 
    // Logical Op
    if constexpr (Op == IntegerOperation::LogicalAnd)
-      stack[_STK - 1].setInt(a.getInt() && b.getInt());
+      stack[_STK - 1].setBool(a.getInt() && b.getInt());
    if constexpr (Op == IntegerOperation::LogicalOr)
-      stack[_STK - 1].setInt(a.getInt() || b.getInt());
+      stack[_STK - 1].setBool(a.getInt() || b.getInt());
 
    _STK--;
 }
@@ -593,9 +593,9 @@ TORQUE_FORCEINLINE void doIntOperation()
 
       // Logical Op
       if constexpr (Op == IntegerOperation::LogicalAnd)
-         stack[_STK - 1].setFastInt(a.getFastInt() && b.getFastInt());
+         stack[_STK - 1].setBool(a.getFastInt() && b.getFastInt());
       if constexpr (Op == IntegerOperation::LogicalOr)
-         stack[_STK - 1].setFastInt(a.getFastInt() || b.getFastInt());
+         stack[_STK - 1].setBool(a.getFastInt() || b.getFastInt());
 
       _STK--;
    }
@@ -1344,7 +1344,7 @@ ConsoleValue CodeBlock::exec(U32 ip, const char* functionName, Namespace* thisNa
          break;
 
       case OP_NOT:
-         stack[_STK].setInt(!stack[_STK].getInt());
+         stack[_STK].setBool(!stack[_STK].getInt());
          break;
 
       case OP_NOTF:

--- a/Engine/source/core/volume.cpp
+++ b/Engine/source/core/volume.cpp
@@ -618,13 +618,13 @@ bool MountSystem::_dumpDirectories(DirectoryRef directory, Vector<StringTableEnt
          // So if we queried for data/ and are currently processing data/ExampleModule/datablocks we want to output
          // ExampleModule/datablocks
          Path newDirectoryPath;
-         for (U32 iteration = basePathDirectoryCount; iteration < directoryPath.getDirectoryCount(); ++iteration)
+         for (U32 subIteration = basePathDirectoryCount; subIteration < directoryPath.getDirectoryCount(); ++subIteration)
          {
-            if (iteration > basePathDirectoryCount)
+            if (subIteration > basePathDirectoryCount)
             {
                newDirectoryPath.setPath(newDirectoryPath.getPath() + "/");
             }
-            newDirectoryPath.setPath(newDirectoryPath.getPath() + directoryPath.getDirectory(iteration));
+            newDirectoryPath.setPath(newDirectoryPath.getPath() + directoryPath.getDirectory(subIteration));
          }
 
          newDirectoryPath.setFileName(directoryPath.getFileName());


### PR DESCRIPTION
parser had a few spots where it was throwing int compares to ints instead of bools for logical and/ors. not bitwise ones. _dumpDirectories had a stray itterator dupe