### PR TITLE
work around collide not returning false with a null object

### DIFF
--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -1999,7 +1999,7 @@ void WorldEditor::on3DMouseMove(const Gui3DMouseEvent & event)
    if ( !mHitObject )
    {
       SceneObject *hitObj = NULL;
-      if ( collide(event, &hitObj) && !hitObj->isDeleted() && hitObj->isSelectionEnabled() && !objClassIgnored(hitObj) )
+      if ( collide(event, &hitObj) && hitObj && !hitObj->isDeleted() && hitObj->isSelectionEnabled() && !objClassIgnored(hitObj) )
       {
          mHitObject = hitObj;
       }
@@ -2060,7 +2060,7 @@ void WorldEditor::on3DMouseDown(const Gui3DMouseEvent & event)
    }   
 
    SceneObject *hitObj = NULL;
-   if ( collide( event, &hitObj ) && hitObj->isSelectionEnabled() && !objClassIgnored( hitObj ) )
+   if ( collide( event, &hitObj ) && hitObj && hitObj->isSelectionEnabled() && !objClassIgnored( hitObj ) )
    {
       mPossibleHitObject = hitObj;
       mNoMouseDrag = true;


### PR DESCRIPTION
fix a crash caused by having boundingBoxCollision on, while projecting the mouse so that there is nothing between it and a globalbounds object it would seem we're somehow ending up in a state of WorldEditor::collide returning true it hit somethging, but NULL as far as *what* until we properly fix this, doublecheck to make sure the hitObject isn't NULL before we start trying to reference membervars/methods