### PR TITLE
Adds a logical check for when we try and check for found adapters

### DIFF
--- a/Engine/source/gfx/gfxInit.cpp
+++ b/Engine/source/gfx/gfxInit.cpp
@@ -333,17 +333,26 @@ GFXAdapter *GFXInit::getBestAdapterChoice()
       }
    }
 
-   // Return best found in order DX11, GL
-   if (foundAdapter11)
-      return foundAdapter11;
+   if (renderer.equal("NullDevice", String::NoCase) == false)
+   {
+      // Return best found in order DX11, GL
+      if (foundAdapter11)
+         return foundAdapter11;
 
-   if (foundAdapterGL)
-      return foundAdapterGL;
+      if (foundAdapterGL)
+         return foundAdapterGL;
 
-   // Uh oh - we didn't find anything. Grab whatever we can that's not Null...
-   for(S32 i=0; i<smAdapters.size(); i++)
-      if(smAdapters[i]->mType != NullDevice)
-         return smAdapters[i];
+      // Uh oh - we didn't find anything. Grab whatever we can that's not Null...
+      for (S32 i = 0; i < smAdapters.size(); i++)
+         if (smAdapters[i]->mType != NullDevice)
+            return smAdapters[i];
+   }
+   else
+   {
+      for (S32 i = 0; i < smAdapters.size(); i++)
+         if (smAdapters[i]->mType == NullDevice)
+            return smAdapters[i];
+   }
 
    // Dare we return a null device? No. Just return NULL.
    return NULL;


### PR DESCRIPTION
Adds a logical check for when we try and check for found adapters, so if we're defined to use a Null device, we can skip looking around