### PR TITLE
fix non player class pathshape jitter

### DIFF
--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -1729,11 +1729,7 @@ void SceneObject::updateRenderChangesByParent(){
 		//add the "offset" caused by the parents change, and add it to it's own
 		// This is needed by objects that update their own render transform thru interpolate tick
 		// Mostly for stationary objects.
-
-          if (getClassName() == StringTable->insert("Player"))
-			mat.mul(offset,getRenderTransform());  
-		else										
-			mat.mul(offset,getTransform());	 
+      mat.mul(offset,getRenderTransform());
 			setRenderTransform(mat);
 	}
 }


### PR DESCRIPTION
everything has a consistent getRenderTransform() nowadays