### PR TITLE
clean up "Add" menubar categoes on the 3d object side via the following:

### DIFF
--- a/Engine/source/T3D/accumulationVolume.h
+++ b/Engine/source/T3D/accumulationVolume.h
@@ -74,7 +74,7 @@ class AccumulationVolume : public ScenePolyhedralSpace
       // SimObject.
       DECLARE_CONOBJECT( AccumulationVolume );
       DECLARE_DESCRIPTION( "Allows objects in an area to have accumulation effect applied." );
-      DECLARE_CATEGORY( "Area" );
+      DECLARE_CATEGORY("Volume");
 
       virtual bool onAdd();
       virtual void onRemove();

--- a/Engine/source/T3D/accumulationVolume.h
+++ b/Engine/source/T3D/accumulationVolume.h
@@ -74,7 +74,7 @@ class AccumulationVolume : public ScenePolyhedralSpace
       // SimObject.
       DECLARE_CONOBJECT( AccumulationVolume );
       DECLARE_DESCRIPTION( "Allows objects in an area to have accumulation effect applied." );
-      DECLARE_CATEGORY( "3D Scene" );
+      DECLARE_CATEGORY( "Area" );
 
       virtual bool onAdd();
       virtual void onRemove();

--- a/Engine/source/T3D/aiPlayer.h
+++ b/Engine/source/T3D/aiPlayer.h
@@ -150,6 +150,7 @@ protected:
 
 public:
    DECLARE_CONOBJECT( AIPlayer );
+   DECLARE_CATEGORY("Actor \t AI");
 
    AIPlayer();
    ~AIPlayer();

--- a/Engine/source/T3D/camera.h
+++ b/Engine/source/T3D/camera.h
@@ -249,7 +249,7 @@ class Camera: public ShapeBase
       virtual void unpackUpdate( NetConnection* conn, BitStream* stream );
 
       DECLARE_CONOBJECT( Camera );
-      DECLARE_CATEGORY( "Game" );
+      DECLARE_CATEGORY("Actor \t Controllable");
       DECLARE_DESCRIPTION( "Represents a position, direction and field of view to render a scene from." );
       static F32 getMovementSpeed() { return smMovementSpeed; }
       bool isCamera() const { return true; }

--- a/Engine/source/T3D/convexShape.h
+++ b/Engine/source/T3D/convexShape.h
@@ -194,6 +194,7 @@ public:
    virtual ~ConvexShape();
 
    DECLARE_CONOBJECT( ConvexShape );
+   DECLARE_CATEGORY("Object \t Simple");
 
    // ConsoleObject
    static void initPersistFields();

--- a/Engine/source/T3D/debris.h
+++ b/Engine/source/T3D/debris.h
@@ -179,6 +179,7 @@ public:
    void  setRotAngles( const Point3F &angles ){ mRotAngles = angles; }
 
    DECLARE_CONOBJECT(Debris);
+   DECLARE_CATEGORY("UNLISTED");
 
 private:
    SimObject*   ss_object;

--- a/Engine/source/T3D/decal/decalManager.cpp
+++ b/Engine/source/T3D/decal/decalManager.cpp
@@ -87,6 +87,7 @@ const U32 DecalManager::smMaxIndices = 10000;
 DecalManager *gDecalManager = NULL;
 
 IMPLEMENT_CONOBJECT(DecalManager);
+DECLARE_CATEGORY("UNLISTED");
 
 ConsoleDoc(
    "@defgroup Decals\n"

--- a/Engine/source/T3D/decal/decalManager.h
+++ b/Engine/source/T3D/decal/decalManager.h
@@ -270,6 +270,7 @@ class DecalManager : public SceneObject
 
       // SimObject.
       DECLARE_CONOBJECT( DecalManager );
+      DECLARE_CATEGORY("UNLISTED");
       static void consoleInit();
 };
 

--- a/Engine/source/T3D/fx/explosion.h
+++ b/Engine/source/T3D/fx/explosion.h
@@ -205,6 +205,7 @@ class Explosion : public GameBase, public ISceneLight
    void setCollideType( U32 cType ){ mCollideType = cType; }
 
    DECLARE_CONOBJECT(Explosion);
+   DECLARE_CATEGORY("UNLISTED");
    static void initPersistFields();
 private:
    SimObject*     ss_object;

--- a/Engine/source/T3D/fx/fxFoliageReplicator.h
+++ b/Engine/source/T3D/fx/fxFoliageReplicator.h
@@ -390,6 +390,7 @@ public:
 
    // Declare Console Object.
    DECLARE_CONOBJECT(fxFoliageReplicator);
+   DECLARE_CATEGORY("UNLISTED");
 };
 #pragma warning( pop ) 
 #endif // _FOLIAGEREPLICATOR_H_

--- a/Engine/source/T3D/fx/fxShapeReplicator.h
+++ b/Engine/source/T3D/fx/fxShapeReplicator.h
@@ -59,6 +59,7 @@ public:
    void setTransform(const MatrixF & mat) { Parent::setTransform(mat); setRenderTransform(mat); };
 
    DECLARE_CONOBJECT(fxShapeReplicatedStatic);
+   DECLARE_CATEGORY("UNLISTED");
 };
 
 
@@ -187,6 +188,7 @@ public:
 
    // Declare Console Object.
    DECLARE_CONOBJECT(fxShapeReplicator);
+   DECLARE_CATEGORY("UNLISTED");
 };
 
 #endif // _SHAPEREPLICATOR_H_

--- a/Engine/source/T3D/fx/groundCover.h
+++ b/Engine/source/T3D/fx/groundCover.h
@@ -123,6 +123,7 @@ public:
    ~GroundCover();
 
    DECLARE_CONOBJECT(GroundCover);
+   DECLARE_CATEGORY("Environment \t BackGround");
 
    static void consoleInit();
    static void initPersistFields();

--- a/Engine/source/T3D/fx/lightning.h
+++ b/Engine/source/T3D/fx/lightning.h
@@ -239,6 +239,7 @@ class Lightning : public GameBase
    void processEvent(LightningStrikeEvent*);
 
    DECLARE_CONOBJECT(Lightning);
+   DECLARE_CATEGORY("Environment \t Weather");
    static void initPersistFields();
 
    U32  packUpdate  (NetConnection *conn, U32 mask, BitStream *stream);

--- a/Engine/source/T3D/fx/particleEmitter.h
+++ b/Engine/source/T3D/fx/particleEmitter.h
@@ -168,6 +168,7 @@ class ParticleEmitter : public GameBase
    ~ParticleEmitter();
 
    DECLARE_CONOBJECT(ParticleEmitter);
+   DECLARE_CATEGORY("UNLISTED");
 
    static Point3F mWindVelocity;
    static void setWindVelocity( const Point3F &vel ){ mWindVelocity = vel; }

--- a/Engine/source/T3D/fx/particleEmitterNode.h
+++ b/Engine/source/T3D/fx/particleEmitterNode.h
@@ -103,6 +103,7 @@ class ParticleEmitterNode : public GameBase
    void advanceTime(F32 dt);
 
    DECLARE_CONOBJECT(ParticleEmitterNode);
+   DECLARE_CATEGORY("Environment \t FX");
    static void initPersistFields();
 
    U32  packUpdate  (NetConnection *conn, U32 mask, BitStream* stream);

--- a/Engine/source/T3D/fx/precipitation.h
+++ b/Engine/source/T3D/fx/precipitation.h
@@ -280,6 +280,7 @@ class Precipitation : public GameBase
 
    bool onNewDataBlock( GameBaseData *dptr, bool reload );
    DECLARE_CONOBJECT(Precipitation);
+   DECLARE_CATEGORY("Environment \t Weather");
    static void initPersistFields();
    
    U32  packUpdate(NetConnection*, U32 mask, BitStream* stream);

--- a/Engine/source/T3D/fx/ribbon.h
+++ b/Engine/source/T3D/fx/ribbon.h
@@ -124,6 +124,7 @@ public:
    ~Ribbon();
 
    DECLARE_CONOBJECT(Ribbon);
+   DECLARE_CATEGORY("UNLISTED");
    static void initPersistFields();
    bool onNewDataBlock(GameBaseData*,bool);
    void onRemove();

--- a/Engine/source/T3D/fx/ribbonNode.h
+++ b/Engine/source/T3D/fx/ribbonNode.h
@@ -87,6 +87,7 @@ public:
    void advanceTime(F32 dt);
 
    DECLARE_CONOBJECT(RibbonNode);
