### PR TITLE
Fix zip archive reading.

### DIFF
--- a/Engine/source/CMakeLists.txt
+++ b/Engine/source/CMakeLists.txt
@@ -97,7 +97,7 @@ endif (WIN32 AND TORQUE_D3D11)
 
 # Handle core
 torqueAddSourceDirectories("core" "core/stream" "core/strings" "core/util"
-                              "core/util/journal" "core/util/zip" "core/util/compressors")
+                              "core/util/journal" "core/util/zip" "core/util/zip/compressors")
 # Handle GUI
 torqueAddSourceDirectories("gui" "gui/buttons" "gui/containers" "gui/controls" "gui/core"
                               "gui/game" "gui/shiny" "gui/utility" "gui/3d")

--- a/Engine/source/gfx/bitmap/gBitmap.cpp
+++ b/Engine/source/gfx/bitmap/gBitmap.cpp
@@ -1279,9 +1279,14 @@ template<> void *Resource<GBitmap>::create(const Torque::Path &path)
    const String extension = path.getExtension();
    if( !bmp->readBitmap( extension, path ) )
    {
-      Con::errorf( "Resource<GBitmap>::create - error reading '%s'", path.getFullPath().c_str() );
-      delete bmp;
-      bmp = NULL;
+      // we can only get here if the stream was successful, so attempt to read the stream.
+      Con::warnf("Was unable to load as file, going to try the stream instead.");
+      if (!bmp->readBitmapStream(extension, stream, stream.getStreamSize()))
+      {
+         Con::errorf("Resource<GBitmap>::create - error reading '%s'", path.getFullPath().c_str());
+         delete bmp;
+         bmp = NULL;
+      }
    }
 
    return bmp;

--- a/Engine/source/gfx/bitmap/loaders/bitmapSTB.cpp
+++ b/Engine/source/gfx/bitmap/loaders/bitmapSTB.cpp
@@ -200,8 +200,7 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
       if (!stbErr)
          stbErr = "Unknown Error!";
 
-      Con::errorf("STB failed to get image info: %s", stbErr);
-      return false;
+      Con::errorf("STB get file info: %s", stbErr);
    }
 
    // do this to map 2 channels to 4, 2 channel not supported by gbitmap yet..
@@ -331,8 +330,7 @@ bool sReadStreamSTB(Stream& stream, GBitmap* bitmap, U32 len)
       if (!stbErr)
          stbErr = "Unknown Error!";
 
-      Con::errorf("STB failed to get image info: %s", stbErr);
-      Con::warnf("Going to attempt to load stream anyway.");
+      Con::errorf("STB get memory info: %s", stbErr);
    }
 
    S32 reqCom = comp;

--- a/Engine/source/gfx/bitmap/loaders/bitmapSTB.cpp
+++ b/Engine/source/gfx/bitmap/loaders/bitmapSTB.cpp
@@ -195,6 +195,12 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
    if (!stbi_info(path.getFullPath().c_str(), &x, &y, &channels))
    {
       FrameAllocator::setWaterMark(prevWaterMark);
+      const char* stbErr = stbi_failure_reason();
+
+      if (!stbErr)
+         stbErr = "Unknown Error!";
+
+      Con::errorf("STB failed to get image info: %s", stbErr);
       return false;
    }
 
@@ -326,7 +332,7 @@ bool sReadStreamSTB(Stream& stream, GBitmap* bitmap, U32 len)
          stbErr = "Unknown Error!";
 
       Con::errorf("STB failed to get image info: %s", stbErr);
-      return false;
+      Con::warnf("Going to attempt to load stream anyway.");
    }
 
    S32 reqCom = comp;

--- a/Engine/source/ts/assimp/assimpShapeLoader.cpp
+++ b/Engine/source/ts/assimp/assimpShapeLoader.cpp
@@ -261,38 +261,40 @@ void AssimpShapeLoader::processAnimations()
 
    Vector<aiNodeAnim*> ambientChannels;
    F32 duration = 0.0f;
