### PR TITLE
rigidshape and derivatives cleanups

### DIFF
--- a/Engine/source/T3D/rigidShape.cpp
+++ b/Engine/source/T3D/rigidShape.cpp
@@ -276,7 +276,7 @@ RigidShapeData::RigidShapeData()
    for (S32 i = 0; i < Sounds::MaxSounds; i++)
       INIT_SOUNDASSET_ARRAY(WaterSounds, i);
 
-   dragForce            = 0;
+   dragForce            = 0.01f;
    vertFactor           = 0.25;
 
    dustTrailEmitter = NULL;
@@ -354,7 +354,7 @@ bool RigidShapeData::preload(bool server, String &errorStr)
       }
    }
 
-   if (dragForce <= 0.01f) 
+   if (dragForce < 0.01f) 
    {
       Con::warnf("RigidShapeData::preload: dragForce must be at least 0.01");
       dragForce = 0.01f;

--- a/Engine/source/T3D/vehicles/flyingVehicle.cpp
+++ b/Engine/source/T3D/vehicles/flyingVehicle.cpp
@@ -143,8 +143,7 @@ bool FlyingVehicleData::preload(bool server, String &errorStr)
       {
          if (!isFlyingSoundsValid(i))
          {
-            Con::errorf(ConsoleLogEntry::General, "FlyingVehicleData::preload: Invalid FlyingSounds asset.");
-            return false;
+            //return false; -TODO: trigger asset download
          }
       }
       for (S32 j = 0; j < MaxJetEmitters; j++)

--- a/Engine/source/T3D/vehicles/hoverVehicle.cpp
+++ b/Engine/source/T3D/vehicles/hoverVehicle.cpp
@@ -123,8 +123,6 @@ HoverVehicle::JetActivation HoverVehicle::sJetActivation[NumThrustDirections] = 
 //
 HoverVehicleData::HoverVehicleData()
 {
-   dragForce            = 0;
-   vertFactor           = 0.25f;
    floatingThrustFactor = 0.15f;
 
    mainThrustForce    = 0;

--- a/Engine/source/T3D/vehicles/hoverVehicle.h
+++ b/Engine/source/T3D/vehicles/hoverVehicle.h
@@ -74,9 +74,6 @@ class HoverVehicleData : public VehicleData
    static const char *sJetNode[MaxJetNodes];
    S32 jetNode[MaxJetNodes];
 
-
-   F32 dragForce;
-   F32 vertFactor;
    F32 floatingThrustFactor;
 
    F32 mainThrustForce;


### PR DESCRIPTION
dragforce for rigidshapes and children defaulted to a value it's own debuggers won't complain about out of the gate removed duplicate invalidation for flying vehicle sounds causing network instability removed redundant hovervehicle vars