### PR TITLE
add an $undoIgnoreList

### DIFF
--- a/Templates/BaseGame/game/tools/guiEditor/scripts/guiEditorUndo.ed.tscript
+++ b/Templates/BaseGame/game/tools/guiEditor/scripts/guiEditorUndo.ed.tscript
@@ -20,6 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
+//command variable feilds. do not trip them by unsetting or resetting these
+$undoIgnoreList = "docsURL EditPosOffset Bake EditPostEffects selectAll sync Prototype";
 
 //---------------------------------------------------------------------------------------------
 
@@ -451,6 +453,15 @@ function GenericUndoAction::undo(%this)
       for(%j = 0; %j < getWordCount(%fieldNames); %j++)
       {
          %field = getWord(%fieldNames, %j);
+         %skip = false;
+         for(%k = 0; %k < getWordCount($undoIgnoreList); %k++)
+         {
+            if(%field $= getWord(%fieldNames, %k)) //specialty field, we can't 'undo' it
+                %skip = true;
+         }
+         if (%skip)
+            continue;
+            
          %object.setFieldValue(%field, %this.fieldValues[%object, %field]);
       }
       // null out the fields in the null list
@@ -470,7 +481,6 @@ function GenericUndoAction::undo(%this)
 function GenericUndoAction::redo(%this)
 {
    // set the objects to the new values
-   // set the objects to the new values
    // scan through our objects
    %objectList = %this.objectIdList;
    for(%i = 0; %i < getWordCount(%objectList); %i++)
@@ -481,6 +491,15 @@ function GenericUndoAction::redo(%this)
       for(%j = 0; %j < getWordCount(%fieldNames); %j++)
       {
          %field = getWord(%fieldNames, %j);
+         %skip = false;
+         for(%k = 0; %k < getWordCount($undoIgnoreList); %k++)
+         {
+            if(%field $= getWord(%fieldNames, %k)) //specialty field, we can't 'redo' it
+                %skip = true;
+         }
+         if (%skip)         
+            continue;
+            
          %object.setFieldValue(%field, %this.newFieldValues[%object, %field]);
       }
       // null out the fields in the null list


### PR DESCRIPTION
of variable names for the editor's genericundoaction to ignore mostly aimed at action buttons