### PR TITLE
Misc BaseGame fixes

### DIFF
--- a/Templates/BaseGame/game/data/UI/guis/GameMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/GameMenu.tscript
@@ -1,6 +1,7 @@
 function GameMenu::onAdd(%this)
 {
    %this.gameMenusArray = new ArrayObject(){};
+   %this.currentMenuIdx = 0;
 }
 
 function GameMenu::onWake(%this)

--- a/Templates/BaseGame/game/data/UI/scripts/utility.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/utility.tscript
@@ -57,9 +57,9 @@ function getButtonBitmap(%device, %button)
          %assetId = %assetId @ "Right_Stick";
       else if(%button $= "thumblx" || %button $= "thumbly")
          %assetId = %assetId @ "Left_Stick";
-      else if(%button $= "start")
+      else if(%button $= "start" || %button $= "btn_start" )
          %assetId = %assetId @ "Options";
-      else if(%button $= "back")
+      else if(%button $= "back"|| %button $= "btn_back")
          %assetId = %assetId @ "Share";   
       else if(%button $= "dpadu")
          %assetId = %assetId @ "Dpad_Up";  
@@ -96,9 +96,9 @@ function getButtonBitmap(%device, %button)
          %assetId = %assetId @ "Right_Stick";
       else if(%button $= "thumblx" || %button $= "thumbly")
          %assetId = %assetId @ "Left_Stick";
-      else if(%button $= "start")
+      else if(%button $= "start" || %button $= "btn_start" )
          %assetId = %assetId @ "Plus";
-      else if(%button $= "back")
+      else if(%button $= "back" || %button $= "btn_back" )
          %assetId = %assetId @ "Minus";   
       else if(%button $= "dpadu")
          %assetId = %assetId @ "Dpad_Up";  
@@ -142,9 +142,9 @@ function getButtonBitmap(%device, %button)
          %assetId = %assetId @ "Right_Stick";
       else if(%button $= "thumblx" || %button $= "thumbly")
          %assetId = %assetId @ "Left_Stick";
-      else if(%button $= "start")
+      else if(%button $= "start" || %button $= "btn_start" )
          %assetId = %assetId @ "Menu";
-      else if(%button $= "back")
+      else if(%button $= "back" || %button $= "btn_back" )
          %assetId = %assetId @ "Windows";   
       else if(%button $= "dpadu")
          %assetId = %assetId @ "Dpad_Up";  

--- a/Templates/BaseGame/game/data/defaults.tscript
+++ b/Templates/BaseGame/game/data/defaults.tscript
@@ -51,6 +51,8 @@ $pref::Video::disablePixSpecular = false;
 
 $pref::Video::disableCubemapping = false;
 
+$pref::PostFX::EnableHDRBloom = true;
+
 ///
 $pref::Video::enableParallaxMapping = true;
 

--- a/Templates/BaseGame/game/tools/forestEditor/forestEditorGui.tscript
+++ b/Templates/BaseGame/game/tools/forestEditor/forestEditorGui.tscript
@@ -301,6 +301,12 @@ function ForestEditorGui::onActiveForestUpdated( %this, %forest, %createNew )
                         %this @ ".createForest();", "" );
       return;                                                         
    }  
+   
+   if(%gotForest)
+   {
+      EWorldEditor.isDirty = true;
+      ForestEditorPlugin.dirty = true;
+   }
 }
 
 /// Called from a message box when a forest is not found.

--- a/Templates/BaseGame/game/tools/gui/messageBoxes/messageBox.ed.tscript
+++ b/Templates/BaseGame/game/tools/gui/messageBoxes/messageBox.ed.tscript
@@ -134,6 +134,7 @@ function toolsMessageBoxOK(%title, %message, %callback)
 {
    MBOKFrame.text = %title;
    Canvas.pushDialog(toolsMessageBoxOKDlg);
+   MBOKFrame.selectWindow();
    MBSetText(MBOKText, MBOKFrame, %message);
    toolsMessageBoxOKDlg.callback = %callback;
 }
