### PR TITLE
Fix SkipMainCs flag, it was inverted

### DIFF
--- a/Engine/source/app/mainLoop.cpp
+++ b/Engine/source/app/mainLoop.cpp
@@ -468,7 +468,7 @@ bool StandardMainLoop::handleCommandLine( S32 argc, const char **argv )
 #endif
          mainCsStream = &str;
       }
-      else if (String::compare(argv[1], "SkipMainCs"))
+      else if (String::compare(argv[1], "SkipMainCs") == 0)
       {
          return true;
       }


### PR DESCRIPTION
This bug shouldn't have any impact on users, since we only check that branch after everything else has failed. So this is mostly a bug for the C# use-case