### PR TITLE
This implements a fix to an issue with the CICD that causes a segfault.

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -252,6 +252,10 @@ DXGI_SWAP_CHAIN_DESC GFXD3D11Device::setupPresentParams(const GFXVideoMode &mode
 
 void GFXD3D11Device::enumerateAdapters(Vector<GFXAdapter*> &adapterList)
 {
+   S32 monitorCount = PlatformWindowManager::get()->getMonitorCount();
+   if (monitorCount < 1)
+      return;
+
    IDXGIAdapter1* EnumAdapter;
    IDXGIFactory1* DXGIFactory;
 

--- a/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
+++ b/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
@@ -77,6 +77,10 @@ void EnumerateVideoModes(Vector<GFXVideoMode>& outModes)
 
 void GFXGLDevice::enumerateAdapters( Vector<GFXAdapter*> &adapterList )
 {
+   S32 monitorCount = PlatformWindowManager::get()->getMonitorCount();
+   if (monitorCount < 1)
+      return;
+
    AssertFatal( SDL_WasInit(SDL_INIT_VIDEO), "");
 
    PlatformGL::init(); // for hints about context creation

--- a/Engine/source/windowManager/test/windowManagerTest.cpp
+++ b/Engine/source/windowManager/test/windowManagerTest.cpp
@@ -28,9 +28,16 @@
 TEST(WinMgr, BasicAPI)
 {
    PlatformWindowManager *pwm = CreatePlatformWindowManager();
+   EXPECT_TRUE(pwm)
+      << "CreatePlatformWindowManager creation Failed!";
+   if (!pwm)
+      return;
 
-   ASSERT_TRUE(pwm)
+   S32 monitorCount = PlatformWindowManager::get()->getMonitorCount();
+   EXPECT_GT(monitorCount, 0)
       << "no monitor to test against!";
+   if (monitorCount == 0)
+      return;
 
    // Check out the primary desktop area...
    RectI primary = pwm->getPrimaryDesktopArea();


### PR DESCRIPTION
The fix adds a sanity check to the D3D and GL device enumeration function that exits early if there's no registered display from the OS(implying it's running in commandline). With newer versions of SDL, attempting to enumerate the GL device causes a segfault because the OS will return back a valid context, but the context isn't actually valid. So when tested against, it crashes. Avoiding enumerating the device when you're not in a position to render works around the issue.

TODO: If the machine is running in terminal-only mode, and thus has no valid render context, but still has a monitor plugged into the machine, it can sidestep the sanity check and still result in a segfault. Need a more robust check for that circumstance in a future fix.