### PR TITLE
Update bitmapSTB.cpp

### DIFF
--- a/Engine/source/gfx/bitmap/loaders/bitmapSTB.cpp
+++ b/Engine/source/gfx/bitmap/loaders/bitmapSTB.cpp
@@ -328,19 +328,8 @@ bool sReadStreamSTB(Stream& stream, GBitmap* bitmap, U32 len)
    stream.read(len, data);
 
    S32 width, height, comp = 0;
-   if (stbi_info_from_memory(data, len, &width, &height, &comp))
-   {
-      const char* stbErr = stbi_failure_reason();
 
-      if (!stbErr)
-         stbErr = "Unknown Error!";
-
-      Con::errorf("STB get memory info: %s", stbErr);
-   }
-
-   S32 reqCom = comp;
-
-   unsigned char* pixelData = stbi_load_from_memory((const U8*)data, (int)len, &width, &height, &comp, reqCom);
+   unsigned char* pixelData = stbi_load_from_memory((const U8*)data, (int)len, &width, &height, &comp, 0);
 
    if (!pixelData)
    {


### PR DESCRIPTION
stb loader was spamming NO SOI with the function of stbi_info_from_memory because it checks for a jpeg first. This will always return an error if you are sending any other format. Remove this check and just load the memory stream. if it fails to return pixeldata then we have an error.