### PR TITLE
SFXResource was unnecessarily creating SFXFileStreams

### DIFF
--- a/Engine/source/sfx/sfxResource.cpp
+++ b/Engine/source/sfx/sfxResource.cpp
@@ -64,10 +64,11 @@ Resource< SFXResource > SFXResource::load( String filename )
    return ResourceManager::get().load( filename );
 }
 
-SFXResource::SFXResource( String fileName, SFXStream *stream )
+SFXResource::SFXResource( String fileName, const ThreadSafeRef<SFXStream>& stream)
    : mFileName( fileName ),
      mFormat( stream->getFormat() ),
-     mDuration( stream->getDuration() )
+     mDuration( stream->getDuration() ),
+     mStream(stream)
 {
 }
 
@@ -76,7 +77,7 @@ bool SFXResource::exists( String filename )
    return SFXFileStream::exists( filename );
 }
 
-SFXStream* SFXResource::openStream()
+ThreadSafeRef<SFXStream> SFXResource::openStream()
 {
-   return SFXFileStream::create( mFileName );
+   return mStream;
 }

--- a/Engine/source/sfx/sfxResource.h
+++ b/Engine/source/sfx/sfxResource.h
@@ -30,9 +30,9 @@
    #include "core/resource.h"
 #endif
 
-
-class SFXStream;
-
+#ifndef _SFXSTREAM_H_
+#include "sfx/sfxStream.h"
+#endif
 
 /// This is the base class for all sound file resources including
 /// streamed sound files.  It acts much like an always in-core
@@ -68,10 +68,12 @@ class SFXResource
 
       /// The length of the sample in milliseconds.
       U32 mDuration;
+
+      ThreadSafeRef<SFXStream> mStream;
       
       /// Construct a resource instance for the given file.  Format and duration
       /// are read from the given stream.
-      SFXResource( String fileName, SFXStream* stream );
+      SFXResource( String fileName, const ThreadSafeRef<SFXStream>& stream);
       
    public:
 
@@ -103,7 +105,7 @@ class SFXResource
       const SFXFormat& getFormat() const { return mFormat; }
 
       /// Open a stream for reading the resource's sample data.
-      SFXStream* openStream();
+      ThreadSafeRef<SFXStream> openStream();
 
       // Internal.
       struct _NewHelper;


### PR DESCRIPTION
SFXResource was always creating a new file for each sound resource. Sometimes this would happen 3 times since the asset was creating a resource, then the profile, then the object that was using it.

Now if the sfxResource exists and we call openStream it returns the sfxFileStream linked to that file instead of just creating a new one.