### PR TITLE
Add cstdint to ies_loader

### DIFF
--- a/Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp
+++ b/Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp
@@ -37,7 +37,6 @@
 #include "ies_loader.h"
 #include <assert.h>
 #include <algorithm>
-#include <cstdint>
 #include <functional>
 
 #include "math/mMathFn.h"

--- a/Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp
+++ b/Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp
@@ -34,6 +34,7 @@
 // | (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // | OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // +----------------------------------------------------------------------
+#include "ies_loader.h"
 #include <assert.h>
 #include <algorithm>
 #include <cstdint>

--- a/Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp
+++ b/Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp
@@ -34,7 +34,6 @@
 // | (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // | OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // +----------------------------------------------------------------------
-#include "ies_loader.h"
 #include <assert.h>
 #include <algorithm>
 #include <cstdint>

--- a/Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp
+++ b/Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp
@@ -37,6 +37,7 @@
 #include "ies_loader.h"
 #include <assert.h>
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 
 #include "math/mMathFn.h"

--- a/Engine/source/gfx/bitmap/loaders/ies/ies_loader.h
+++ b/Engine/source/gfx/bitmap/loaders/ies/ies_loader.h
@@ -37,6 +37,7 @@
 #ifndef _H_IES_LOADER_H_
 #define _H_IES_LOADER_H_
 
+#include <cstdint>
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
On a Ubuntu install with gcc 11.4.0, Torque3D builds fine without any modifications. On my Void Linux install however, which uses gcc 13.2.0, `Engine/source/gfx/bitmap/loaders/ies/ies_loader.cpp` and `Engine/source/gfx/bitmap/loaders/ies/ies_loader.h` fail to build.
Adding `#include <cstdint>` to these files fixes the issue, I have also tested this modification on Ubuntu (with gcc 11) and it builds just fine.