### PR TITLE
clean up malformed stream conversion

### DIFF
--- a/Engine/source/sfx/sfxMemoryStream.cpp
+++ b/Engine/source/sfx/sfxMemoryStream.cpp
@@ -39,9 +39,10 @@ SFXMemoryStream::SFXMemoryStream( const SFXFormat& format,
 
 void SFXMemoryStream::reset()
 {
-   if( dynamic_cast< IResettable* >( getSourceStream() ) )
+   IResettable* rStream = dynamic_cast<IResettable*>(getSourceStream());
+   if(rStream )
    {
-      reinterpret_cast< IResettable* >( getSourceStream() )->reset();
+      rStream->reset();
       
       if( mCurrentPacket )
          destructSingle( mCurrentPacket );


### PR DESCRIPTION
reinterpret_cast was misaligning the pointer. just use the already leveraged dynamic_cast