### PR TITLE
gtest tweaks

### DIFF
--- a/Engine/source/console/test/ScriptTest.cpp
+++ b/Engine/source/console/test/ScriptTest.cpp
@@ -443,7 +443,7 @@ TEST(Script, ForEachLoop)
          %count = 0;
          foreach (%obj in %this)
          {
-            if (%obj.getName() $= "A")
+            if (%obj.getName() $= "A_FEC")
                continue;
 
              %count++;
@@ -454,7 +454,7 @@ TEST(Script, ForEachLoop)
       function a()
       {
          %set = new SimSet();
-         %set.add(new SimObject(A));
+         %set.add(new SimObject(A_FEC));
          %set.add(new SimObject());
          %set.add(new SimObject());
 
@@ -471,7 +471,7 @@ TEST(Script, ForEachLoop)
       {
          foreach (%obj in %this)
          {
-            if (%obj.getName() $= "A")
+            if (%obj.getName() $= "A_FER")
                return 76;
          }
          return 0;
@@ -480,7 +480,7 @@ TEST(Script, ForEachLoop)
       function a()
       {
          %set = new SimSet();
-         %set.add(new SimObject(A));
+         %set.add(new SimObject(A_FER));
          %set.add(new SimObject());
          %set.add(new SimObject());
 
@@ -499,7 +499,7 @@ TEST(Script, ForEachLoop)
          {
             foreach (%innerObj in %this)
             {
-               if (%innerObj.getName() $= "A")
+               if (%innerObj.getName() $= "A_FENR")
                   return 42;
             }
          }
@@ -509,7 +509,7 @@ TEST(Script, ForEachLoop)
       function a()
       {
          %set = new SimSet();
-         %set.add(new SimObject(A));
+         %set.add(new SimObject(A_FENR));
          %set.add(new SimObject());
          %set.add(new SimObject());
 

--- a/Engine/source/platform/test/platformFileIOTest.cpp
+++ b/Engine/source/platform/test/platformFileIOTest.cpp
@@ -68,13 +68,17 @@ TEST(File, TouchAndTime)
 
    // Touch a file and note its last-modified.
    dFileTouch("testTouch.file");
+
+   // Sleep for a tick
+   Platform::sleep(32);
+
    EXPECT_TRUE(Platform::isFile("testTouch.file"))
       << "We just touched this file - it should exist.";
    EXPECT_TRUE(Platform::getFileTimes("testTouch.file", &create[0], &modify[0]))
       << "Failed to get filetimes for a file we just created.";
 
    // Sleep for a tick
-   Platform::sleep(10);
+   Platform::sleep(32);
 
    // Touch it again, and compare the last-modifieds.
    EXPECT_TRUE(Platform::isFile("testTouch.file"))

--- a/Engine/source/platform/threads/test/threadSafePriorityQueueTest.cpp
+++ b/Engine/source/platform/threads/test/threadSafePriorityQueueTest.cpp
@@ -35,7 +35,7 @@ TEST(ThreadSafePriorityQueue, Serial)
    const U32 len = 11;
 
    U32 indices[len]    = {  2,   7,   4,   6,   1,   5,   3,   8,   6,   9, 0};
-   F32 priorities[len] = {0.2, 0.7, 0.4, 0.6, 0.1, 0.5, 0.3, 0.8, 0.6, 0.9, 0};
+   F32 priorities[len] = {0.2f, 0.7f, 0.4f, 0.6f, 0.1f, 0.5f, 0.3f, 0.8f, 0.6f, 0.9f, 0.0f};
    
    ThreadSafePriorityQueue<U32, F32, true>  minQueue;
    ThreadSafePriorityQueue<U32, F32, false> maxQueue;
@@ -92,7 +92,7 @@ TEST(ThreadSafePriorityQueue, Concurrent)
       virtual void run(void*)
       {
          U32 indices[LEN]    = {  2,   7,   4,   6,   1,   5,   3,   8,   6,   9, 0};
-         F32 priorities[LEN] = {0.2, 0.7, 0.4, 0.6, 0.1, 0.5, 0.3, 0.8, 0.6, 0.9, 0};
+         F32 priorities[LEN] = {0.2f, 0.7f, 0.4f, 0.6f, 0.1f, 0.5f, 0.3f, 0.8f, 0.6f, 0.9f, 0.0f};
 
          for(U32 i = 0; i < LEN; i++)
          {

--- a/Engine/source/platform/threads/threadSafeFreeList.h
+++ b/Engine/source/platform/threads/threadSafeFreeList.h
@@ -85,7 +85,7 @@ class ThreadSafeFreeList
       {
          #ifdef TORQUE_DEBUG
          AssertWarn( mNumNodesTotal == mNumNodesFree,
-            "ThreadSafeFreeList::~ThreadSafeFreeList() - still got live instances" );
+            avar("ThreadSafeFreeList::~ThreadSafeFreeList() - still got live instances:[%i/%i]", mNumNodesTotal,mNumNodesFree) );
          #endif
 
          // Destroy remaining nodes.  Not synchronized.  We assume all

--- a/Engine/source/windowManager/test/windowManagerTest.cpp
+++ b/Engine/source/windowManager/test/windowManagerTest.cpp
@@ -29,6 +29,9 @@ TEST(WinMgr, BasicAPI)
 {
    PlatformWindowManager *pwm = CreatePlatformWindowManager();
 
+   ASSERT_TRUE(pwm)
+      << "no monitor to test against!";
+
    // Check out the primary desktop area...
    RectI primary = pwm->getPrimaryDesktopArea();
 


### PR DESCRIPTION
refactor concurrency test consumer thread runner to generate timeouts at excessive attempts (32ms*runlength) threadsafefreelist reporting augs
scripttest object name conflict resolutions
skip testing platform window creation if no monitor was found