### PR TITLE
add TypeHints for scenetree viewing

### DIFF
--- a/Engine/source/T3D/gameBase/gameBase.h
+++ b/Engine/source/T3D/gameBase/gameBase.h
@@ -275,6 +275,8 @@ public:
    /// Returns the datablock for this object.
    GameBaseData* getDataBlock()  { return mDataBlock; }
 
+   /// returns the datablock name for this object
+   StringTableEntry getTypeHint() const override { return (mDataBlock) ? mDataBlock->getName() : StringTable->EmptyString(); };
    /// Called when a new datablock is set. This allows subclasses to
    /// appropriately handle new datablocks.
    ///

--- a/Engine/source/T3D/missionMarker.h
+++ b/Engine/source/T3D/missionMarker.h
@@ -166,6 +166,8 @@ class SpawnSphere : public MissionMarker
       bool     mAutoSpawn;
       bool     mSpawnTransform;
 
+      /// returns the datablock spawned for this object
+      StringTableEntry getTypeHint() const override { return (mSpawnDataBlock.isNotEmpty()) ? mSpawnDataBlock.c_str() : StringTable->EmptyString(); };
       // Radius/weight info
       F32      mRadius;
       F32      mSphereWeight;

--- a/Engine/source/T3D/prefab.cpp
+++ b/Engine/source/T3D/prefab.cpp
@@ -93,6 +93,10 @@ void Prefab::initPersistFields()
    Parent::initPersistFields();
 }
 
+StringTableEntry Prefab::getTypeHint() const
+{
+   return (mFilename != StringTable->EmptyString()) ? StringTable->insert(Torque::Path(mFilename).getFileName().c_str()) : StringTable->EmptyString();
+}
 extern bool gEditingMission;
 
 bool Prefab::onAdd()

--- a/Engine/source/T3D/prefab.h
+++ b/Engine/source/T3D/prefab.h
@@ -60,6 +60,9 @@ public:
   
    static void initPersistFields();
 
+   /// returns the filename for this object
+   StringTableEntry getTypeHint() const override;
+   
    // SimObject
    virtual bool onAdd();
    virtual void onRemove();

--- a/Engine/source/T3D/sfx/sfxEmitter.h
+++ b/Engine/source/T3D/sfx/sfxEmitter.h
@@ -106,6 +106,8 @@ class SFXEmitter : public SceneObject
 
       DECLARE_SOUNDASSET(SFXEmitter, Sound);
       DECLARE_ASSET_NET_SETGET(SFXEmitter, Sound, DirtyUpdateMask);
+      /// returns the shape asset used for this object
+      StringTableEntry getTypeHint() const override { return (getSoundAsset()) ? getSoundAsset()->getAssetName() : StringTable->EmptyString(); }
 
       /// The sound source for the emitter.
       SFXSource *mSource;

--- a/Engine/source/T3D/tsStatic.h
+++ b/Engine/source/T3D/tsStatic.h
@@ -237,6 +237,8 @@ public:
 
    DECLARE_CONOBJECT(TSStatic);
    static void initPersistFields();
+   /// returns the shape asset used for this object
+   StringTableEntry getTypeHint() const override { return (getShapeAsset()) ? getShapeAsset()->getAssetName(): StringTable->EmptyString(); }
    static void consoleInit();
    static bool _setFieldSkin(void* object, const char* index, const char* data);
    static const char* _getFieldSkin(void* object, const char* data);

--- a/Engine/source/console/simObject.h
+++ b/Engine/source/console/simObject.h
@@ -549,6 +549,9 @@ class SimObject: public ConsoleObject, public TamlCallbacks
       /// Get the internal name of this control
       StringTableEntry getInternalName() const { return mInternalName; }
 
+      /// type-specified slot for returning hints for the main difference between object instances
+      virtual StringTableEntry getTypeHint() const { return StringTable->EmptyString(); }
+
       /// Set the original name of this control
       void setOriginalName(const char* originalName);
 

--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -425,6 +425,7 @@ U32 GuiTreeViewCtrl::Item::getDisplayTextLength()
 
       StringTableEntry name = obj->getName();
       StringTableEntry internalName = obj->getInternalName();
+      StringTableEntry typeHint = obj->getTypeHint();
       StringTableEntry className = obj->getClassName();      
 
       if( showInternalNameOnly() )
@@ -466,6 +467,11 @@ U32 GuiTreeViewCtrl::Item::getDisplayTextLength()
          if( internalName && internalName[ 0 ] )
             len += dStrlen( internalName ) + 3; // ' [<internalname>]'
       }
