### PR TITLE
Adjusts the logic for when creating a simObject from a taml to handle array'd prefix field's values

### DIFF
--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -560,7 +560,7 @@ void SimObject::onTamlCustomRead(TamlCustomNodes const& customNodes)
                   // Check common fields.
                   if (field)
                   {
-                     setDataField(fieldName, buf, cField->getFieldValue());
+                     setPrefixedDataField(fieldName, buf, cField->getFieldValue());
                   }
                   else
                   {


### PR DESCRIPTION
Adjusts the logic for when creating a simObject from a taml so that array elements(like material slots or sound asset slots) properly can handle prefixed field values, such as referencing loose asset files.