+   DECLARE_CATEGORY("Environment \t FX");
    static void initPersistFields();
 
    U32  packUpdate  (NetConnection *conn, U32 mask, BitStream* stream);

--- a/Engine/source/T3D/fx/splash.h
+++ b/Engine/source/T3D/fx/splash.h
@@ -195,6 +195,7 @@ public:
 
    bool onNewDataBlock( GameBaseData *dptr, bool reload );
    DECLARE_CONOBJECT(Splash);
+   DECLARE_CATEGORY("UNLISTED");
 };
 
 

--- a/Engine/source/T3D/gameBase/gameBase.h
+++ b/Engine/source/T3D/gameBase/gameBase.h
@@ -105,6 +105,7 @@ public:
 
    // The derived class should provide the following:
    DECLARE_CONOBJECT(GameBaseData);
+   DECLARE_CATEGORY("Datablock");
    GameBaseData();
    static void initPersistFields();
    bool preload(bool server, String &errorStr);
@@ -442,6 +443,7 @@ public:
    #endif
 
    DECLARE_CONOBJECT (GameBase );
+   DECLARE_CATEGORY("UNLISTED");
 
    /// @name Callbacks
    /// @{

--- a/Engine/source/T3D/groundPlane.h
+++ b/Engine/source/T3D/groundPlane.h
@@ -60,6 +60,7 @@ public:
    typedef SceneObject Parent;
 
    DECLARE_CONOBJECT( GroundPlane );
+   DECLARE_CATEGORY("Environment \t BackGround");
 
    GroundPlane();
    virtual ~GroundPlane();

--- a/Engine/source/T3D/item.h
+++ b/Engine/source/T3D/item.h
@@ -159,6 +159,7 @@ class Item: public ShapeBase
 
   public:
    DECLARE_CONOBJECT(Item);
+   DECLARE_CATEGORY("Item");
 
 
    Item();

--- a/Engine/source/T3D/lightBase.h
+++ b/Engine/source/T3D/lightBase.h
@@ -111,6 +111,7 @@ public:
    void inspectPostApply();
    static void initPersistFields();
    DECLARE_CONOBJECT(LightBase);
+   DECLARE_CATEGORY("UNLISTED");
 
    // NetObject
    U32 packUpdate( NetConnection *conn, U32 mask, BitStream *stream );

--- a/Engine/source/T3D/lighting/boxEnvironmentProbe.h
+++ b/Engine/source/T3D/lighting/boxEnvironmentProbe.h
@@ -69,6 +69,7 @@ public:
    // Declare this object as a ConsoleObject so that we can
    // instantiate it into the world and network it
    DECLARE_CONOBJECT(BoxEnvironmentProbe);
+   DECLARE_CATEGORY("Lighting \t Probes");
 
    //--------------------------------------------------------------------------
    // Object Editing

--- a/Engine/source/T3D/lighting/reflectionProbe.h
+++ b/Engine/source/T3D/lighting/reflectionProbe.h
@@ -274,6 +274,7 @@ public:
    // Declare this object as a ConsoleObject so that we can
    // instantiate it into the world and network it
    DECLARE_CONOBJECT(ReflectionProbe);
+   DECLARE_CATEGORY("UNLISTED");
 
    //--------------------------------------------------------------------------
    // Object Editing

--- a/Engine/source/T3D/lighting/skylight.h
+++ b/Engine/source/T3D/lighting/skylight.h
@@ -68,6 +68,7 @@ public:
    // Declare this object as a ConsoleObject so that we can
    // instantiate it into the world and network it
    DECLARE_CONOBJECT(Skylight);
+   DECLARE_CATEGORY("Lighting \t Probes");
 
    //--------------------------------------------------------------------------
    // Object Editing

--- a/Engine/source/T3D/lighting/sphereEnvironmentProbe.h
+++ b/Engine/source/T3D/lighting/sphereEnvironmentProbe.h
@@ -64,6 +64,7 @@ public:
    // Declare this object as a ConsoleObject so that we can
    // instantiate it into the world and network it
    DECLARE_CONOBJECT(SphereEnvironmentProbe);
+   DECLARE_CATEGORY("Lighting \t Probes");
 
    //--------------------------------------------------------------------------
    // Object Editing

--- a/Engine/source/T3D/missionMarker.h
+++ b/Engine/source/T3D/missionMarker.h
@@ -85,6 +85,7 @@ class MissionMarker : public ShapeBase
       void unpackUpdate(NetConnection *conn,           BitStream *stream);
 
       DECLARE_CONOBJECT(MissionMarker);
+      DECLARE_CATEGORY("Markers");
       static void initPersistFields();
 };
 
@@ -217,6 +218,7 @@ class CameraBookmark : public MissionMarker
       static void initPersistFields();
 
       DECLARE_CONOBJECT(CameraBookmark);