-
-   for (U32 i = 0; i < mScene->mNumAnimations; ++i)
+   if (mScene->mNumAnimations > 0)
    {
-      aiAnimation* anim = mScene->mAnimations[i];
-      for (U32 j = 0; j < anim->mNumChannels; j++)
+      for (U32 i = 0; i < mScene->mNumAnimations; ++i)
       {
-         aiNodeAnim* nodeAnim = anim->mChannels[j];
-         // Determine the maximum keyframe time for this animation
-         F32 maxKeyTime = 0.0f;
-         for (U32 k = 0; k < nodeAnim->mNumPositionKeys; k++) {
-            maxKeyTime = getMax(maxKeyTime, (F32)nodeAnim->mPositionKeys[k].mTime);
-         }
-         for (U32 k = 0; k < nodeAnim->mNumRotationKeys; k++) {
-            maxKeyTime = getMax(maxKeyTime, (F32)nodeAnim->mRotationKeys[k].mTime);
-         }
-         for (U32 k = 0; k < nodeAnim->mNumScalingKeys; k++) {
-            maxKeyTime = getMax(maxKeyTime, (F32)nodeAnim->mScalingKeys[k].mTime);
-         }
+         aiAnimation* anim = mScene->mAnimations[i];
+         for (U32 j = 0; j < anim->mNumChannels; j++)
+         {
+            aiNodeAnim* nodeAnim = anim->mChannels[j];
+            // Determine the maximum keyframe time for this animation
+            F32 maxKeyTime = 0.0f;
+            for (U32 k = 0; k < nodeAnim->mNumPositionKeys; k++) {
+               maxKeyTime = getMax(maxKeyTime, (F32)nodeAnim->mPositionKeys[k].mTime);
+            }
+            for (U32 k = 0; k < nodeAnim->mNumRotationKeys; k++) {
+               maxKeyTime = getMax(maxKeyTime, (F32)nodeAnim->mRotationKeys[k].mTime);
+            }
+            for (U32 k = 0; k < nodeAnim->mNumScalingKeys; k++) {
+               maxKeyTime = getMax(maxKeyTime, (F32)nodeAnim->mScalingKeys[k].mTime);
+            }
 
-         ambientChannels.push_back(nodeAnim);
+            ambientChannels.push_back(nodeAnim);
 
-         duration = getMax(duration, maxKeyTime);
+            duration = getMax(duration, maxKeyTime);
+         }
       }
+
+      ambientSeq->mNumChannels = ambientChannels.size();
+      ambientSeq->mChannels = ambientChannels.address();
+      ambientSeq->mDuration = duration;
+      ambientSeq->mTicksPerSecond = 24.0;
+
+      AssimpAppSequence* defaultAssimpSeq = new AssimpAppSequence(ambientSeq);
+      appSequences.push_back(defaultAssimpSeq);
    }
-
-   ambientSeq->mNumChannels = ambientChannels.size();
-   ambientSeq->mChannels = ambientChannels.address();
-   ambientSeq->mDuration = duration;
-   ambientSeq->mTicksPerSecond = 24.0;
-
-   AssimpAppSequence* defaultAssimpSeq = new AssimpAppSequence(ambientSeq);
-   appSequences.push_back(defaultAssimpSeq);
 }
 
 void AssimpShapeLoader::computeBounds(Box3F& bounds)

--- a/Templates/BaseGame/game/data/Prototyping/shapes/kork_chanShape.asset.taml
+++ b/Templates/BaseGame/game/data/Prototyping/shapes/kork_chanShape.asset.taml
@@ -1,6 +1,0 @@
-<ShapeAsset
-    AssetName="kork_chanShape"
-    fileName="@assetFile=kork_chanShape.fbx"
-    constuctorFileName="@assetFile=kork_chanShape.tscript"
-    materialSlot0="@asset=Prototyping:kork_chan_mat"
-    originalFilePath="C:/dev/T3D/PRs/MiscFixes20220525/Templates/BaseGame/game/data/Prototyping/shapes/kork_chanShape.fbx"/>

