### PR TITLE
Adjustments to upfront load behavior to improve launch and display times of app.

### DIFF
--- a/Engine/source/gui/controls/guiBitmapCtrl.cpp
+++ b/Engine/source/gui/controls/guiBitmapCtrl.cpp
@@ -81,7 +81,9 @@ void GuiBitmapCtrl::initPersistFields()
    docsURL;
    addGroup( "Bitmap" );
 
-   INITPERSISTFIELD_IMAGEASSET(Bitmap, GuiBitmapCtrl, The bitmap file to display in the control);
+      addField("Bitmap", TypeImageFilename, Offset(mBitmapName, GuiBitmapCtrl), assetDoc(Bitmap, docs), AbstractClassRep::FIELD_HideInInspectors);
+      addField("BitmapAsset", TypeImageAssetId, Offset(mBitmapAssetId, GuiBitmapCtrl), assetDoc(Bitmap, asset docs.));
+
       addField("color", TypeColorI, Offset(mColor, GuiBitmapCtrl),"color mul");
       addField( "wrap",   TypeBool,     Offset( mWrap, GuiBitmapCtrl ),
          "If true, the bitmap is tiled inside the control rather than stretched to fit." );

--- a/Engine/source/materials/materialManager.cpp
+++ b/Engine/source/materials/materialManager.cpp
@@ -297,10 +297,19 @@ BaseMatInstance *MaterialManager::getMeshDebugMatInstance(const LinearColorF &me
 
 void MaterialManager::mapMaterial(const String & textureName, const String & materialName)
 {
-   if (getMapEntry(textureName).isNotEmpty())
+   String currentMapEntry = getMapEntry(textureName);
+   if (currentMapEntry.isNotEmpty())
    {
       if (!textureName.equal("unmapped_mat", String::NoCase))
-         Con::warnf(ConsoleLogEntry::General, "Warning, overwriting material for: %s", textureName.c_str());
+      {
+         SimObject* originalMat;
+         SimObject* newMat;
+
+         if (Sim::findObject(currentMapEntry, originalMat) && Sim::findObject(materialName, newMat))
+            Con::warnf(ConsoleLogEntry::General, "Warning, overwriting material for: \"%s\" in %s by %s", textureName.c_str(), originalMat->getFilename(), newMat->getFilename());
+         else
+            Con::warnf(ConsoleLogEntry::General, "Warning, overwriting material for: %s", textureName.c_str());
+      }
    }
 
    mMaterialMap[String::ToLower(textureName)] = materialName;

--- a/Engine/source/persistence/taml/binary/tamlBinaryReader.cpp
+++ b/Engine/source/persistence/taml/binary/tamlBinaryReader.cpp
@@ -147,6 +147,8 @@ SimObject* TamlBinaryReader::parseElement( Stream& stream, const U32 versionId )
     if ( pSimObject == NULL )
         return NULL;
 
+    pSimObject->setFilename(mpTaml->getFilePathBuffer());
+
     // Find Taml callbacks.
     TamlCallbacks* pCallbacks = dynamic_cast<TamlCallbacks*>( pSimObject );
 

--- a/Engine/source/persistence/taml/xml/tamlXmlReader.cpp
+++ b/Engine/source/persistence/taml/xml/tamlXmlReader.cpp
@@ -119,6 +119,8 @@ SimObject* TamlXmlReader::parseElement( tinyxml2::XMLElement* pXmlElement )
     if ( pSimObject == NULL )
         return NULL;
 
+    pSimObject->setFilename(mpTaml->getFilePathBuffer());
+
     // Find Taml callbacks.
     TamlCallbacks* pCallbacks = dynamic_cast<TamlCallbacks*>( pSimObject );
 

--- a/Templates/BaseGame/game/core/clientServer/scripts/client/client.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/client/client.tscript
@@ -25,5 +25,4 @@ function initClient()
    // Copy saved script prefs into C++ code.
    setDefaultFov( $pref::Player::defaultFov );
    setZoomSpeed( $pref::Player::zoomSpeed );
-   loadModuleMaterials();
 }

--- a/Templates/BaseGame/game/core/clientServer/scripts/server/server.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/server.tscript
@@ -58,7 +58,6 @@ function initServer()
    //Maybe this should be a pref for better per-project control
    //But many physically based/gameplay things utilize materials being detected
    //So we'll load on the server as well
-   loadModuleMaterials();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
- Disabled the initial forced materials load, now all materials loadon-demand via asset refs and dependencies
- Changes guiBitmapCtrl to not forcefully load and bind the image asset directly from the field so we don't upfront load every bitmap of every gui control on client startup
- Changes materialManager so that if a material mapping entry override occurs, we try and find the filenames of the original and the overrider so it's easier to chase down those cases
- Makes the taml reader properly assign the fileName of objects created from the taml serialization