+      DECLARE_CATEGORY("Markers");
 	  /*DECLARE_CALLBACK( void, onAdd, () );
 	  DECLARE_CALLBACK( void, onRemove, () );
 	  DECLARE_CALLBACK( void, onGroupAdd, () );

--- a/Engine/source/T3D/notesObject.h
+++ b/Engine/source/T3D/notesObject.h
@@ -67,6 +67,7 @@ public:
    // Declare this object as a ConsoleObject so that we can
    // instantiate it into the world and network it
    DECLARE_CONOBJECT(NotesObject);
+   DECLARE_CATEGORY("Markers");
 
    //--------------------------------------------------------------------------
    // Object Editing

--- a/Engine/source/T3D/occlusionVolume.h
+++ b/Engine/source/T3D/occlusionVolume.h
@@ -64,7 +64,7 @@ class OcclusionVolume : public ScenePolyhedralSpace
       // SimObject.
       DECLARE_CONOBJECT( OcclusionVolume );
       DECLARE_DESCRIPTION( "A visibility blocking volume." );
-      DECLARE_CATEGORY("Area");
+      DECLARE_CATEGORY("Volume");
 
       virtual bool onAdd();
 

--- a/Engine/source/T3D/occlusionVolume.h
+++ b/Engine/source/T3D/occlusionVolume.h
@@ -64,7 +64,7 @@ class OcclusionVolume : public ScenePolyhedralSpace
       // SimObject.
       DECLARE_CONOBJECT( OcclusionVolume );
       DECLARE_DESCRIPTION( "A visibility blocking volume." );
-      DECLARE_CATEGORY( "3D Scene" );
+      DECLARE_CATEGORY("Area");
 
       virtual bool onAdd();
 

--- a/Engine/source/T3D/pathCamera.h
+++ b/Engine/source/T3D/pathCamera.h
@@ -92,6 +92,7 @@ private:
 
 public:
    DECLARE_CONOBJECT(PathCamera);
+   DECLARE_CATEGORY("Cinematic");
    
    DECLARE_CALLBACK( void, onNode, (S32 node));
 

--- a/Engine/source/T3D/pathShape.h
+++ b/Engine/source/T3D/pathShape.h
@@ -79,6 +79,7 @@ private:
 
 public:
    DECLARE_CONOBJECT(PathShape);
+   DECLARE_CATEGORY("Cinematic");
 
    PathShape();
    ~PathShape();

--- a/Engine/source/T3D/physicalZone.h
+++ b/Engine/source/T3D/physicalZone.h
@@ -77,7 +77,7 @@ class PhysicalZone : public SceneObject
 
    // SimObject
    DECLARE_CONOBJECT(PhysicalZone);
-   DECLARE_CATEGORY("Area");
+   DECLARE_CATEGORY("Volume");
    static void consoleInit();
    static void initPersistFields();
    bool onAdd();

--- a/Engine/source/T3D/physicalZone.h
+++ b/Engine/source/T3D/physicalZone.h
@@ -77,6 +77,7 @@ class PhysicalZone : public SceneObject
 
    // SimObject
    DECLARE_CONOBJECT(PhysicalZone);
+   DECLARE_CATEGORY("Area");
    static void consoleInit();
    static void initPersistFields();
    bool onAdd();

--- a/Engine/source/T3D/physics/physicsDebris.h
+++ b/Engine/source/T3D/physics/physicsDebris.h
@@ -129,6 +129,7 @@ public:
    virtual ~PhysicsDebris();
 
    DECLARE_CONOBJECT(PhysicsDebris);
+   DECLARE_CATEGORY("UNLISTED");
    static void initPersistFields();
 
    bool onAdd();

--- a/Engine/source/T3D/physics/physicsForce.h
+++ b/Engine/source/T3D/physics/physicsForce.h
@@ -48,7 +48,7 @@ public:
    virtual ~PhysicsForce();
 
    DECLARE_CONOBJECT( PhysicsForce );
-
+   DECLARE_CATEGORY("UNLISTED");
    // SimObject
    static void initPersistFields();
    bool onAdd();

--- a/Engine/source/T3D/physics/physicsShape.h
+++ b/Engine/source/T3D/physics/physicsShape.h
@@ -229,6 +229,7 @@ public:
    virtual ~PhysicsShape();
 
    DECLARE_CONOBJECT( PhysicsShape );
+   DECLARE_CATEGORY("Object \t Destructable");
 
    /// Returns the PhysicsShapeData datablock.
    PhysicsShapeData* getDataBlock() { return static_cast<PhysicsShapeData*>( Parent::getDataBlock() ); }

--- a/Engine/source/T3D/player.h
+++ b/Engine/source/T3D/player.h
@@ -697,6 +697,7 @@ protected:
 
 public:
    DECLARE_CONOBJECT(Player);
+   DECLARE_CATEGORY("Actor \t Controllable");
 
    Player();
    ~Player();

--- a/Engine/source/T3D/pointLight.h
+++ b/Engine/source/T3D/pointLight.h
@@ -47,6 +47,7 @@ public:
 
    // ConsoleObject
    DECLARE_CONOBJECT( PointLight );
+   DECLARE_CATEGORY("Lighting \t Lights");
    static void initPersistFields();
 
    // SceneObject

--- a/Engine/source/T3D/portal.h
+++ b/Engine/source/T3D/portal.h
@@ -185,7 +185,8 @@ class Portal : public Zone
 
       // SimObject.
       DECLARE_CONOBJECT( Portal );
-      
+      DECLARE_CATEGORY("Area");
+
       static void initPersistFields();
       static void consoleInit();
 

--- a/Engine/source/T3D/portal.h
+++ b/Engine/source/T3D/portal.h
@@ -185,7 +185,7 @@ class Portal : public Zone
 
       // SimObject.
       DECLARE_CONOBJECT( Portal );
-      DECLARE_CATEGORY("Area");
+      DECLARE_CATEGORY("Volume");
 
       static void initPersistFields();
       static void consoleInit();

--- a/Engine/source/T3D/prefab.h
+++ b/Engine/source/T3D/prefab.h
@@ -57,6 +57,7 @@ public:
    virtual ~Prefab();
 
    DECLARE_CONOBJECT(Prefab);
+   DECLARE_CATEGORY("Object \t Collection");
   
    static void initPersistFields();
 

--- a/Engine/source/T3D/projectile.h
+++ b/Engine/source/T3D/projectile.h
@@ -187,6 +187,7 @@ public:
    ~Projectile();
 
    DECLARE_CONOBJECT(Projectile);
+   DECLARE_CATEGORY("UNLISTED");
 
    // SimObject
    bool onAdd();

--- a/Engine/source/T3D/rigidShape.h
+++ b/Engine/source/T3D/rigidShape.h
@@ -308,6 +308,7 @@ public:
    void unpackUpdate(NetConnection *conn,           BitStream *stream);
 
    DECLARE_CONOBJECT(RigidShape);
+   DECLARE_CATEGORY("Object \t Destructable");
 };
 
 

--- a/Engine/source/T3D/scopeAlwaysShape.cpp
+++ b/Engine/source/T3D/scopeAlwaysShape.cpp
@@ -30,6 +30,7 @@ class ScopeAlwaysShape : public StaticShape
       ScopeAlwaysShape();
       static void initPersistFields();
       DECLARE_CONOBJECT(ScopeAlwaysShape);
+      DECLARE_CATEGORY("UNLISTED");
 };
 
 ScopeAlwaysShape::ScopeAlwaysShape()

--- a/Engine/source/T3D/sfx/sfxEmitter.h
+++ b/Engine/source/T3D/sfx/sfxEmitter.h
@@ -260,7 +260,7 @@ class SFXEmitter : public SceneObject
 
       DECLARE_CONOBJECT( SFXEmitter );
       DECLARE_DESCRIPTION( "A 3D object emitting sound." );
-      DECLARE_CATEGORY( "3D Sound" );
+      DECLARE_CATEGORY("Environment \t FX");
 };
 
 #endif // _SFXEMITTER_H_

--- a/Engine/source/T3D/sfx/sfxSpace.h
+++ b/Engine/source/T3D/sfx/sfxSpace.h
@@ -55,7 +55,7 @@ class SFXSpace : public SceneAmbientSoundObject< ScenePolyhedralObject< SceneSpa
       // SimObject.
       DECLARE_CONOBJECT( SFXSpace );
       DECLARE_DESCRIPTION( "A box volume that defines an ambient sound space." );
-      DECLARE_CATEGORY("Area");
+      DECLARE_CATEGORY("Volume");
 
       static void consoleInit();
 };

--- a/Engine/source/T3D/sfx/sfxSpace.h
+++ b/Engine/source/T3D/sfx/sfxSpace.h
@@ -55,7 +55,7 @@ class SFXSpace : public SceneAmbientSoundObject< ScenePolyhedralObject< SceneSpa
       // SimObject.
       DECLARE_CONOBJECT( SFXSpace );
       DECLARE_DESCRIPTION( "A box volume that defines an ambient sound space." );
-      DECLARE_CATEGORY( "3D Sound" );
+      DECLARE_CATEGORY("Area");
 
       static void consoleInit();
 };

--- a/Engine/source/T3D/spotLight.h
+++ b/Engine/source/T3D/spotLight.h
@@ -51,6 +51,7 @@ public:
 
    // ConsoleObject
    DECLARE_CONOBJECT( SpotLight );
+   DECLARE_CATEGORY("Lighting \t Lights");
    static void initPersistFields();
 
    // SceneObject

--- a/Engine/source/T3D/staticShape.h
+++ b/Engine/source/T3D/staticShape.h
@@ -75,6 +75,7 @@ protected:
 
 public:
    DECLARE_CONOBJECT(StaticShape);
+   DECLARE_CATEGORY("Object \t Destructable");
 
    StaticShape();
    ~StaticShape();

--- a/Engine/source/T3D/trigger.h
+++ b/Engine/source/T3D/trigger.h
@@ -127,7 +127,7 @@ class Trigger : public GameBase
 
    // SimObject
    DECLARE_CONOBJECT(Trigger);
-   DECLARE_CATEGORY("Area");
+   DECLARE_CATEGORY("Volume");
 
    DECLARE_CALLBACK( void, onAdd, ( U32 objectId ) );
    DECLARE_CALLBACK( void, onRemove, ( U32 objectId ) );

--- a/Engine/source/T3D/trigger.h
+++ b/Engine/source/T3D/trigger.h
@@ -127,6 +127,7 @@ class Trigger : public GameBase
 
    // SimObject
    DECLARE_CONOBJECT(Trigger);
+   DECLARE_CATEGORY("Area");
 
    DECLARE_CALLBACK( void, onAdd, ( U32 objectId ) );
    DECLARE_CALLBACK( void, onRemove, ( U32 objectId ) );

--- a/Engine/source/T3D/tsStatic.h
+++ b/Engine/source/T3D/tsStatic.h
@@ -236,6 +236,7 @@ public:
    ~TSStatic();
 
    DECLARE_CONOBJECT(TSStatic);
+   DECLARE_CATEGORY("Object \t Simple");
    static void initPersistFields();
    /// returns the shape asset used for this object
    StringTableEntry getTypeHint() const override { return (getShapeAsset()) ? getShapeAsset()->getAssetName(): StringTable->EmptyString(); }

--- a/Engine/source/T3D/vehicles/flyingVehicle.h
+++ b/Engine/source/T3D/vehicles/flyingVehicle.h
@@ -180,6 +180,7 @@ class FlyingVehicle: public Vehicle
    U32 getCollisionMask();
   public:
    DECLARE_CONOBJECT(FlyingVehicle);
+   DECLARE_CATEGORY("Actor \t Controllable");
    static void initPersistFields();
 
    FlyingVehicle();

--- a/Engine/source/T3D/vehicles/hoverVehicle.h
+++ b/Engine/source/T3D/vehicles/hoverVehicle.h
@@ -200,6 +200,7 @@ class HoverVehicle : public Vehicle
    void advanceTime(F32 dt);
 
    DECLARE_CONOBJECT(HoverVehicle);
+   DECLARE_CATEGORY("Actor \t Controllable");
 //   static void initPersistFields();
 
    U32  packUpdate  (NetConnection *conn, U32 mask, BitStream *stream);

--- a/Engine/source/T3D/vehicles/vehicle.h
+++ b/Engine/source/T3D/vehicles/vehicle.h
@@ -165,6 +165,7 @@ public:
    /// @}
 
    DECLARE_CONOBJECT(Vehicle);
+   DECLARE_CATEGORY("UNLISTED");
 };
 
 

--- a/Engine/source/T3D/vehicles/vehicleBlocker.h
+++ b/Engine/source/T3D/vehicles/vehicleBlocker.h
@@ -52,6 +52,7 @@ class VehicleBlocker : public SceneObject
    ~VehicleBlocker();
 
    DECLARE_CONOBJECT(VehicleBlocker);
+   DECLARE_CATEGORY("Area");
    static void initPersistFields();
 
    U32  packUpdate  (NetConnection *conn, U32 mask, BitStream *stream);

--- a/Engine/source/T3D/vehicles/vehicleBlocker.h
+++ b/Engine/source/T3D/vehicles/vehicleBlocker.h
@@ -52,7 +52,7 @@ class VehicleBlocker : public SceneObject
    ~VehicleBlocker();
 
    DECLARE_CONOBJECT(VehicleBlocker);
-   DECLARE_CATEGORY("Area");
+   DECLARE_CATEGORY("Volume");
    static void initPersistFields();
 
    U32  packUpdate  (NetConnection *conn, U32 mask, BitStream *stream);

--- a/Engine/source/T3D/vehicles/wheeledVehicle.h
+++ b/Engine/source/T3D/vehicles/wheeledVehicle.h
@@ -225,6 +225,7 @@ class WheeledVehicle: public Vehicle
 
 public:
    DECLARE_CONOBJECT(WheeledVehicle);
+   DECLARE_CATEGORY("Actor \t Controllable");
    static void initPersistFields();
 
    WheeledVehicle();

--- a/Engine/source/T3D/zone.h
+++ b/Engine/source/T3D/zone.h
@@ -68,7 +68,7 @@ class Zone : public SceneAmbientSoundObject< ScenePolyhedralZone >
       // SimObject
       DECLARE_CONOBJECT( Zone );
       DECLARE_DESCRIPTION( "A volume that encloses objects for visibility culling." );
-      DECLARE_CATEGORY( "Area" );
+      DECLARE_CATEGORY("Volume");
 
       static void consoleInit();
 };

--- a/Engine/source/T3D/zone.h
+++ b/Engine/source/T3D/zone.h
@@ -68,7 +68,7 @@ class Zone : public SceneAmbientSoundObject< ScenePolyhedralZone >
       // SimObject
       DECLARE_CONOBJECT( Zone );
       DECLARE_DESCRIPTION( "A volume that encloses objects for visibility culling." );
-      DECLARE_CATEGORY( "3D" );
+      DECLARE_CATEGORY( "Area" );
 
       static void consoleInit();
 };

--- a/Engine/source/afx/afxCamera.h
+++ b/Engine/source/afx/afxCamera.h
@@ -51,7 +51,6 @@ struct afxCameraData: public ShapeBaseData {
 
   //
   DECLARE_CONOBJECT(afxCameraData);
-  DECLARE_CATEGORY("AFX");
   static void initPersistFields();
   virtual void packData(BitStream* stream);
   virtual void unpackData(BitStream* stream);
@@ -144,7 +143,7 @@ public:
   bool            isCamera() const { return true; }
 
   DECLARE_CONOBJECT(afxCamera);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 
 private:          // 3POV SECTION
   void            cam_update_3pov(F32 dt, bool on_server);

--- a/Engine/source/afx/afxChoreographer.h
+++ b/Engine/source/afx/afxChoreographer.h
@@ -57,7 +57,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxChoreographerData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -200,7 +199,7 @@ public:
   virtual void  impactNotify(const Point3F& p, const Point3F& n, SceneObject*) { }
 
   DECLARE_CONOBJECT(afxChoreographer);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
   
   // CONSTRAINT REMAPPING <<
 protected:

--- a/Engine/source/afx/afxEffectGroup.h
+++ b/Engine/source/afx/afxEffectGroup.h
@@ -96,7 +96,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxEffectGroupData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/afxEffectWrapper.h
+++ b/Engine/source/afx/afxEffectWrapper.h
@@ -100,7 +100,6 @@ public:
   virtual void    gather_cons_defs(Vector<afxConstraintDef>& defs) { };
 
   DECLARE_CONOBJECT(afxEffectBaseData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //class afxEffectWrapperData : public GameBaseData, public afxEffectDefs
@@ -207,7 +206,6 @@ public:
   static void       initPersistFields();
 
   DECLARE_CONOBJECT(afxEffectWrapperData);
-  DECLARE_CATEGORY("AFX");
 };
 
 inline bool afxEffectWrapperData::testExecConditions(U32 conditions)
@@ -382,7 +380,6 @@ public:
   static afxEffectWrapper* ew_create(afxChoreographer*, afxEffectWrapperData*, afxConstraintMgr*, F32 time_factor, S32 group_index=0);
 
   DECLARE_CONOBJECT(afxEffectWrapper);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/afxEffectron.h
+++ b/Engine/source/afx/afxEffectron.h
@@ -82,7 +82,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxEffectronData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -178,7 +177,6 @@ public:
   void          finish_startup();
 
   DECLARE_CONOBJECT(afxEffectron);
-  DECLARE_CATEGORY("AFX");
 
 private:
   void          process_server();

--- a/Engine/source/afx/afxMagicMissile.h
+++ b/Engine/source/afx/afxMagicMissile.h
@@ -218,7 +218,6 @@ public:
   static void           initPersistFields();
   
   DECLARE_CONOBJECT(afxMagicMissileData);
-  DECLARE_CATEGORY("AFX");
 
 public:
   /*C*/                 afxMagicMissileData(const afxMagicMissileData&, bool = false);
