### PR TITLE
Adds a sanity check to SimObject's setFieldValue console method

### DIFF
--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -3072,6 +3072,13 @@ DefineEngineMethod( SimObject, setFieldValue, bool, ( const char* fieldName, con
 {
    char fieldNameBuffer[ 1024 ];
    char arrayIndexBuffer[ 64 ];
+
+   if( !fieldName || !fieldName[0] )
+   {
+      AssertFatal(false, "SimObject::setFieldValue - Invalid field name.");
+      Con::errorf( "SimObject::setFieldValue - Invalid field name." );
+      return false;
+   }
    
    // Parse out index if the field is given in the form of 'name[index]'.
    


### PR DESCRIPTION
Adds a sanity check to SimObject's setFieldValue console method so if you pass in a blank field name it doesn't crash, instead asserting in debug, and logging the error in release