### PR TITLE
macosx changes

### DIFF
--- a/Engine/source/core/resource.h
+++ b/Engine/source/core/resource.h
@@ -194,7 +194,7 @@ template<class T> class ResourceHolder : public ResourceHolderBase
 {
 public:
    ResourceHolder(T *t) : ResourceHolderBase(t) {}
-   virtual ~ResourceHolder() { delete ((T*)mRes); }
+   virtual ~ResourceHolder() { mRes = static_cast<T*>(mRes); SAFE_DELETE(mRes); }
 };
 
 // Resource template.  When dealing with resources, this is the

--- a/Engine/source/core/resource.h
+++ b/Engine/source/core/resource.h
@@ -47,6 +47,8 @@
 #include "platform/platformAssert.h"
 #endif
 
+#include <memory>
+
 class ResourceManager;
 
 // This is a utility class used by the resource manager.
@@ -62,17 +64,18 @@ class ResourceHolderBase
 public:
    static FreeListChunker<ResourceHolderBase> smHolderFactory;
 
-   ResourceHolderBase() : mRes(NULL) { ; } // @note this is needed for the chunked allocator
+   ResourceHolderBase() = default; // Default constructor
    virtual ~ResourceHolderBase() {}
-   
+
    // Return void pointer to resource data.
-   void *getResource() const { return mRes; }
+   void* getResource() const { return mRes.get(); }
 
 protected:
    // Construct a resource holder pointing at 'p'.
-   ResourceHolderBase(void *p) : mRes(p) {}
+   template<typename T>
+   ResourceHolderBase(T* p) : mRes(p, [](void*) {}) {}
 
-   void *mRes;
+   std::unique_ptr<void, void(*)(void*)> mRes{ nullptr, [](void*) {} };
 };
 
 // All resources are derived from this type.  The base type
@@ -85,7 +88,7 @@ protected:
 class ResourceBase
 {
    friend class ResourceManager;
- 
+
 protected:
    class Header;
 
@@ -131,7 +134,7 @@ protected:
       virtual void destroySelf();
 
    private:
-      
+
       friend class ResourceBase;
       friend class ResourceManager;
 
@@ -182,7 +185,7 @@ protected:
 
       return sLoadSignal;
    }
-   
+
    virtual void _triggerPostLoadSignal() {}
    virtual NotifyUnloadFn _getNotifyUnloadFn() { return ( NotifyUnloadFn ) NULL; }
 };
@@ -190,11 +193,17 @@ protected:
 // This is a utility class used by resource manager.  Classes derived
 // from this template pretty much just know how to delete the template's
 // type.
-template<class T> class ResourceHolder : public ResourceHolderBase
+template<class T>
+class ResourceHolder : public ResourceHolderBase
 {
 public:
-   ResourceHolder(T *t) : ResourceHolderBase(t) {}
-   virtual ~ResourceHolder() { mRes = static_cast<T*>(mRes); SAFE_DELETE(mRes); }
+   ResourceHolder(T* t) : ResourceHolderBase(t) {}
+   virtual ~ResourceHolder() {
+      if (mRes) {
+         T* typedmRes = static_cast<T*>(mRes.get());
+         typedmRes->~T(); // Call the destructor explicitly
+      }
+   }
 };
 
 // Resource template.  When dealing with resources, this is the
@@ -234,7 +243,7 @@ public:
       static Signal<bool(const Torque::Path &, void**)>   sLoadSignal;
       return sLoadSignal;
    }
-   
+
    /// Register with this signal to get notified when resources of this type
    /// have been loaded.
    static Signal< void( Resource< T >& ) >& getPostLoadSignal()
@@ -242,7 +251,7 @@ public:
       static Signal< void( Resource< T >& ) > sPostLoadSignal;
       return sPostLoadSignal;
    }
-   
+
    /// Register with this signal to get notified when resources of this type
    /// are about to get unloaded.
    static Signal< void( const Torque::Path&, T* ) >& getUnloadSignal()
@@ -260,9 +269,9 @@ private:
    ResourceHolderBase   *createHolder(void *);
 
    Signal<bool(const Torque::Path &, void**)>   &getStaticLoadSignal() { return getLoadSignal(); }
-   
+
    static void _notifyUnload( const Torque::Path& path, void* resource ) { getUnloadSignal().trigger( path, ( T* ) resource ); }
-   
+
    virtual void _triggerPostLoadSignal() { getPostLoadSignal().trigger( *this ); }
    virtual NotifyUnloadFn _getNotifyUnloadFn() { return ( NotifyUnloadFn ) &_notifyUnload; }
 
