### PR TITLE
Test PR for generating cubemap mips

### DIFF
--- a/Engine/source/T3D/lighting/IBLUtilities.cpp
+++ b/Engine/source/T3D/lighting/IBLUtilities.cpp
@@ -171,7 +171,7 @@ namespace IBLUtilities
             prefilterConsts->setSafe(prefilterRoughnessSC, roughness);
             prefilterConsts->setSafe(prefilterMipSizeSC, mipSize);
             U32 size = prefilterSize * mPow(0.5f, mip);
-            renderTarget->attachTexture(GFXTextureTarget::Color0, cubemapOut, face, mip);
+            renderTarget->attachTexture(GFXTextureTarget::Color0, cubemapOut, face);
             GFX->setActiveRenderTarget(renderTarget, false);//we set the viewport ourselves
             GFX->setViewport(RectI(0, 0, size, size));
             GFX->clear(GFXClearTarget, LinearColorF::BLACK, 1.0f, 0);

--- a/Engine/source/gfx/D3D11/gfxD3D11Cubemap.h
+++ b/Engine/source/gfx/D3D11/gfxD3D11Cubemap.h
@@ -37,6 +37,7 @@ public:
    void initStatic( GFXTexHandle *faces ) override;
    void initStatic( DDSFile *dds ) override;
    void initDynamic( U32 texSize, GFXFormat faceFormat = GFXFormatR8G8B8A8, U32 mipLevels = 0) override;
+   void generateMipMaps() override;
    void setToTexUnit( U32 tuNum ) override;
    U32 getSize() const override { return mTexSize; }
    GFXFormat getFormat() const override { return mFaceFormat; }
@@ -52,7 +53,7 @@ public:
 
    // Get functions
    ID3D11ShaderResourceView* getSRView();
-   ID3D11RenderTargetView* getRTView(U32 faceIdx, U32 mipIndex=0);
+   ID3D11RenderTargetView* getRTView(U32 faceIdx);
    ID3D11DepthStencilView* getDSView();
    ID3D11Texture2D* get2DTex();
 
@@ -63,7 +64,7 @@ private:
 
    ID3D11Texture2D* mTexture;
    ID3D11ShaderResourceView* mSRView; // for shader resource input
-   ID3D11RenderTargetView* mRTView[CubeFaces][MaxMipMaps]; // for render targets, 6 faces of the cubemap
+   ID3D11RenderTargetView* mRTView[CubeFaces]; // for render targets, 6 faces of the cubemap
    ID3D11DepthStencilView* mDSView; //render target view for depth stencil
 
    bool mAutoGenMips;

--- a/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
@@ -217,7 +217,7 @@ void GFXD3D11TextureTarget::attachTexture( RenderSlot slot, GFXCubemap *tex, U32
 
    mTargets[slot] = cube->get2DTex();
    mTargets[slot]->AddRef();
-   mTargetViews[slot] = cube->getRTView(face, mipLevel);
+   mTargetViews[slot] = cube->getRTView(face);
    mTargetViews[slot]->AddRef();
    mTargetSRViews[slot] = cube->getSRView();
    mTargetSRViews[slot]->AddRef();

--- a/Engine/source/gfx/Null/gfxNullDevice.cpp
+++ b/Engine/source/gfx/Null/gfxNullDevice.cpp
@@ -162,6 +162,7 @@ public:
    void initStatic( GFXTexHandle *faces ) override { };
    void initStatic( DDSFile *dds ) override { };
    void initDynamic( U32 texSize, GFXFormat faceFormat = GFXFormatR8G8B8A8, U32 mipLevels = 0) override { };
+   void generateMipMaps() override {}
    U32 getSize() const override { return 0; }
    GFXFormat getFormat() const override { return GFXFormatR8G8B8A8; }
 

--- a/Engine/source/gfx/gfxCubemap.h
+++ b/Engine/source/gfx/gfxCubemap.h
@@ -70,6 +70,7 @@ public:
    /// Returns the size of the faces.
    virtual U32 getSize() const = 0;
 
+   virtual void generateMipMaps() = 0;
    /// Returns the face texture format.
    virtual GFXFormat getFormat() const = 0;
 

--- a/Engine/source/gfx/gl/gfxGLCubemap.cpp
+++ b/Engine/source/gfx/gl/gfxGLCubemap.cpp
@@ -225,6 +225,10 @@ void GFXGLCubemap::initDynamic(U32 texSize, GFXFormat faceFormat, U32 mipLevels)
     mInitialized = true;
 }
 
+void GFXGLCubemap::generateMipMaps()
+{
+}
+
 void GFXGLCubemap::zombify()
 {
    glDeleteTextures(1, &mCubemap);

--- a/Engine/source/gfx/gl/gfxGLCubemap.h
+++ b/Engine/source/gfx/gl/gfxGLCubemap.h
@@ -43,6 +43,7 @@ public:
    void initStatic( GFXTexHandle *faces ) override;
    void initStatic( DDSFile *dds ) override;
    void initDynamic( U32 texSize, GFXFormat faceFormat = GFXFormatR8G8B8A8, U32 mipLevels = 0) override;
+   void generateMipMaps() override;
    U32 getSize() const override { return mWidth; }
    GFXFormat getFormat() const override { return mFaceFormat; }
 

--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -652,9 +652,10 @@ void RenderProbeMgr::bakeProbe(ReflectionProbe* probe)
       clientProbe->mPrefilterMap->mCubemap->initDynamic(resolution, reflectFormat);
 
       GFXTextureTargetRef renderTarget = GFX->allocRenderToTextureTarget(false);
+      clientProbe->mPrefilterMap->mCubemap = cubeRefl.getCubemap();
 
       IBLUtilities::GenerateIrradianceMap(renderTarget, cubeRefl.getCubemap(), clientProbe->mIrridianceMap->mCubemap);
-      IBLUtilities::GeneratePrefilterMap(renderTarget, cubeRefl.getCubemap(), prefilterMipLevels, clientProbe->mPrefilterMap->mCubemap);
+      //IBLUtilities::GeneratePrefilterMap(renderTarget, cubeRefl.getCubemap(), prefilterMipLevels, clientProbe->mPrefilterMap->mCubemap);
 
       U32 endMSTime = Platform::getRealMilliseconds();
       F32 diffTime = F32(endMSTime - startMSTime);

--- a/Engine/source/scene/reflector.cpp
+++ b/Engine/source/scene/reflector.cpp
@@ -338,7 +338,8 @@ void CubeReflector::updateReflection( const ReflectParams &params, Point3F expli
 
    for ( U32 i = 0; i < 6; i++ )
       updateFace( params, i, explicitPostion);
-   
+
+   mCubemap->generateMipMaps();
 
    GFX->popActiveRenderTarget();
 


### PR DESCRIPTION
note ibl skips prefilter step and prefilter just becomes the cubeRefl.getCubemap()

Generates cubemap mip levels after the bake correctly on DX side.