### PR TITLE
fileModifiedTime cleanups

### DIFF
--- a/Engine/source/platformWin32/winTime.cpp
+++ b/Engine/source/platformWin32/winTime.cpp
@@ -93,7 +93,7 @@ String Platform::localTimeToString( const LocalTime &lt )
    outStr += "\t";
 
    result = GetTimeFormat( LOCALE_USER_DEFAULT,
-                           0,
+                           TIME_FORCE24HOURFORMAT,
                            &st,
                            NULL,
                            (LPTSTR)buffer,

--- a/Engine/source/platformWin32/winVolume.cpp
+++ b/Engine/source/platformWin32/winVolume.cpp
@@ -138,20 +138,27 @@ static void _CopyStatAttributes(const WIN32_FIND_DATAW& info, FileNode::Attribut
    if (info.dwFileAttributes & FILE_ATTRIBUTE_READONLY)
       attr->flags |= FileNode::ReadOnly;
 
+   SYSTEMTIME st, stLocal;
+   FILETIME ftLocal;
+
    attr->size = info.nFileSizeLow;
-   attr->mtime = Win32FileTimeToTime(
-      info.ftLastWriteTime.dwLowDateTime,
-      info.ftLastWriteTime.dwHighDateTime);
 
-   attr->atime = Win32FileTimeToTime(
-      info.ftLastAccessTime.dwLowDateTime,
-      info.ftLastAccessTime.dwHighDateTime);
+   FileTimeToSystemTime(&(info.ftLastWriteTime), &st);
+   SystemTimeToTzSpecificLocalTime(NULL, &st, &stLocal);
+   SystemTimeToFileTime(&stLocal, &ftLocal);
+   attr->mtime = Win32FileTimeToTime(ftLocal.dwLowDateTime, ftLocal.dwHighDateTime);
 
-   attr->ctime = Win32FileTimeToTime(
-      info.ftCreationTime.dwLowDateTime,
-      info.ftCreationTime.dwHighDateTime);
+   FileTimeToSystemTime(&(info.ftLastAccessTime), &st);
+   SystemTimeToTzSpecificLocalTime(NULL, &st, &stLocal);
+   SystemTimeToFileTime(&stLocal, &ftLocal);
+   attr->atime = Win32FileTimeToTime(ftLocal.dwLowDateTime, ftLocal.dwHighDateTime);
+
+
+   FileTimeToSystemTime(&(info.ftCreationTime), &st);
+   SystemTimeToTzSpecificLocalTime(NULL, &st, &stLocal);
+   SystemTimeToFileTime(&stLocal, &ftLocal);
+   attr->ctime = Win32FileTimeToTime(ftLocal.dwLowDateTime, ftLocal.dwHighDateTime);
 }
-
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
leverage more windows-specific commands for  _CopyStatAttributes to among other things account for timezones when comparing vs the getTimeStamp() command