### PR TITLE
Fix buffer overflow in GuiTreeViewCtrl class.

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -466,6 +466,10 @@ U32 GuiTreeViewCtrl::Item::getDisplayTextLength()
          if( internalName && internalName[ 0 ] )
             len += dStrlen( internalName ) + 3; // ' [<internalname>]'
       }
+      if( mState.test( Marked ) )
+      {
+         len += 1; // '*<name>'
+      }
 
       return len;
    }


### PR DESCRIPTION
When calculating text length (in method `GuiTreeViewCtrl::Item::getDisplayTextLength()`) the code doesn't take into account the `ItemState::Marked`, which adds additional char in `GuiTreeViewCtrl::Item::getDisplayText()` method.

This commit fixes warning printed into console when calling `dSprintf()` as the buffer is now enough to fit all data.