### PR TITLE
TORQUE_TOOLS off compile fix

### DIFF
--- a/Engine/source/console/consoleFunctions.h
+++ b/Engine/source/console/consoleFunctions.h
@@ -18,7 +18,12 @@ void gotoWebPage(const char* address);
 bool getDocsURL(void* obj, const char* array, const char* data);
 const char* getDocsLink(const char* filename, U32 lineNumber);
 
+#ifdef TORQUE_TOOLS
 #define docsURL addGroup("Ungrouped");\
                 addProtectedField("docsURL", TypeBool, Offset(mDocsClick, ConsoleObject), &getDocsURL, &defaultProtectedGetFn, getDocsLink(__FILE__,__LINE__), AbstractClassRep::FieldFlags::FIELD_ComponentInspectors);\
                 endGroup("Ungrouped")
+#else
+#define docsURL NULL
+#endif
+
 #endif

--- a/Engine/source/gui/editor/guiMenuBar.cpp
+++ b/Engine/source/gui/editor/guiMenuBar.cpp
@@ -581,6 +581,7 @@ PopupMenu* GuiMenuBar::findMenu(String barTitle)
 //-----------------------------------------------------------------------------
 // Console Methods
 //-----------------------------------------------------------------------------
+#ifdef TORQUE_TOOLS
 DefineEngineMethod(GuiMenuBar, attachToCanvas, void, (const char *canvas, S32 pos), , "(GuiCanvas, pos)")
 {
    GuiCanvas* canv = dynamic_cast<GuiCanvas*>(Sim::findObject(canvas));
@@ -597,6 +598,7 @@ DefineEngineMethod(GuiMenuBar, removeFromCanvas, void, (), , "()")
    if(canvas)
       canvas->setMenuBar(nullptr);
 }
+#endif
 
 DefineEngineMethod(GuiMenuBar, getMenuCount, S32, (), , "()")
 {


### PR DESCRIPTION
fix a cornercase for when TORQUE_TOOLS is #undef at the torqueconfig.h level