### PR TITLE
Fix castray for cases where callback is used

### DIFF
--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -318,6 +318,7 @@ struct SceneRayHelper
                xformedEnd.convolveInverse(ptr->mObjScale);
 
                RayInfo ri;
+               ri.object = ptr;
                ri.generateTexCoord = info->generateTexCoord;
 
                if (mFunc && !mFunc(&ri))


### PR DESCRIPTION
Basic problem here: ri.object wasn't being set