### PR TITLE
hide particleemitter dupes

### DIFF
--- a/Templates/BaseGame/game/tools/particleEditor/particleEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/particleEditor/particleEditor.ed.tscript
@@ -222,6 +222,13 @@ function ParticleEditor::resetEmitterNode( %this )
       
       ParticleEditor.updateEmitterNode();
    }
+   if (EWorldEditor.getSelectionSize()>0)
+   {
+        %obj = EWorldEditor.getSelectedObject(0);
+        if (%obj.isMemberOfClass("ParticleEmitterNode"))
+            $ParticleEditor::emitterNode.sethidden(true);
+   }
+        
 }
 
 //---------------------------------------------------------------------------------------------


### PR DESCRIPTION
if you have a selected particleemitternode when opening the particle editor, don't show the edit-copy one