### PR TITLE
resolve ambiguity

### DIFF
--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -488,7 +488,7 @@ bool WorldEditor::pasteSelection( bool dropSel )
          continue;
 
       StringTableEntry baseName = obj->getName();
-      String outName = (baseName != StringTable->EmptyString()) ? Sim::getUniqueName(baseName) : StringTable->EmptyString();
+      const char * outName = (baseName != StringTable->EmptyString()) ? Sim::getUniqueName(baseName).c_str() : StringTable->EmptyString();
       obj->assignName(outName);
 
       if (targetGroup)


### PR DESCRIPTION
clang + ninja via clion disliked a string assignment from a case that could feed a string either another string or a char *, soi used the latter acroiss the board