--- a/Templates/BaseGame/game/data/Prototyping/shapes/kork_chanShape.tscript
+++ b/Templates/BaseGame/game/data/Prototyping/shapes/kork_chanShape.tscript
@@ -1,28 +1,8 @@
-//--- OBJECT WRITE BEGIN ---
-new TSShapeConstructor(kork_chanShape_fbx) {
-   baseShapeAsset = "Prototyping:kork_chanShape";
-   upAxis = "DEFAULT";
-   unit = "-1";
-   LODType = "TrailingNumber";
+
+singleton TSShapeConstructor(kork_chanShapefbx)
+{
+   baseShapeAsset = ":kork_chanShape_shape";
    singleDetailSize = "0";
-   IgnoreNodeScale = "0";
-   AdjustCenter = "0";
-   AdjustFloor = "0";
-   forceUpdateMaterials = "0";
-   convertLeftHanded = "0";
-   calcTangentSpace = "0";
-   genUVCoords = "0";
-   transformUVCoords = "0";
-   flipUVCoords = "1";
-   findInstances = "0";
-   limitBoneWeights = "0";
-   JoinIdenticalVerts = "1";
-   reverseWindingOrder = "1";
-   invertNormals = "0";
-   removeRedundantMats = "1";
-   animTiming = "Seconds";
+   neverImportMat = "DefaultMaterial	ColorEffect*";
    animFPS = "2";
-   canSave = "1";
-   canSaveDynamicFields = "1";
 };
-//--- OBJECT WRITE END ---

--- a/Templates/BaseGame/game/data/Prototyping/shapes/kork_chanShape_shape.asset.taml
+++ b/Templates/BaseGame/game/data/Prototyping/shapes/kork_chanShape_shape.asset.taml
@@ -1,0 +1,5 @@
+<ShapeAsset
+    AssetName="kork_chanShape_shape"
+    fileName="@assetFile=kork_chanShape.fbx"
+    constuctorFileName="@assetFile=kork_chanShape.tscript"
+    materialSlot0="@asset=Prototyping:kork_chan_mat"/>

--- a/Templates/BaseGame/game/data/Prototyping/shapes/kork_chan_image.asset.taml
+++ b/Templates/BaseGame/game/data/Prototyping/shapes/kork_chan_image.asset.taml
@@ -1,4 +1,3 @@
 <ImageAsset
     AssetName="kork_chan_image"
-    imageFile="@assetFile=kork_chan.png"
-    originalFilePath="C:/dev/T3D/PRs/MiscFixes20220525/Templates/BaseGame/game/data/Prototyping/shapes/kork_chan.png"/>
+    imageFile="@assetFile=kork_chan.png"/>

--- a/Templates/BaseGame/game/data/Prototyping/shapes/kork_chan_mat.asset.taml
+++ b/Templates/BaseGame/game/data/Prototyping/shapes/kork_chan_mat.asset.taml
@@ -5,12 +5,11 @@
     <Material
         Name="kork_chan_mat"
         mapTo="kork_chan"
-        alphaTest="true"
-        alphaRef="100">
+        doubleSided="true"
+        originalAssetName="kork_chan_mat">
         <Material.Stages>
             <Stages_beginarray
-                DiffuseMapAsset="Prototyping:kork_chan_image"
-                doubleSided="true"/>
+                DiffuseMapAsset="Prototyping:kork_chan_image"/>
         </Material.Stages>
     </Material>
 </MaterialAsset>


### PR DESCRIPTION
Incorrect cmake directory was messing up reading from zips 

STB was failing to read from zips, it was failing to get the file info, something we were using as an early out, now if that fails on the filepath, we use the memory read instead since stream needs to be a success to get to that point.