### PR TITLE
temp workaround for material editor crash

### DIFF
--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -745,8 +745,9 @@ function MaterialEditorGui::setActiveMaterial( %this, %material )
    MaterialEditorGui.lastMaterial = %material;
    
    // we create or recreate a material to hold in a pristine state
-   if(isObject(notDirtyMaterial))
-      notDirtyMaterial.delete();
+   // or, this crashes the ap. fix properly - BJR
+//   if(isObject(notDirtyMaterial))
+//      notDirtyMaterial.delete();
       
    singleton Material(notDirtyMaterial)
    {


### PR DESCRIPTION
selection swapping is causing an apcrash
notDirtyMaterial.delete(); *should* work, but we know what they say about assumptions. supressing deletion of workspace material kill off and recreation pending proper review