### PR TITLE
fix sun corona

### DIFF
--- a/Engine/source/environment/scatterSky.cpp
+++ b/Engine/source/environment/scatterSky.cpp
@@ -921,6 +921,13 @@ void ScatterSky::_initMoon()
       features.removeFeature(MFT_ReflectionProbes);      
       features.addFeature(MFT_isBackground);
       mMoonMatInst = MATMGR->createMatInstance(mMoonMatAsset->getMaterialDefinitionName(), features, getGFXVertexFormat<GFXVertexPCT>());
+
+      GFXStateBlockDesc desc;
+      desc.setBlend(true);
+      desc.setAlphaTest(true);
+      desc.setZReadWrite(true, false);
+      mMoonMatInst->addStateBlockDesc(desc);
+      mMoonMatInst->init(features, getGFXVertexFormat<GFXVertexPCT>());
    }
 }
 

--- a/Engine/source/environment/sun.cpp
+++ b/Engine/source/environment/sun.cpp
@@ -41,6 +41,7 @@
 #include "materials/baseMatInstance.h"
 #include "materials/sceneData.h"
 #include "math/util/matrixSet.h"
+#include "materials/materialFeatureTypes.h"
 
 
 IMPLEMENT_CO_NETOBJECT_V1(Sun);
@@ -454,7 +455,21 @@ void Sun::_initCorona()
 
    if (mCoronaMaterialAsset.notNull())
    {
-      mCoronaMatInst = MATMGR->createMatInstance(mCoronaMaterialAsset->getMaterialDefinitionName(), MATMGR->getDefaultFeatures(), getGFXVertexFormat<GFXVertexPCT>());
+      FeatureSet features = MATMGR->getDefaultFeatures();
+      features.removeFeature(MFT_RTLighting);
+      features.removeFeature(MFT_Visibility);
+      features.removeFeature(MFT_ReflectionProbes);
+      features.addFeature(MFT_isBackground);
+      features.addFeature(MFT_VertLit);
+
+      mCoronaMatInst = MATMGR->createMatInstance(mCoronaMaterialAsset->getMaterialDefinitionName(), features, getGFXVertexFormat<GFXVertexPCT>());
+
+      GFXStateBlockDesc desc;
+      desc.setBlend(true);
+      desc.setAlphaTest(true);
+      desc.setZReadWrite(true, false);
+      mCoronaMatInst->addStateBlockDesc(desc);
+      mCoronaMatInst->init(features, getGFXVertexFormat<GFXVertexPCT>());
    }
 }
 


### PR DESCRIPTION
by locking in the material feature variation to ensure it uses vertex lighting due to colorization, as well as a few other switches, and applying an explicit vs default stateblock blend do similar with moon so you don't have to set that to explicitly translucent either