### PR TITLE
Adds a callback invoke for objects in the scene to inform them if the level is being saved

### DIFF
--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.tscript
@@ -328,7 +328,13 @@ function EditorSaveMission()
    // now write the terrain and mission files out:
 
    if(EWorldEditor.isDirty || ETerrainEditor.isMissionDirty)
+   {
+      //Inform objects a save is happening, in case there is any special pre-save behavior a class needs to do
+      getScene(0).callOnChildren("onSaving", $Server::MissionFile);
+   
       getScene(0).save($Server::MissionFile);
+      
+   }
    if(ETerrainEditor.isDirty)
    {
       // Find all of the terrain files


### PR DESCRIPTION
Adds a callback invoke for objects in the scene to inform them if the level is being saved. Allows for certain special actions, like having objects reset to an original position before the save occurs.