### PR TITLE
Update assimpShapeLoader.cpp

### DIFF
--- a/Engine/source/ts/assimp/assimpShapeLoader.cpp
+++ b/Engine/source/ts/assimp/assimpShapeLoader.cpp
@@ -247,9 +247,7 @@ void AssimpShapeLoader::processAnimations()
    {
       if (n == 0)
       {
-         //first animation name empty? set it to ambient.
-         if(mScene->mAnimations[n]->mName.length == 0)
-            mScene->mAnimations[n]->mName = "ambient";
+         mScene->mAnimations[n]->mName = "ambient";
       }
 
       Con::printf("[ASSIMP] Animation Found: %s", mScene->mAnimations[n]->mName.C_Str());

--- a/Engine/source/ts/assimp/assimpShapeLoader.cpp
+++ b/Engine/source/ts/assimp/assimpShapeLoader.cpp
@@ -243,8 +243,15 @@ void AssimpShapeLoader::enumerateScene()
 
 void AssimpShapeLoader::processAnimations()
 {
-   for(U32 n = 0; n < mScene->mNumAnimations; ++n)
+   for (U32 n = 0; n < mScene->mNumAnimations; ++n)
    {
+      if (n == 0)
+      {
+         //first animation name empty? set it to ambient.
+         if(mScene->mAnimations[n]->mName.length == 0)
+            mScene->mAnimations[n]->mName = "ambient";
+      }
+
       Con::printf("[ASSIMP] Animation Found: %s", mScene->mAnimations[n]->mName.C_Str());
 
       AssimpAppSequence* newAssimpSeq = new AssimpAppSequence(mScene->mAnimations[n]);


### PR DESCRIPTION
Needs properly tested, but it should only rename the first animation to ambient if it doesn't already have a name.