### PR TITLE
filter inspector buttons out of the following:

### DIFF
--- a/Engine/source/console/persistenceManager.cpp
+++ b/Engine/source/console/persistenceManager.cpp
@@ -1358,7 +1358,7 @@ void PersistenceManager::updateObject(SimObject* object, ParsedObject* parentObj
       const AbstractClassRep::Field* f = &list[i];
 
       // Skip the special field types.
-      if ( f->type >= AbstractClassRep::ARCFirstCustomField )
+      if ( f->type >= AbstractClassRep::ARCFirstCustomField || f->flag.test(AbstractClassRep::FieldFlags::FIELD_ComponentInspectors))
          continue;
 
       for(U32 j = 0; S32(j) < f->elementCount; j++)

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -317,7 +317,7 @@ void SimObject::writeFields(Stream &stream, U32 tabStop)
       const AbstractClassRep::Field* f = &list[i];
 
       // Skip the special field types.
-      if ( f->type >= AbstractClassRep::ARCFirstCustomField )
+      if ( f->type >= AbstractClassRep::ARCFirstCustomField || f->flag.test(AbstractClassRep::FieldFlags::FIELD_ComponentInspectors))
          continue;
 
       for(U32 j = 0; S32(j) < f->elementCount; j++)
@@ -913,7 +913,7 @@ void SimObject::assignFieldsFrom(SimObject *parent)
             continue;
 
          // Skip the special field types.
-         if ( f->type >= AbstractClassRep::ARCFirstCustomField )
+         if ( f->type >= AbstractClassRep::ARCFirstCustomField || f->flag.test(AbstractClassRep::FieldFlags::FIELD_ComponentInspectors))
             continue;
             
          // Skip certain fields that we don't want to see copied so we don't
@@ -3255,7 +3255,7 @@ DefineEngineMethod( SimObject, getFieldCount, S32, (),,
       f = &list[i];
 
       // The special field types do not need to be counted.
-      if ( f->type >= AbstractClassRep::ARCFirstCustomField )
+      if ( f->type >= AbstractClassRep::ARCFirstCustomField || f->flag.test(AbstractClassRep::FieldFlags::FIELD_ComponentInspectors))
          numDummyEntries++;
    }
 
@@ -3280,7 +3280,7 @@ DefineEngineMethod( SimObject, getField, const char*, ( S32 index ),,
       f = &list[i];
 
       // The special field types can be skipped.
-      if ( f->type >= AbstractClassRep::ARCFirstCustomField )
+      if ( f->type >= AbstractClassRep::ARCFirstCustomField || f->flag.test(AbstractClassRep::FieldFlags::FIELD_ComponentInspectors))
          continue;
 
       if(currentField == index)

--- a/Engine/source/console/simSerialize.cpp
+++ b/Engine/source/console/simSerialize.cpp
@@ -48,7 +48,7 @@ bool SimObject::writeObject(Stream *stream)
 
    for(itr = fieldList.begin();itr != fieldList.end();itr++)
    {
-      if( itr->type >= AbstractClassRep::ARCFirstCustomField )
+      if( itr->type >= AbstractClassRep::ARCFirstCustomField || itr->flag.test(AbstractClassRep::FieldFlags::FIELD_ComponentInspectors))
       {
          numFields--;
          continue;


### PR DESCRIPTION
PersistenceManager::updateObject
SimObject::writeFields
SimObject::assignFieldsFrom
DefineEngineMethod( SimObject, getFieldCount, S32, (),, DefineEngineMethod( SimObject, getField, const char*, ( S32 index ),, SimObject::writeObject

do not do so for
SimObject::setDataField
DefineEngineMethod( SimObject, dump, void, ( bool detailed ), ( false ),