### PR TITLE
filter out component inspector button callbacks

### DIFF
--- a/Engine/source/gui/editor/inspector/dynamicField.cpp
+++ b/Engine/source/gui/editor/inspector/dynamicField.cpp
@@ -74,7 +74,7 @@ void GuiInspectorDynamicField::setData( const char* data, bool callbacks )
       {
          target->inspectPreApply();
          
-         if( callbacks )
+         if( callbacks && !mField->flag.test(AbstractClassRep::FieldFlags::FIELD_ComponentInspectors))
          {
             if( isRemoval )
                Con::executef( mInspector, "onFieldRemoved", target->getIdString(), mDynField->slotName );

--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -378,7 +378,7 @@ void GuiInspectorField::setData( const char* data, bool callbacks )
          
          // Fire callback single-object undo.
          
-         if( callbacks )
+         if( callbacks && !mField->flag.test(AbstractClassRep::FieldFlags::FIELD_ComponentInspectors) )
             Con::executef( mInspector, "onInspectorFieldModified", 
                                           target->getIdString(), 
                                           mField->pFieldname, 


### PR DESCRIPTION
specifically targets the undo manager via avoiding onInspectorFieldModified et al tripping on clicks