### PR TITLE
when pasting, ensure you add a unique name

### DIFF
--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -487,6 +487,10 @@ bool WorldEditor::pasteSelection( bool dropSel )
       if ( !obj )
          continue;
 
+      StringTableEntry baseName = obj->getName();
+      String outName = (baseName != StringTable->EmptyString()) ? Sim::getUniqueName(baseName) : StringTable->EmptyString();
+      obj->assignName(outName);
+
       if (targetGroup)
          targetGroup->addObject( obj );
 


### PR DESCRIPTION
object names are namespaces, so they cannot match or it confuses the lookup tables