### PR TITLE
shift capturing from a globalMacro to a sceneRenderstate S32

### DIFF
--- a/Engine/source/materials/processedCustomMaterial.cpp
+++ b/Engine/source/materials/processedCustomMaterial.cpp
@@ -328,6 +328,7 @@ bool ProcessedCustomMaterial::setupPass( SceneRenderState *state, const SceneDat
 
    shaderConsts->setSafe(rpd->shaderHandles.mAccumTimeSC, MATMGR->getTotalTime());
    shaderConsts->setSafe(rpd->shaderHandles.mDampnessSC, MATMGR->getDampnessClamped());
+   shaderConsts->setSafe(rpd->shaderHandles.mIsCapturingSC, state ? (S32)state->isCapturing() : 0);
    
    return true;
 }

--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -115,6 +115,8 @@ void ShaderConstHandles::init( GFXShader *shader, CustomMaterial* mat /*=NULL*/)
    // MFT_HardwareSkinning
    mNodeTransforms = shader->getShaderConstHandle( "$nodeTransforms" );
 
+   mIsCapturingSC = shader->getShaderConstHandle(ShaderGenVars::isCapturing);
+
    // Clear any existing texture handles.
    dMemset( mTexHandlesSC, 0, sizeof( mTexHandlesSC ) );
    if(mat)
