### PR TITLE
extended onCreateGame functionality

### DIFF
--- a/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/levelLoad.tscript
@@ -139,7 +139,7 @@ function loadMissionStage3()
    
    // Construct MOD paths
    pathOnMissionLoadDone();
-
+   getRootScene().callOnChildren("onCreateGame");
    // Mission loading done...
    echo("*** Mission loaded");
 
@@ -152,6 +152,16 @@ function loadMissionStage3()
    %hasGameMode = callGamemodeFunction("onMissionStart");
    
 }
+
+function GameBase::onCreateGame(%this)
+{
+    %db = %this.getDatablock();
+    if (%db.isMethod("onCreateGame"))
+    {
+        %db.onCreateGame(%this);
+    }
+}
+
 function endMission()
 {
    if (!isObject( getScene(0) ))


### PR DESCRIPTION
now also trips on object instances and datablock namespaces ensures there's a generic hook for post-load processing for objects created by a scene to reference other objects created during that process