@@ -147,6 +148,7 @@ function toolsMessageBoxOKCancel(%title, %message, %callback, %cancelCallback)
 {
    MBOKCancelFrame.text = %title;
    Canvas.pushDialog(toolsMessageBoxOKCancelDlg);
+   MBOKCancelFrame.selectWindow();
    MBSetText(MBOKCancelText, MBOKCancelFrame, %message);
    toolsMessageBoxOKCancelDlg.callback = %callback;
    toolsMessageBoxOKCancelDlg.cancelCallback = %cancelCallback;
@@ -169,6 +171,8 @@ function toolsMessageBoxOKCancelDetails(%title, %message, %details, %callback, %
    MBOKCancelDetailsFrame.setText( %title );
    
    Canvas.pushDialog(toolsMessageBoxOKCancelDetailsDlg);
+   MBOKCancelDetailsFrame.selectWindow();
+   
    MBSetText(MBOKCancelDetailsText, MBOKCancelDetailsFrame, %message);
    MBOKCancelDetailsInfoText.setText(%details);
    
@@ -233,6 +237,7 @@ function toolsMessageBoxYesNo(%title, %message, %yesCallback, %noCallback)
    MBYesNoFrame.text = %title;
    toolsMessageBoxYesNoDlg.profile = "GuiOverlayProfile";
    Canvas.pushDialog(toolsMessageBoxYesNoDlg);
+   MBYesNoFrame.selectWindow();
    MBSetText(MBYesNoText, MBYesNoFrame, %message);
    toolsMessageBoxYesNoDlg.yesCallBack = %yesCallback;
    toolsMessageBoxYesNoDlg.noCallback = %noCallBack;
@@ -243,6 +248,7 @@ function toolsMessageBoxYesNoCancel(%title, %message, %yesCallback, %noCallback,
    MBYesNoCancelFrame.text = %title;
    toolsMessageBoxYesNoDlg.profile = "GuiOverlayProfile";
    Canvas.pushDialog(toolsMessageBoxYesNoCancelDlg);
+   MBYesNoCancelFrame.selectWindow();
    MBSetText(MBYesNoCancelText, MBYesNoCancelFrame, %message);
    toolsMessageBoxYesNoCancelDlg.yesCallBack = %yesCallback;
    toolsMessageBoxYesNoCancelDlg.noCallback = %noCallBack;
@@ -264,6 +270,7 @@ function MessagePopup(%title, %message, %delay)
    // Currently two lines max.
    MessagePopFrame.setText(%title);
    Canvas.pushDialog(MessagePopupDlg);
+   MessagePopFrame.selectWindow();
    MBSetText(MessagePopText, MessagePopFrame, %message);
    if (%delay !$= "")
       schedule(%delay, 0, CloseMessagePopup);
@@ -279,6 +286,7 @@ function IODropdown(%title, %message, %simgroup, %callback, %cancelCallback)
 {
    IODropdownFrame.text = %title;
    Canvas.pushDialog(IODropdownDlg);
+   IODropdownFrame.selectWindow();
    MBSetText(IODropdownText, IODropdownFrame, %message);
    
    if(isObject(%simgroup))

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
@@ -749,6 +749,8 @@ function EditorGui::addCameraBookmark( %this, %name )
    
    EWorldEditor.isDirty = true;
    EditorTree.buildVisibleTree(true);
+   
+   return %obj;
 }
 
 function EditorGui::removeCameraBookmark( %this, %name )
@@ -813,7 +815,9 @@ function EditorGui::addCameraBookmarkByGui( %this )
          break;
       }
    }
-   EditorGui.addCameraBookmark( %name );
+   %obj = EditorGui.addCameraBookmark( %name );
+
+   return %obj;
 }
 
 function EditorGui::toggleCameraBookmarkWindow( %this )


### PR DESCRIPTION
* Ensures the HDRBloom pref is properly set as part of the default settings
* Adds a few input names to the bitmap button lookup for the BaseUI logic
* Properly defaults the current menu index for the GameMenu gui
* Ensures that all editing actions for forest editor flag the editor/map as dirty for saving
* Ensures editor messageBoxes are properly focused on popping up
* Returns the newly created camera bookmark objects from their create functions