+      if ( mState.test(ShowTypeHint) )
+      {
+         if (typeHint && typeHint[0])
+            len += dStrlen(typeHint) + 3;
+      }
       if( mState.test( Marked ) )
       {
          len += 1; // '*<name>'
@@ -502,8 +508,10 @@ void GuiTreeViewCtrl::Item::getDisplayText(U32 bufLen, char *buf)
       {
          const char* pObjName = pObject->getName();
          const char* pInternalName = pObject->getInternalName();
+         const char* pTypeHint = pObject->getTypeHint();
 
          bool hasInternalName = pInternalName && pInternalName[0];
+         bool hasTypeHint = pTypeHint && pTypeHint[0];
          bool hasObjectName = pObjName && pObjName[0];
 
          const char* pClassName = pObject->getClassName();
@@ -565,6 +573,14 @@ void GuiTreeViewCtrl::Item::getDisplayText(U32 bufLen, char *buf)
                   dSprintf(ptr, len, " *[%s]", pInternalName);
                else
                   dSprintf(ptr, len, " [%s]", pInternalName);
+            }
+            if (hasTypeHint && mState.test(ShowTypeHint))
+            {
+               if (mState.test(Item::Marked))
+                  dSprintf(ptr, len, " *<%s>", pTypeHint);
+               else
+                  dSprintf(ptr, len, " <%s>", pTypeHint);
+
             }
          }
       }
@@ -835,6 +851,7 @@ GuiTreeViewCtrl::GuiTreeViewCtrl()
    mShowClassNames = true;
    mShowObjectNames = true;
    mShowInternalNames = true;
+   mShowTypeHints = false;
    mShowClassNameForUnnamedObjects = false;
    mFlags.set(RebuildVisible);
 
@@ -894,7 +911,10 @@ void GuiTreeViewCtrl::initPersistFields()
       addField( "showObjectNames", TypeBool, Offset( mShowObjectNames, GuiTreeViewCtrl ),
          "If true, item text labels for objects will include object names." );
       addField( "showInternalNames", TypeBool, Offset( mShowInternalNames, GuiTreeViewCtrl ),
-         "If true, item text labels for obje ts will include internal names." );
+         "If true, item text labels for objets will include internal names." );
+      addField("showTypeHints", TypeBool, Offset(mShowTypeHints, GuiTreeViewCtrl),
+         "If true, item text labels for objets will include TypeHints.");
+      
       addField( "showClassNameForUnnamedObjects", TypeBool, Offset( mShowClassNameForUnnamedObjects, GuiTreeViewCtrl ),
          "If true, class names will be used as object names for unnamed objects." );
       addField( "compareToObjectID",    TypeBool,   Offset(mCompareToObjectID,    GuiTreeViewCtrl));
@@ -1794,6 +1814,7 @@ bool GuiTreeViewCtrl::onAdd()
          mShowClassNames = false;
          mShowObjectNames = false;
          mShowInternalNames = true;
+         mShowTypeHints = false;
       }
 
       const char* objectNamesOnly = getDataField( sObjectNamesOnly, NULL );
@@ -1803,6 +1824,7 @@ bool GuiTreeViewCtrl::onAdd()
          mShowClassNames = false;
          mShowObjectNames = true;
          mShowInternalNames = false;
+         mShowTypeHints = false;
       }
    }
       
@@ -4109,6 +4131,10 @@ GuiTreeViewCtrl::Item* GuiTreeViewCtrl::addInspectorDataItem(Item *parent, SimOb
       item->mState.clear( Item::ShowInternalName );
    else
       item->mState.set( Item::ShowInternalName );
+   if (!mShowTypeHints)
+      item->mState.clear(Item::ShowTypeHint);
+   else
+      item->mState.set(Item::ShowTypeHint);
    if( mShowClassNameForUnnamedObjects )
       item->mState.set( Item::ShowClassNameForUnnamed );
 

--- a/Engine/source/gui/controls/guiTreeViewCtrl.h
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.h
@@ -79,6 +79,7 @@ class GuiTreeViewCtrl : public GuiArrayCtrl
                ForceItemName = BIT(15),
                ForceDragTarget = BIT(16),
                DenyDrag = BIT(17),
+               ShowTypeHint = BIT(18),
             };
 
             GuiTreeViewCtrl* mParentControl;
@@ -394,6 +395,9 @@ class GuiTreeViewCtrl : public GuiArrayCtrl
       
       /// If true, internal names will be included in inspector tree item labels.
       bool mShowInternalNames;
+
+      /// If true, TypeHints will be included in inspector tree item labels.
+      bool mShowTypeHints;
 
       /// If true, class names will be used as object names for unnamed objects.
       bool mShowClassNameForUnnamedObjects;

--- a/Templates/BaseGame/game/tools/worldEditor/gui/WorldEditorTreeWindow.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/WorldEditorTreeWindow.ed.gui
@@ -172,6 +172,7 @@ $guiContent = new GuiControl() {
                   showClassNames = "0";
                   showObjectNames = "1";
                   showInternalNames = "1";
+                  showTypeHints = "1";
                   showClassNameForUnnamedObjects = "1";
                };
             };


### PR DESCRIPTION
typehints operate as an additional label for a given class in the GuiTreeViewCtrl, allowing one to specify what class-entry to use as a tag examples: Prefab displays prefab filename
TSStatic displays the used shape asset name
SFXEmitter displays the played sound asset
GameBase derivatives display the datablock used