@@ -303,7 +312,7 @@ template< class T >
 class ResourceRegisterPostLoadSignal
 {
    public:
-   
+
       ResourceRegisterPostLoadSignal( Delegate< void( Resource< T >& ) > func )
       {
          Resource< T >::getPostLoadSignal().notify( func );
@@ -314,7 +323,7 @@ template< class T >
 class ResourceRegisterUnloadSignal
 {
    public:
-   
+
       ResourceRegisterUnloadSignal( Delegate< void( const Torque::Path&, T* ) > func )
       {
          Resource< T >::getUnloadSignal().notify( func );

--- a/Engine/source/testing/resourceTest.cpp
+++ b/Engine/source/testing/resourceTest.cpp
@@ -1,0 +1,97 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2014 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+#include "unitTesting.h"
+
+#include "platform/platform.h"
+
+#include "core/util/fourcc.h"
+#include "console/console.h"
+#include "core/resourceManager.h"
+static bool destructorCalled;
+
+struct TestResource
+{
+public:
+   U64 values[4] = { 0,0,0,0 };
+   virtual ~TestResource() { destructorCalled = true; }
+
+   static Resource< TestResource > load(const Torque::Path& path);
+   static ResourceRegisterPostLoadSignal< TestResource > _smAutoLoad;
+   static void _onTestLoaded(Resource< TestResource >& test);
+};
+
+template<> ResourceBase::Signature  Resource<TestResource>::signature()
+{
+   return MakeFourCC('T', 'E', 'S', 'T'); // Direct Draw Surface
+}
+template<> void* Resource<TestResource>::create(const Torque::Path& path)
+{
+   TestResource* testRes = new TestResource;
+
+   return testRes;
+}
+
+Resource<TestResource> TestResource::load(const Torque::Path& path)
+{
+   Resource<TestResource> testRes = ResourceManager::get().load(path);
+
+   return testRes;
+}
+
+ResourceRegisterPostLoadSignal< TestResource > TestResource::_smAutoLoad(&TestResource::_onTestLoaded);
+
+void TestResource::_onTestLoaded(Resource<TestResource>& test)
+{
+   test->values[0] = 1;
+   test->values[1] = 1;
+   test->values[2] = 1;
+   test->values[3] = 1;
+}
+TEST(ResourceManagerTests, All_Resource_Functionality)
+{
+   if (true)
+   {
+      Resource<TestResource> testRes;
+
+      testRes = TestResource::load("empty");
+
+      EXPECT_EQ(testRes.signature(), MakeFourCC('T', 'E', 'S', 'T')) << "Incorrect resource type returned!";
+
+      EXPECT_EQ(testRes.getPath(), "empty") << "Wrong path!";
+
+      U64 postLoadValues[4];
+      postLoadValues[0] = 1;
+      postLoadValues[1] = 1;
+      postLoadValues[2] = 1;
+      postLoadValues[3] = 1;
+
+      for (U32 i = 0; i < 4; i++)
+      {
+         EXPECT_EQ(testRes->values[i], postLoadValues[i]) << "Array not equal";
+      }
+
+      EXPECT_EQ(destructorCalled, false) << "Destructor true should be false";
+   }
+
+   EXPECT_EQ(destructorCalled, true) << "Destructor false should be true";
+}
+

--- a/Templates/BaseGame/game/core/rendering/scripts/gfxData/shaders.tscript
+++ b/Templates/BaseGame/game/core/rendering/scripts/gfxData/shaders.tscript
@@ -182,7 +182,7 @@ singleton ShaderData( ThickLineGUI )
    DXGeometryShaderFile = $Core::CommonShaderPath @ "/fixedFunction/thickLineG.hlsl";
    DXPixelShaderFile    = $Core::CommonShaderPath @ "/fixedFunction/thickLineP.hlsl";
 
-   OGLVertexShaderFile   = $Core::CommonShaderPath @ "/fixedFunction/gl/colorV.glsl";
+   OGLVertexShaderFile   = $Core::CommonShaderPath @ "/fixedFunction/gl/thickLineV.glsl";
    OGLGeometryShaderFile = $Core::CommonShaderPath @ "/fixedFunction/gl/thickLineG.glsl";
    OGLPixelShaderFile    = $Core::CommonShaderPath @ "/fixedFunction/gl/thickLineP.glsl";
       

--- a/Templates/BaseGame/game/core/rendering/shaders/fixedFunction/gl/thickLineV.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/fixedFunction/gl/thickLineV.glsl
@@ -1,0 +1,39 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2012 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+#include "../../gl/hlslCompat.glsl"
+
+in vec4 vPosition;
+in vec4 vColor;
+
+uniform mat4 modelview;
+
+out VS_OUT {
+    vec4 color;
+} vs_out;
+
+
+void main()
+{
+   gl_Position = tMul(modelview, vPosition);
+   correctSSP(gl_Position);
+   vs_out.color = vColor;
+}


### PR DESCRIPTION
changes required to get masox to run.

Some further changes are possibly required around resourceHolder in future.

The geometry shader works in macosx with gl version 3.3, though i do think some changes are required internally to account for a lack of OUT_col