### PR TITLE
overdark causality review

### DIFF
--- a/Templates/BaseGame/game/core/postFX/scripts/HDR/HDRPostFX.tscript
+++ b/Templates/BaseGame/game/core/postFX/scripts/HDR/HDRPostFX.tscript
@@ -26,11 +26,7 @@ $PostFX::HDRPostFX::enableToneMapping = 0.5;
 
 /// The tone mapping middle grey or exposure value used
 /// to adjust the overall "balance" of the image.
-///
-/// 0.18 is fairly common value.
-///
-
-$PostFX::HDRPostFX::keyValue = 0.115;
+$PostFX::HDRPostFX::keyValue = 0.5;
 
 
 //Explicit HDR Params

--- a/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
@@ -224,8 +224,8 @@ float getDistanceAtt( vec3 unormalizedLightVector , float invSqrAttRadius )
 
 vec3 evaluateStandardBRDF(Surface surface, SurfaceToLight surfaceToLight)
 {
-   //lambert diffuse
-   vec3 Fd = Fr_DisneyDiffuse(surface.f0, surface.NdotV, surfaceToLight.NdotL, surfaceToLight.NdotH, surface.linearRoughness);
+   //diffuse term
+   vec3 Fd = surface.albedo.rgb * M_1OVER_PI_F;
     
    //GGX specular
    vec3 F = F_Schlick(surface.f0, surface.f90, surfaceToLight.HdotV);

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
@@ -225,8 +225,8 @@ float getDistanceAtt( float3 unormalizedLightVector , float invSqrAttRadius )
 
 float3 evaluateStandardBRDF(Surface surface, SurfaceToLight surfaceToLight)
 {
-   //disney diffuse
-   float3 Fd = Fr_DisneyDiffuse(surface.f0, surface.NdotV, surfaceToLight.NdotL, surfaceToLight.NdotH, surface.linearRoughness);
+   //diffuse term
+   float3 Fd = float3 Fd = surface.albedo.rgb * M_1OVER_PI_F;
     
    //GGX specular
    float3 F = F_Schlick(surface.f0, surface.f90, surfaceToLight.HdotV);


### PR DESCRIPTION
two things stuck out as proximal causes for an overdark result on community review:
 1) $PostFX::HDRPostFX::keyValue was significantly too low given existing calculations, so upped that to 0.5 in keeping with the general assumption we remain intending to have that be the dead center value of a luminance range 
 2)  Fr_DisneyDiffuse input assumptions differ from current engine ones, so reverting that to lambert .