@@ -400,7 +399,7 @@ public:
   virtual void      onDeleteNotify(SimObject*);
 
   DECLARE_CONOBJECT(afxMagicMissile);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 
   static void       initPersistFields();  
 

--- a/Engine/source/afx/afxMagicSpell.h
+++ b/Engine/source/afx/afxMagicSpell.h
@@ -122,7 +122,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxMagicSpellData);
-  DECLARE_CATEGORY("AFX");
 
   /// @name Callbacks
   /// @{
@@ -320,7 +319,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxMagicSpell);
-  DECLARE_CATEGORY("AFX");
 
 private:
   void          process_server();

--- a/Engine/source/afx/afxResidueMgr.h
+++ b/Engine/source/afx/afxResidueMgr.h
@@ -171,7 +171,7 @@ public:
   static void           setMaster(afxResidueMgr* m) { the_mgr = m; }
 
   DECLARE_CONOBJECT(afxResidueMgr);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/afxSelectron.h
+++ b/Engine/source/afx/afxSelectron.h
@@ -106,7 +106,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxSelectronData);
-  DECLARE_CATEGORY("AFX");
 };
 
 inline bool afxSelectronData::matches(U32 mask, U8 style)
@@ -219,7 +218,7 @@ public:
   void          finish_startup();
 
   DECLARE_CONOBJECT(afxSelectron);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 
 private:
   void          process_server();

--- a/Engine/source/afx/afxSpellBook.h
+++ b/Engine/source/afx/afxSpellBook.h
@@ -68,7 +68,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxSpellBookData);
-  DECLARE_CATEGORY("AFX");
 };
 
 inline bool afxSpellBookData::verifyPageSlot(S32 page, S32 slot)
@@ -128,7 +127,7 @@ public:
   F32                     getCooldownFactor(S32 page, S32 slot);
 
   DECLARE_CONOBJECT(afxSpellBook);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 inline S32 afxSpellBook::getPageSlotIndex(S32 page, S32 slot)

