### PR TITLE
remove arbitrary impact sound spam

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -5075,8 +5075,12 @@ F32 Player::_doCollisionImpact( const Collision *collision, bool fallingCollisio
    if ( ((bd > mDataBlock->minImpactSpeed && fallingCollision) || bd > mDataBlock->minLateralImpactSpeed) 
       && !mMountPending )
    {
-      if ( !isGhost() )
-         onImpact( collision->object, collision->normal * bd );
+      if (!isGhost())
+      {
+         onImpact(collision->object, collision->normal * bd);
+         mImpactSound = PlayerData::ImpactNormal;
+         setMaskBits(ImpactMask);
+      }
 
       if (mDamageState == Enabled && mState != RecoverState) 
       {
@@ -5099,13 +5103,6 @@ F32 Player::_doCollisionImpact( const Collision *collision, bool fallingCollisio
             setState(RecoverState, recover);
          }
       }
-   }
-
-   if ( isServerObject() && 
-      (bd > (mDataBlock->minImpactSpeed / 3.0f) || bd > (mDataBlock->minLateralImpactSpeed / 3.0f )) ) 
-   {
-      mImpactSound = PlayerData::ImpactNormal;
-      setMaskBits(ImpactMask);
    }
 
    return bd;


### PR DESCRIPTION
1) don't call them when onimpact threshold isn't crossed. 2) *definitely* don't call them with an arbirtary /3 threshold