@@ -1093,6 +1095,8 @@ void ProcessedShaderMaterial::_setShaderConstants(SceneRenderState * state, cons
    shaderConsts->setSafe( handles->mAccumTimeSC, MATMGR->getTotalTime() );
 
    shaderConsts->setSafe(handles->mDampnessSC, MATMGR->getDampnessClamped());
+   shaderConsts->setSafe(handles->mIsCapturingSC, (S32)state->isCapturing());
+   
    // If the shader constants have not been lost then
    // they contain the content from a previous render pass.
    //

--- a/Engine/source/materials/processedShaderMaterial.h
+++ b/Engine/source/materials/processedShaderMaterial.h
@@ -104,6 +104,7 @@ public:
 
    GFXShaderConstHandle* mNodeTransforms;
 
+   GFXShaderConstHandle* mIsCapturingSC;
    struct customHandleData
    {
 	   StringTableEntry handleName;

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -498,7 +498,8 @@ PostEffect::PostEffect()
       mMatCameraToWorldSC( NULL),
       mInvCameraTransSC(NULL),
       mMatCameraToScreenSC(NULL),
-      mMatScreenToCameraSC(NULL)
+      mMatScreenToCameraSC(NULL),
+      mIsCapturingSC(NULL)
 {
    dMemset( mTexSRGB, 0, sizeof(bool) * NumTextures);
    dMemset( mActiveTextures, 0, sizeof( GFXTextureObject* ) * NumTextures );
@@ -798,7 +799,11 @@ void PostEffect::_setupConstants( const SceneRenderState *state )
       mInvCameraTransSC = mShader->getShaderConstHandle("$invCameraTrans");
       mMatCameraToScreenSC = mShader->getShaderConstHandle("$cameraToScreen");
       mMatScreenToCameraSC = mShader->getShaderConstHandle("$screenToCamera");
+      mIsCapturingSC = mShader->getShaderConstHandle("$isCapturing");
    }
+
+   if (mIsCapturingSC->isValid())
+      mShaderConsts->set(mIsCapturingSC, (S32)state->isCapturing());
 
    // Set up shader constants for source image size
    if ( mRTSizeSC->isValid() )

--- a/Engine/source/postFx/postEffect.h
+++ b/Engine/source/postFx/postEffect.h
@@ -164,6 +164,8 @@ protected:
    GFXShaderConstHandle *mMatCameraToScreenSC;
    GFXShaderConstHandle *mMatScreenToCameraSC;
 
+   GFXShaderConstHandle* mIsCapturingSC;
+
    bool mAllowReflectPass;
 
    /// If true update the shader.

--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -503,47 +503,13 @@ void RenderProbeMgr::reloadTextures()
 void RenderProbeMgr::preBake()
 {
    RenderProbeMgr::smBakeReflectionProbes = true;
-   GFXShader::addGlobalMacro("CAPTURING", String("1"));
-
-   //Con::setVariable("$Probes::Capturing", "1");
-   mRenderMaximumNumOfLights = AdvancedLightBinManager::smMaximumNumOfLights;
-   mRenderUseLightFade = AdvancedLightBinManager::smUseLightFade;
-
-   AdvancedLightBinManager::smMaximumNumOfLights = -1;
-   AdvancedLightBinManager::smUseLightFade = false;
-
-   //kickstart rendering
-   LightManager* lm = LIGHTMGR;
-   if (lm)
-   {
-      SceneManager* sm = lm->getSceneManager();
-      if (sm && sm->getContainer() == &gClientContainer)
-      {
-         lm->deactivate();
-         lm->activate(sm);
-      }
-   }
+   Con::setBoolVariable("$ReflectionProbes::Capturing", RenderProbeMgr::smBakeReflectionProbes);
 }
 
 void RenderProbeMgr::postBake()
 {
    RenderProbeMgr::smBakeReflectionProbes = false;
-   GFXShader::addGlobalMacro("CAPTURING", String("0"));
-   //Con::setVariable("$Probes::Capturing", "0");
-   AdvancedLightBinManager::smMaximumNumOfLights = mRenderMaximumNumOfLights;
-   AdvancedLightBinManager::smUseLightFade = mRenderUseLightFade;
-
-   //kickstart rendering
-   LightManager* lm = LIGHTMGR;
-   if (lm)
-   {
-      SceneManager* sm = lm->getSceneManager();
-      if (sm && sm->getContainer() == &gClientContainer)
-      {
-         lm->deactivate();
-         lm->activate(sm);
-      }
-   }
+   Con::setBoolVariable("$ReflectionProbes::Capturing", RenderProbeMgr::smBakeReflectionProbes);
 }
 
 void RenderProbeMgr::bakeProbe(ReflectionProbe* probe)

--- a/Engine/source/scene/sceneRenderState.h
+++ b/Engine/source/scene/sceneRenderState.h
@@ -223,6 +223,7 @@ class SceneRenderState
       /// Returns true if this is not one of the other rendering passes.
       bool isOtherPass() const { return mScenePassType >= SPT_Other; }
 
+      bool isCapturing() const { return Con::getBoolVariable("$ReflectionProbes::Capturing", false); };
       /// @}
 
       /// @name Render Style

--- a/Engine/source/shaderGen/shaderGenVars.cpp
+++ b/Engine/source/shaderGen/shaderGenVars.cpp
@@ -74,6 +74,8 @@ const String ShaderGenVars::vectorLightDirection("$vectorLightDirection");
 const String ShaderGenVars::vectorLightColor("$vectorLightColor");
 const String ShaderGenVars::vectorLightBrightness("$vectorLightBrightness");
 
+const String ShaderGenVars::isCapturing("$isCapturing");
+
 const String ShaderGenVars::ormConfig("$ORMConfig");
 const String ShaderGenVars::roughness("$roughness");
 const String ShaderGenVars::metalness("$metalness");

--- a/Engine/source/shaderGen/shaderGenVars.h
+++ b/Engine/source/shaderGen/shaderGenVars.h
@@ -86,6 +86,8 @@ struct ShaderGenVars
    const static String vectorLightColor;
    const static String vectorLightBrightness;
 
+   const static String isCapturing;
+
    const static String ormConfig;
    const static String roughness;
    const static String metalness;

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
@@ -222,9 +222,9 @@ void main()
    float horizonOcclusion = 1.3;
    float horizon = saturate( 1 + horizonOcclusion * dot(surface.R, surface.N));
    horizon *= horizon;
-#if CAPTURING == 1
-   OUT_col = vec4(mix((irradiance + specular* horizon),surface.baseColor.rgb, surface.metalness),0);
-#else
-   OUT_col = vec4((irradiance + specular* horizon)*ambientColor, 0);//alpha writes disabled
-#endif
+   
+   if(isCapturing == 1)
+      OUT_col = vec4(mix((irradiance + specular* horizon),surface.baseColor.rgb, surface.metalness),0);
+   else
+      OUT_col = vec4((irradiance + specular* horizon)*ambientColor, 0);//alpha writes disabled
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/reflectionProbeArrayP.hlsl
@@ -208,9 +208,9 @@ float4 main(PFXVertToPix IN) : SV_TARGET
    float horizonOcclusion = 1.3;
    float horizon = saturate( 1 + horizonOcclusion * dot(surface.R, surface.N));
    horizon *= horizon;
-#if CAPTURING == 1
-    return float4(lerp((irradiance + specular* horizon), surface.baseColor.rgb,surface.metalness),0);
-#else
-   return float4((irradiance + specular* horizon)*ambientColor, 0);//alpha writes disabled   
-#endif
+   
+   if(isCapturing == 1)
+      return float4(lerp((irradiance + specular* horizon), surface.baseColor.rgb,surface.metalness),0);
+   else
+      return float4((irradiance + specular* horizon)*ambientColor, 0);//alpha writes disabled
 }


### PR DESCRIPTION
lets us ditch shader recompilation so that can be done on the fly without hitches, though does cost us a per-shader const for objects and postfx