--- a/Engine/source/afx/afxZodiacGroundPlaneRenderer_T3D.h
+++ b/Engine/source/afx/afxZodiacGroundPlaneRenderer_T3D.h
@@ -83,7 +83,6 @@ public:
 
    // ConsoleObject
    DECLARE_CONOBJECT(afxZodiacGroundPlaneRenderer);
-   DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/afxZodiacMeshRoadRenderer_T3D.h
+++ b/Engine/source/afx/afxZodiacMeshRoadRenderer_T3D.h
@@ -84,7 +84,6 @@ public:
 
    // ConsoleObject
    DECLARE_CONOBJECT(afxZodiacMeshRoadRenderer);
-   DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/afxZodiacPolysoupRenderer_T3D.h
+++ b/Engine/source/afx/afxZodiacPolysoupRenderer_T3D.h
@@ -84,7 +84,6 @@ public:
 
    // ConsoleObject
    DECLARE_CONOBJECT(afxZodiacPolysoupRenderer);
-   DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/afxZodiacTerrainRenderer_T3D.h
+++ b/Engine/source/afx/afxZodiacTerrainRenderer_T3D.h
@@ -84,7 +84,6 @@ public:
 
    // ConsoleObject
    DECLARE_CONOBJECT(afxZodiacTerrainRenderer);
-   DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/arcaneFX.cpp
+++ b/Engine/source/afx/arcaneFX.cpp
@@ -83,7 +83,6 @@ public:
   }
 
   DECLARE_CONOBJECT(ClientZoneInEvent);
-  DECLARE_CATEGORY("AFX");
 };
 IMPLEMENT_CO_SERVEREVENT_V1(ClientZoneInEvent);
 

--- a/Engine/source/afx/ce/afxAnimClip.h
+++ b/Engine/source/afx/ce/afxAnimClip.h
@@ -73,7 +73,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxAnimClipData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxAnimLock.h
+++ b/Engine/source/afx/ce/afxAnimLock.h
@@ -40,7 +40,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxAnimLockData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxAreaDamage.h
+++ b/Engine/source/afx/ce/afxAreaDamage.h
@@ -54,7 +54,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxAreaDamageData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxAudioBank.h
+++ b/Engine/source/afx/ce/afxAudioBank.h
@@ -59,7 +59,6 @@ public:
    virtual bool       allowSubstitutions() const { return true; }
 
    DECLARE_CONOBJECT(afxAudioBank);
-   DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxBillboard.h
+++ b/Engine/source/afx/ce/afxBillboard.h
@@ -74,7 +74,6 @@ public:
   void onChangeTexture() {}
 
   DECLARE_CONOBJECT(afxBillboardData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxBillboardData::BlendStyle afxBillboard_BlendStyle;
@@ -117,7 +116,7 @@ public:
   void              _renderBillboard(ObjectRenderInst*, SceneRenderState*, BaseMatInstance*);
 
   DECLARE_CONOBJECT(afxBillboard);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxCameraPuppet.h
+++ b/Engine/source/afx/ce/afxCameraPuppet.h
@@ -55,7 +55,6 @@ public:
   static void       initPersistFields();
 
   DECLARE_CONOBJECT(afxCameraPuppetData);
-  DECLARE_CATEGORY("AFX");
 };
 
 

