### PR TITLE
theoratexture can't downsample

### DIFF
--- a/Engine/source/gfx/video/theoraTexture.cpp
+++ b/Engine/source/gfx/video/theoraTexture.cpp
@@ -59,7 +59,7 @@
 /// Profile for the video texture.
 GFX_ImplementTextureProfile(  GFXTheoraTextureProfile,
                               GFXTextureProfile::DiffuseMap,
-                              GFXTextureProfile::NoMipmap | GFXTextureProfile::Dynamic,
+                              GFXTextureProfile::NoMipmap | GFXTextureProfile::Dynamic | GFXTextureProfile::PreserveSize,
                               GFXTextureProfile::NONE );
 
 


### PR DESCRIPTION
so don't.
this stops $pref::Video::textureReductionLevel from crashing the applicaton in that scenario