### PR TITLE
probe capture fixes

### DIFF
--- a/Engine/source/T3D/lighting/reflectionProbe.cpp
+++ b/Engine/source/T3D/lighting/reflectionProbe.cpp
@@ -184,6 +184,10 @@ void ReflectionProbe::initPersistFields()
       "@note Only works for shadow mapped lights.\n\n"
       "@ingroup Lighting");
 
+   Con::addVariable("$Probes::Capturing", TypeBool, &RenderProbeMgr::smBakeReflectionProbes,
+      "Toggles probe rendering capture state.\n\n"
+      "@ingroup Lighting");
+
    Con::addVariable("$Light::renderPreviewProbes", TypeBool, &ReflectionProbe::smRenderPreviewProbes,
       "Toggles rendering of light frustums when the light is selected in the editor.\n\n"
       "@note Only works for shadow mapped lights.\n\n"
@@ -823,7 +827,7 @@ void ReflectionProbe::createEditorResources()
 
 void ReflectionProbe::prepRenderImage(SceneRenderState *state)
 {
-   if (!mEnabled || (!RenderProbeMgr::smRenderReflectionProbes && !dStrcmp(Con::getVariable("$Probes::Capturing", "0"),"1")))
+   if (!mEnabled || (!RenderProbeMgr::smRenderReflectionProbes || RenderProbeMgr::smBakeReflectionProbes))
       return;
 
    Point3F distVec = getRenderPosition() - state->getCameraPosition();

--- a/Engine/source/gfx/gl/gfxGLShader.cpp
+++ b/Engine/source/gfx/gl/gfxGLShader.cpp
@@ -1109,9 +1109,12 @@ bool GFXGLShader::initShader( const Torque::Path &file,
       return false;
    }
    
-   if ( !_loadShaderFromStream( activeShader, file, &stream, macros ) )
+   if (!_loadShaderFromStream(activeShader, file, &stream, macros))
+   {
+      if (smLogErrors)
+         Con::errorf("GFXGLShader::initShader - unable to load shader from stream: '%s'.", file.getFullPath().c_str());
       return false;
-   
+   }
    GLint compile;
    glGetShaderiv(activeShader, GL_COMPILE_STATUS, &compile);
 
@@ -1119,17 +1122,13 @@ bool GFXGLShader::initShader( const Torque::Path &file,
    U32 logLength = 0;
    glGetShaderiv(activeShader, GL_INFO_LOG_LENGTH, (GLint*)&logLength);
    
-   GLint compileStatus = GL_TRUE;
    if ( logLength )
    {
       FrameAllocatorMarker fam;
       char* log = (char*)fam.alloc(logLength);
       glGetShaderInfoLog(activeShader, logLength, NULL, log);
 
-      // Always print errors
-      glGetShaderiv( activeShader, GL_COMPILE_STATUS, &compileStatus );
-
-      if ( compileStatus == GL_FALSE )
+      if (compile == GL_FALSE )
       {
          if ( smLogErrors )
          {
@@ -1141,7 +1140,7 @@ bool GFXGLShader::initShader( const Torque::Path &file,
          Con::warnf( "Program %s: %s", file.getFullPath().c_str(), log );
    }
 
-   return compileStatus != GL_FALSE;
+   return compile != GL_FALSE;
 }
 
 /// Returns our list of shader constants, the material can get this and just set the constants it knows about

--- a/Engine/source/renderInstance/renderProbeMgr.h
+++ b/Engine/source/renderInstance/renderProbeMgr.h
@@ -357,6 +357,7 @@ public:
    /// </summary>
    static bool smRenderReflectionProbes;
 
+   static bool smBakeReflectionProbes;
    //=============================================================================
    // Utility functions for processing and setting up the probes for rendering
    //=============================================================================

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/prefilterP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/prefilterP.glsl
@@ -86,7 +86,7 @@ vec3 ImportanceSampleGGX(vec2 Xi, vec3 N)
 
 vec3 prefilterEnvMap(vec3 R)
 {
-    int sampleCount = resolution*2;
+    int sampleCount = 1024;
 	vec3 N = R;
 	vec3 V = R;
 	float totalWeight = 0.0;
@@ -107,7 +107,7 @@ vec3 prefilterEnvMap(vec3 R)
 				float HdotV = max(dot(H, V), 0.0);
 				float pdf = D * NdotH / (4.0 * HdotV) + 0.0001;
 
-				float saTexel = 4.0 * M_PI_F / float(6.0 * sampleCount * sampleCount);
+				float saTexel = 4.0 * M_PI_F / float(6.0 * resolution * resolution);
 				float saSample = 1.0 / (float(sampleCount) * pdf + 0.0001);
 
 				float mipLevel = roughness == 0.0 ? 0.0 : 0.5 * log2(saSample / saTexel);

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/prefilterP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/prefilterP.hlsl
@@ -88,7 +88,7 @@ float3 ImportanceSampleGGX(float2 Xi, float3 N)
 
 float4 prefilterEnvMap(float3 R)
 {
-    int sampleCount = resolution*2;
+    int sampleCount = 1024;
 	float3 N = R;
 	float3 V = R;
 	float totalWeight = 0.0;
@@ -109,7 +109,7 @@ float4 prefilterEnvMap(float3 R)
 				float HdotV = max(dot(H, V), 0.0);
 				float pdf = D * NdotH / (4.0 * HdotV) + 0.0001;
 
-				float saTexel = 4.0 * M_PI_F / (6.0 * sampleCount * sampleCount);
+				float saTexel = 4.0 * M_PI_F / (6.0 * resolution * resolution);
 				float saSample = 1.0 / (float(sampleCount) * pdf + 0.0001);
 
 				float mipLevel = roughness == 0.0 ? 0.0 : 0.5 * log2(saSample / saTexel);


### PR DESCRIPTION
review of pre- and post- bake protocols showed that the CAPTURING shader macro was not being properly recompiled in. as opengl was not playing nice with a simple batch shader recompilation for all effected shaders, a full lightmanager restart is at time of writing required. once we have a proper globally cached scene structure stored off GPU side, we'll want to change  GFXShader::addGlobalMacro("CAPTURING", String("1")); on over to dirtying that value in the cached buffer via setting a shader global uniform review of prefilter examples shows a fixed sample count of 1024 across multiple implementations, so we'll use the standard barring further research into where that number is comming from for a scalar approach review of gl shaders shows a doubleup in compiled state testing, so slimmed that down and added additional debugging reports