--- a/Engine/source/afx/ce/afxCameraShake.h
+++ b/Engine/source/afx/ce/afxCameraShake.h
@@ -49,7 +49,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxCameraShakeData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxCollisionEvent.h
+++ b/Engine/source/afx/ce/afxCollisionEvent.h
@@ -51,7 +51,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxCollisionEventData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxConsoleMessage.h
+++ b/Engine/source/afx/ce/afxConsoleMessage.h
@@ -46,7 +46,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxConsoleMessageData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxDamage.h
+++ b/Engine/source/afx/ce/afxDamage.h
@@ -55,7 +55,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxDamageData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxFootSwitch.h
+++ b/Engine/source/afx/ce/afxFootSwitch.h
@@ -48,7 +48,6 @@ public:
   static void     initPersistFields();
 
   DECLARE_CONOBJECT(afxFootSwitchData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxGuiController.h
+++ b/Engine/source/afx/ce/afxGuiController.h
@@ -50,7 +50,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxGuiControllerData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxGuiText.h
+++ b/Engine/source/afx/ce/afxGuiText.h
@@ -49,7 +49,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxGuiTextData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxLight.h
+++ b/Engine/source/afx/ce/afxLight.h
@@ -30,7 +30,6 @@ struct afxLightData : public GameBaseData
 {
   typedef GameBaseData Parent;
   DECLARE_CONOBJECT(afxLightData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxLightBase_T3D.h
+++ b/Engine/source/afx/ce/afxLightBase_T3D.h
@@ -65,7 +65,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxT3DLightBaseData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxMachineGun.h
+++ b/Engine/source/afx/ce/afxMachineGun.h
@@ -51,7 +51,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxMachineGunData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxModel.h
+++ b/Engine/source/afx/ce/afxModel.h
@@ -98,7 +98,6 @@ public:
   void onSequenceChanged() {}
 
   DECLARE_CONOBJECT(afxModelData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -162,7 +161,7 @@ public:
   F32                   getAnimClipDuration(const char* clip);
 
   DECLARE_CONOBJECT(afxModel);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxMooring.h
+++ b/Engine/source/afx/ce/afxMooring.h
@@ -52,7 +52,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxMooringData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -94,7 +93,7 @@ public:
   virtual void          prepRenderImage(SceneRenderState*);
 
   DECLARE_CONOBJECT(afxMooring);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxMultiLight.h
+++ b/Engine/source/afx/ce/afxMultiLight.h
@@ -30,7 +30,6 @@ struct afxMultiLightData : public GameBaseData
 {
   typedef GameBaseData Parent;
   DECLARE_CONOBJECT(afxMultiLightData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxParticleEmitter.h
+++ b/Engine/source/afx/ce/afxParticleEmitter.h
@@ -67,7 +67,6 @@ public:
   static void initPersistFields();
 
   DECLARE_CONOBJECT(afxParticleEmitterData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -92,7 +91,6 @@ public:
   static void initPersistFields();
 
   DECLARE_CONOBJECT(afxParticleEmitterVectorData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -121,7 +119,6 @@ public:
   static void initPersistFields();
 
   DECLARE_CONOBJECT(afxParticleEmitterConeData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -165,7 +162,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxParticleEmitterPathData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxParticleEmitterPathData::PathOriginType afxParticleEmitterPath_OriginType;
@@ -197,7 +193,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxParticleEmitterDiscData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxPhraseEffect.h
+++ b/Engine/source/afx/ce/afxPhraseEffect.h
@@ -103,7 +103,6 @@ public:
   static void     initPersistFields();
 
   DECLARE_CONOBJECT(afxPhraseEffectData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxPhraseEffectData::MatchType afxPhraseEffect_MatchType;

--- a/Engine/source/afx/ce/afxPhysicalZone.h
+++ b/Engine/source/afx/ce/afxPhysicalZone.h
@@ -57,7 +57,6 @@ public:
   static void       initPersistFields();
 
   DECLARE_CONOBJECT(afxPhysicalZoneData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxPlayerMovement.h
+++ b/Engine/source/afx/ce/afxPlayerMovement.h
@@ -62,7 +62,6 @@ public:
   static void       initPersistFields();
 
   DECLARE_CONOBJECT(afxPlayerMovementData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxPlayerMovementData::OpType afxPlayerMovement_OpType;

--- a/Engine/source/afx/ce/afxPlayerPuppet.h
+++ b/Engine/source/afx/ce/afxPlayerPuppet.h
@@ -55,7 +55,6 @@ public:
   static void       initPersistFields();
 
   DECLARE_CONOBJECT(afxPlayerPuppetData);
-  DECLARE_CATEGORY("AFX");
 };
 
 

--- a/Engine/source/afx/ce/afxPointLight_T3D.h
+++ b/Engine/source/afx/ce/afxPointLight_T3D.h
@@ -48,7 +48,6 @@ public:
   static void initPersistFields();
 
   DECLARE_CONOBJECT(afxT3DPointLightData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxProjectile.h
+++ b/Engine/source/afx/ce/afxProjectile.h
@@ -72,7 +72,6 @@ public:
   static void       initPersistFields();
 
   DECLARE_CONOBJECT(afxProjectileData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxProjectileData::LaunchDirType afxProjectile_LaunchDirType;
@@ -109,7 +108,7 @@ public:
   virtual void        explode(const Point3F& p, const Point3F& n, const U32 collideType);
 
   DECLARE_CONOBJECT(afxProjectile);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxScriptEvent.h
+++ b/Engine/source/afx/ce/afxScriptEvent.h
@@ -49,7 +49,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxScriptEventData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxSpotLight_T3D.h
+++ b/Engine/source/afx/ce/afxSpotLight_T3D.h
@@ -50,7 +50,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxT3DSpotLightData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxStaticShape.h
+++ b/Engine/source/afx/ce/afxStaticShape.h
@@ -54,7 +54,6 @@ public:
   static void initPersistFields();
 
   DECLARE_CONOBJECT(afxStaticShapeData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -90,7 +89,7 @@ public:
   void                  setVisibility(bool flag) { mIs_visible = flag; }
 
   DECLARE_CONOBJECT(afxStaticShape);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxVolumeLight.h
+++ b/Engine/source/afx/ce/afxVolumeLight.h
@@ -30,7 +30,6 @@ struct afxVolumeLightData : public GameBaseData
 {
   typedef GameBaseData Parent;
   DECLARE_CONOBJECT(afxVolumeLightData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ce/afxZodiac.h
+++ b/Engine/source/afx/ce/afxZodiac.h
@@ -124,7 +124,6 @@ public:
   static void       initPersistFields();
 
   DECLARE_CONOBJECT(afxZodiacData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxZodiacData::BlendType afxZodiac_BlendType;

--- a/Engine/source/afx/ce/afxZodiacPlane.h
+++ b/Engine/source/afx/ce/afxZodiacPlane.h
@@ -96,7 +96,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxZodiacPlaneData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxZodiacPlaneData::BlendType afxZodiacPlane_BlendType;
@@ -142,7 +141,7 @@ public:
   void                  _renderZodiacPlane(ObjectRenderInst*, SceneRenderState*, BaseMatInstance*);
 
   DECLARE_CONOBJECT(afxZodiacPlane);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/ea/afxEA_TLKLight.cpp
+++ b/Engine/source/afx/ea/afxEA_TLKLight.cpp
@@ -34,7 +34,6 @@ struct sgLightObjectData : public GameBaseData
 {
   typedef GameBaseData Parent;
   DECLARE_CONOBJECT(sgLightObjectData);
-  DECLARE_CATEGORY("AFX");
 };
 
 IMPLEMENT_CO_DATABLOCK_V1(sgLightObjectData);

--- a/Engine/source/afx/ea/afxEA_Zodiac.cpp
+++ b/Engine/source/afx/ea/afxEA_Zodiac.cpp
@@ -77,7 +77,7 @@ public:
   static void       initPersistFields();
 
   //DECLARE_CONOBJECT(afxEA_Zodiac);
-  DECLARE_CATEGORY("AFX");
+  DECLARE_CATEGORY("UNLISTED");
 };
 
 //IMPLEMENT_CONOBJECT(afxEA_Zodiac);

--- a/Engine/source/afx/forces/afxF_Drag.cpp
+++ b/Engine/source/afx/forces/afxF_Drag.cpp
@@ -50,7 +50,6 @@ public:
   static void     initPersistFields();
 
   DECLARE_CONOBJECT(afxF_DragData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/forces/afxF_Gravity.cpp
+++ b/Engine/source/afx/forces/afxF_Gravity.cpp
@@ -48,7 +48,6 @@ public:
   static void     initPersistFields();
 
   DECLARE_CONOBJECT(afxF_GravityData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/forces/afxXM_Force.cpp
+++ b/Engine/source/afx/forces/afxXM_Force.cpp
@@ -64,7 +64,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_ForceData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_Force : public afxXM_WeightedBase, public afxEffectDefs

--- a/Engine/source/afx/rpg/afxRPGMagicSpell.h
+++ b/Engine/source/afx/rpg/afxRPGMagicSpell.h
@@ -97,7 +97,6 @@ public:
   static void       initPersistFields();
 
   DECLARE_CONOBJECT(afxRPGMagicSpellData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/util/afxParticlePool.h
+++ b/Engine/source/afx/util/afxParticlePool.h
@@ -55,7 +55,6 @@ public:
   static void     initPersistFields();
 
 	DECLARE_CONOBJECT(afxParticlePoolData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxParticlePoolData::PoolType afxParticlePool_PoolType;
@@ -135,7 +134,6 @@ public:
   void            setSortPriority(S8 priority);
 
   DECLARE_CONOBJECT(afxParticlePool);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/util/afxPath.h
+++ b/Engine/source/afx/util/afxPath.h
@@ -94,7 +94,6 @@ public:
   static void           initPersistFields();
 
   DECLARE_CONOBJECT(afxPathData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_Aim.cpp
+++ b/Engine/source/afx/xm/afxXM_Aim.cpp
@@ -54,7 +54,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_AimData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_AltitudeConform.cpp
+++ b/Engine/source/afx/xm/afxXM_AltitudeConform.cpp
@@ -53,7 +53,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_AltitudeConformData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_AltitudeConform : public afxXM_WeightedBase

--- a/Engine/source/afx/xm/afxXM_BoxAdapt.cpp
+++ b/Engine/source/afx/xm/afxXM_BoxAdapt.cpp
@@ -52,7 +52,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_BoxAdaptData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_BoxConform.cpp
+++ b/Engine/source/afx/xm/afxXM_BoxConform.cpp
@@ -53,7 +53,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_BoxConformData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_BoxConform : public afxXM_Base

--- a/Engine/source/afx/xm/afxXM_BoxHeightOffset.cpp
+++ b/Engine/source/afx/xm/afxXM_BoxHeightOffset.cpp
@@ -55,7 +55,6 @@ public:
 #endif
   
   DECLARE_CONOBJECT(afxXM_BoxHeightOffsetData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_Freeze.cpp
+++ b/Engine/source/afx/xm/afxXM_Freeze.cpp
@@ -53,7 +53,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_FreezeData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_GroundConform.cpp
+++ b/Engine/source/afx/xm/afxXM_GroundConform.cpp
@@ -55,7 +55,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_GroundConformData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_GroundConform : public afxXM_WeightedBase

--- a/Engine/source/afx/xm/afxXM_HeightSampler.cpp
+++ b/Engine/source/afx/xm/afxXM_HeightSampler.cpp
@@ -52,7 +52,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_HeightSamplerData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_MountedImageNode.cpp
+++ b/Engine/source/afx/xm/afxXM_MountedImageNode.cpp
@@ -54,7 +54,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_MountedImageNodeData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_Offset.cpp
+++ b/Engine/source/afx/xm/afxXM_Offset.cpp
@@ -59,7 +59,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
   
   DECLARE_CONOBJECT(afxXM_LocalOffsetData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//
@@ -145,7 +144,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
   
   DECLARE_CONOBJECT(afxXM_WorldOffsetData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_Oscillate.cpp
+++ b/Engine/source/afx/xm/afxXM_Oscillate.cpp
@@ -61,7 +61,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_OscillateData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_Oscillate_rot : public afxXM_WeightedBase

--- a/Engine/source/afx/xm/afxXM_OscillateZodiacColor.cpp
+++ b/Engine/source/afx/xm/afxXM_OscillateZodiacColor.cpp
@@ -48,7 +48,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_OscillateZodiacColorData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_OscillateZodiacColor : public afxXM_WeightedBase

--- a/Engine/source/afx/xm/afxXM_PathConform.cpp
+++ b/Engine/source/afx/xm/afxXM_PathConform.cpp
@@ -67,7 +67,6 @@ public:
   afxXM_Base*     create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_PathConformData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxPath3D;

--- a/Engine/source/afx/xm/afxXM_PivotNodeOffset.cpp
+++ b/Engine/source/afx/xm/afxXM_PivotNodeOffset.cpp
@@ -55,7 +55,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_PivotNodeOffsetData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_RandomRot.cpp
+++ b/Engine/source/afx/xm/afxXM_RandomRot.cpp
@@ -60,7 +60,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_RandomRotData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_RandomRot : public afxXM_Base

--- a/Engine/source/afx/xm/afxXM_Scale.cpp
+++ b/Engine/source/afx/xm/afxXM_Scale.cpp
@@ -57,7 +57,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_ScaleData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_Shockwave.cpp
+++ b/Engine/source/afx/xm/afxXM_Shockwave.cpp
@@ -58,7 +58,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_ShockwaveData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxConstraint;

--- a/Engine/source/afx/xm/afxXM_Spin.cpp
+++ b/Engine/source/afx/xm/afxXM_Spin.cpp
@@ -62,7 +62,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_SpinData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_VelocityOffset.cpp
+++ b/Engine/source/afx/xm/afxXM_VelocityOffset.cpp
@@ -60,7 +60,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
   
   DECLARE_CONOBJECT(afxXM_VelocityOffsetData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_WaveBase.h
+++ b/Engine/source/afx/xm/afxXM_WaveBase.h
@@ -172,7 +172,6 @@ public:
   static afxXM_Waveform* getWaveform(U32 waveform_type);
 
   DECLARE_CONOBJECT(afxXM_WaveBaseData);
-  DECLARE_CATEGORY("AFX");
 };
 
 typedef afxXM_WaveBaseData::WaveFormType afxXM_WaveFormType;
@@ -210,7 +209,6 @@ public:
   static void     initPersistFields();
 
   DECLARE_CONOBJECT(afxXM_WaveRiderBaseData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_WaveColor.cpp
+++ b/Engine/source/afx/xm/afxXM_WaveColor.cpp
@@ -181,7 +181,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_WaveColorData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -297,7 +296,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_WaveRiderColorData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXM_WaveScalar.cpp
+++ b/Engine/source/afx/xm/afxXM_WaveScalar.cpp
@@ -596,7 +596,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_WaveScalarData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
@@ -723,7 +722,6 @@ public:
   afxXM_Base*   create(afxEffectWrapper* fx, bool on_server);
 
   DECLARE_CONOBJECT(afxXM_WaveRiderScalarData);
-  DECLARE_CATEGORY("AFX");
 };
 
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//

--- a/Engine/source/afx/xm/afxXfmMod.h
+++ b/Engine/source/afx/xm/afxXfmMod.h
@@ -91,7 +91,6 @@ public:
   virtual afxXM_Base* create(afxEffectWrapper* fx, bool on_server) { return 0; }
 
   DECLARE_CONOBJECT(afxXM_BaseData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_Base : public afxXM_Defs
@@ -147,7 +146,6 @@ public:
   static void   initPersistFields();
 
   DECLARE_CONOBJECT(afxXM_WeightedBaseData);
-  DECLARE_CATEGORY("AFX");
 };
 
 class afxXM_WeightedBase : public afxXM_Base

--- a/Engine/source/console/consoleObject.cpp
+++ b/Engine/source/console/consoleObject.cpp
@@ -831,11 +831,19 @@ DefineEngineFunction( getCategoryOfClass, const char*,  ( const char* className 
             "@ingroup Console")
 {
    AbstractClassRep* rep = AbstractClassRep::findClassRep( className );
-   if( rep )
-      return rep->getCategory();
 
-   Con::errorf( "getCategoryOfClass - no class called '%s'", className );
-   return "";
+   if (rep == NULL)
+   {
+      Con::errorf("getCategoryOfClass - no class called '%s'", className);
+      return "";
+   }
+   while (rep && rep->getParentClass())
+   {
+      if (dStrcmp(rep->getCategory(), "") != 0)
+         break;
+      rep = rep->getParentClass();
+   }
+   return rep ? rep->getCategory() : "";
 }
 
 DefineEngineFunction( enumerateConsoleClasses, const char*, ( const char* className ), ( "" ),

--- a/Engine/source/environment/VolumetricFog.h
+++ b/Engine/source/environment/VolumetricFog.h
@@ -253,6 +253,7 @@ class VolumetricFog : public SceneObject
       void onShapeChanged() {}
    
       DECLARE_CONOBJECT(VolumetricFog);
+      DECLARE_CATEGORY("Environment \t Weather");
    
       DECLARE_CALLBACK(void, onEnterFog, (SimObjectId obj));
       DECLARE_CALLBACK(void, onLeaveFog, (SimObjectId obj));

--- a/Engine/source/environment/VolumetricFogRTManager.h
+++ b/Engine/source/environment/VolumetricFogRTManager.h
@@ -83,6 +83,7 @@ class VolumetricFogRTManager : public SceneObject
       U32 DecFogObjects();
    
    DECLARE_CONOBJECT(VolumetricFogRTManager);
+   DECLARE_CATEGORY("UNLISTED");
 };
    
 extern VolumetricFogRTManager* gVolumetricFogRTManager;

--- a/Engine/source/environment/basicClouds.h
+++ b/Engine/source/environment/basicClouds.h
@@ -65,6 +65,7 @@ public:
    virtual ~BasicClouds() {}
 
    DECLARE_CONOBJECT( BasicClouds );
+   DECLARE_CATEGORY("Environment \t Weather");
 
    // ConsoleObject
    virtual bool onAdd();

--- a/Engine/source/environment/cloudLayer.h
+++ b/Engine/source/environment/cloudLayer.h
@@ -68,6 +68,7 @@ public:
    virtual ~CloudLayer() {}
 
    DECLARE_CONOBJECT( CloudLayer );
+   DECLARE_CATEGORY("Environment \t Weather");
 
    // ConsoleObject
    virtual bool onAdd();

--- a/Engine/source/environment/decalRoad.h
+++ b/Engine/source/environment/decalRoad.h
@@ -154,6 +154,7 @@ public:
 	~DecalRoad();
 
 	DECLARE_CONOBJECT(DecalRoad);
+   DECLARE_CATEGORY("Environment \t BackGround");
 
    // ConsoleObject
 	static void initPersistFields();

--- a/Engine/source/environment/meshRoad.h
+++ b/Engine/source/environment/meshRoad.h
@@ -509,6 +509,7 @@ public:
    ~MeshRoad();
 
    DECLARE_CONOBJECT(MeshRoad);
+   DECLARE_CATEGORY("Environment \t BackGround");
 
    // ConObject.
    static void initPersistFields();

--- a/Engine/source/environment/scatterSky.h
+++ b/Engine/source/environment/scatterSky.h
@@ -85,6 +85,7 @@ public:
 
    // ConsoleObject
    DECLARE_CONOBJECT(ScatterSky);
+   DECLARE_CATEGORY("Environment \t Background");
    void inspectPostApply();
    static void initPersistFields();
 

--- a/Engine/source/environment/skyBox.h
+++ b/Engine/source/environment/skyBox.h
@@ -75,6 +75,7 @@ public:
    virtual ~SkyBox();
 
    DECLARE_CONOBJECT( SkyBox );
+   DECLARE_CATEGORY("Environment \t Background");
 
    // SimObject
    void onStaticModified( const char *slotName, const char *newValue );

--- a/Engine/source/environment/skySphere.h
+++ b/Engine/source/environment/skySphere.h
@@ -66,6 +66,7 @@ public:
    virtual ~SkySphere();
 
    DECLARE_CONOBJECT(SkySphere);
+   DECLARE_CATEGORY("Environment \t Background");
 
    // SimObject
    void onStaticModified(const char* slotName, const char* newValue);

--- a/Engine/source/environment/sun.h
+++ b/Engine/source/environment/sun.h
@@ -116,7 +116,8 @@ public:
    virtual void onRemove();
 
    // ConsoleObject
-   DECLARE_CONOBJECT(Sun);   
+   DECLARE_CONOBJECT(Sun);
+   DECLARE_CATEGORY("Lighting \t Lights");
    static void initPersistFields();
    void inspectPostApply();
 

--- a/Engine/source/environment/timeOfDay.h
+++ b/Engine/source/environment/timeOfDay.h
@@ -76,6 +76,7 @@ public:
 	static void initPersistFields();
    static void consoleInit();
    DECLARE_CONOBJECT( TimeOfDay );
+   DECLARE_CATEGORY("Environment \t Weather");
    void inspectPostApply();
 
    // SimObject

--- a/Engine/source/environment/waterObject.h
+++ b/Engine/source/environment/waterObject.h
@@ -149,6 +149,7 @@ public:
    virtual ~WaterObject();
 
    DECLARE_CONOBJECT( WaterObject );
+   DECLARE_CATEGORY("Environment \t Water");
 
    // ConsoleObject
    static void consoleInit();

--- a/Engine/source/forest/forest.h
+++ b/Engine/source/forest/forest.h
@@ -147,6 +147,7 @@ public:
    virtual ~Forest();
 
    DECLARE_CONOBJECT(Forest);
+   DECLARE_CATEGORY("Environment \t BackGround");
    static void consoleInit();
    static void initPersistFields();   
 

--- a/Engine/source/forest/forestWindEmitter.h
+++ b/Engine/source/forest/forestWindEmitter.h
@@ -214,6 +214,7 @@ public:
    // ConObject.
    static void initPersistFields();
    DECLARE_CONOBJECT(ForestWindEmitter);
+   DECLARE_CATEGORY("Environment \t Weather");
 };
 
 #endif // _FORESTWINDEMITTER_H_

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
@@ -1768,10 +1768,10 @@ void GuiConvexEditorCtrl::submitUndo( UndoType type, const Vector<ConvexShape*> 
 	mIsDirty = true;
 }
 
-bool GuiConvexEditorCtrl::_cursorCastCallback( RayInfo* ri )
+bool GuiConvexEditorCtrl::_cursorCastCallback(SceneObject* object)
 {
    // Reject anything that's not a ConvexShape.
-   return dynamic_cast< ConvexShape* >( ri->object );
+   return dynamic_cast< ConvexShape* >( object );
 }
 
 bool GuiConvexEditorCtrl::_cursorCast( const Gui3DMouseEvent &event, ConvexShape **hitShape, S32 *hitFace )

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.h
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.h
@@ -169,7 +169,7 @@ protected:
    void _renderObject( ObjectRenderInst *ri, SceneRenderState *state, BaseMatInstance *matInst );
 
    bool _cursorCast( const Gui3DMouseEvent &event, ConvexShape **hitShape, S32 *hitFace );
-   static bool _cursorCastCallback( RayInfo* ri );
+   static bool _cursorCastCallback(SceneObject* object);
 
 protected:
 

--- a/Engine/source/navigation/coverPoint.h
+++ b/Engine/source/navigation/coverPoint.h
@@ -54,6 +54,7 @@ public:
    virtual ~CoverPoint();
 
    DECLARE_CONOBJECT(CoverPoint);
+   DECLARE_CATEGORY("Navigation");
 
    /// Amount of cover provided at this point.
    enum Size {

--- a/Engine/source/navigation/navMesh.h
+++ b/Engine/source/navigation/navMesh.h
@@ -239,6 +239,7 @@ public:
    NavMesh();
    ~NavMesh();
    DECLARE_CONOBJECT(NavMesh);
+   DECLARE_CATEGORY("Navigation");
 
    /// Return the server-side NavMesh SimSet.
    static SimSet *getServerSet();

--- a/Engine/source/navigation/navPath.h
+++ b/Engine/source/navigation/navPath.h
@@ -115,6 +115,7 @@ public:
    void renderSimple(ObjectRenderInst *ri, SceneRenderState *state, BaseMatInstance *overrideMat);
 
    DECLARE_CONOBJECT(NavPath);
+   DECLARE_CATEGORY("Navigation");
 
    /// @}
 

--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -318,10 +318,9 @@ struct SceneRayHelper
                xformedEnd.convolveInverse(ptr->mObjScale);
 
                RayInfo ri;
-               ri.object = ptr;
                ri.generateTexCoord = info->generateTexCoord;
 
-               if (mFunc && !mFunc(&ri))
+               if (mFunc && !mFunc(ptr))
                   return false;
 
                bool result = false;

--- a/Engine/source/scene/sceneContainer.h
+++ b/Engine/source/scene/sceneContainer.h
@@ -668,7 +668,7 @@ class SceneContainer
       /// @name Line intersection
       /// @{
 
-      typedef bool ( *CastRayCallback )( RayInfo* ri );
+      typedef bool ( *CastRayCallback )(SceneObject* object);
 
       /// Test against collision geometry -- fast.
       bool castRay( const Point3F &start, const Point3F &end, U32 mask, RayInfo* info, CastRayCallback callback = NULL );

--- a/Engine/source/scene/sceneObject.h
+++ b/Engine/source/scene/sceneObject.h
@@ -754,6 +754,7 @@ class SceneObject : public NetObject, public ProcessObject
       static bool _setGameObject(void* object, const char* index, const char* data);
 
       DECLARE_CONOBJECT( SceneObject );
+      DECLARE_CATEGORY("MISC");
    private:
 
       SceneObject( const SceneObject& ); ///< @deprecated disallowed

--- a/Engine/source/scene/simPath.h
+++ b/Engine/source/scene/simPath.h
@@ -84,6 +84,7 @@ class Path : public GameBase
    U32 getPathIndex() const;
 
    DECLARE_CONOBJECT(Path);
+   DECLARE_CATEGORY("Cinematic");
    static void initPersistFields();
    DECLARE_CALLBACK(void, onAdd, (SimObjectId ID));
 };
@@ -151,6 +152,7 @@ class Marker : public SceneObject
    ~Marker();
 
    DECLARE_CONOBJECT(Marker);
+   DECLARE_CATEGORY("Cinematic");
    static void initPersistFields();
    void inspectPostApply();
 

--- a/Engine/source/terrain/terrData.h
+++ b/Engine/source/terrain/terrData.h
@@ -488,6 +488,7 @@ public:
 
 
    DECLARE_CONOBJECT(TerrainBlock);
+   DECLARE_CATEGORY("Environment \t BackGround");
    static void initPersistFields();
    U32 packUpdate   (NetConnection *conn, U32 mask, BitStream *stream);
    void unpackUpdate(NetConnection *conn,           BitStream *stream);

--- a/Templates/BaseGame/game/tools/worldEditor/gui/objectBuilderGui.ed.gui
+++ b/Templates/BaseGame/game/tools/worldEditor/gui/objectBuilderGui.ed.gui
@@ -1079,6 +1079,14 @@ function ObjectBuilderGui::buildObject(%this, %className)
    %this.process();
 }
 
+function ObjectBuilderGui::buildGameBaseObject(%this, %className)
+{
+   %this.objectClassName = %className;
+   //assumes we fgollow the pattern of class is instance, classData is datablock
+   %this.addField("dataBlock", "TypeDataBlock", "Data block", %className @"Data");
+
+   %this.process();
+}
 //------------------------------------------------------------------------------
 // Environment
 //------------------------------------------------------------------------------

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menus.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menus.ed.tscript
@@ -507,10 +507,15 @@ function EditorGui::buildMenus(%this)
       %class = %class;
       %method = "build" @ %buildfunc;
       if( !ObjectBuilderGui.isMethod( %method ) )
-         %method = "build" @ %class;
-
+         %method = "build" @ %class;         
+         
       if( !ObjectBuilderGui.isMethod( %method ) )
-         %cmd = "return new " @ %class @ "();";
+      {
+         if (isMemberOfClass(%class,"gameBase"))
+            %cmd = "ObjectBuilderGui.buildGameBaseObject("@ %class @");";
+         else
+            %cmd = "return new " @ %class @ "();";
+      }
       else
          %cmd = "ObjectBuilderGui." @ %method @ "();";
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menus.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menus.ed.tscript
@@ -472,7 +472,10 @@ function EditorGui::buildMenus(%this)
    for(%c=0; %c < getFieldCount(%enumeratedClasses); %c++)
    {
       %class = getField(%enumeratedClasses, %c);  
-      
+      //SceneObject itself is not directly spawnable
+      if (%class $= "SceneObject")
+        continue;
+        
       %category = getCategoryOfClass(%class);
 
       if(%category $= "")
@@ -480,7 +483,13 @@ function EditorGui::buildMenus(%this)
          error("Attempted to fetch category of class " @ %class @ " but none were found.");
          continue;  
       }
-      
+      //skip classes explicitly tagged not for listing (typically due to being unspawnable)
+      if(%category $= "UNLISTED")
+        continue;
+        
+      if(%category $= "MISC")
+        warn("unsorted class: "@ %class);
+        
       %parentMenu = %addMenu; //start at the top
       for(%cat=0; %cat < getFieldCount(%category); %cat++)
       {


### PR DESCRIPTION
SceneObject now defaults to a category of "misc"
getCategoryOfClass now checks parent classes for what categories they hold so that variants can inherit categories are in one of a few rough groups and subgroups depending on actual mapper needs/usages