### PR TITLE
file write clarifications

### DIFF
--- a/Engine/source/core/fileObject.cpp
+++ b/Engine/source/core/fileObject.cpp
@@ -85,18 +85,18 @@ FileObject::FileObject()
    mFileBuffer = NULL;
    mBufferSize = 0;
    mCurPos = 0;
-   stream = NULL;
+   mStream = NULL;
 }
 
 FileObject::~FileObject()
 {
    SAFE_DELETE_ARRAY(mFileBuffer);
-   SAFE_DELETE(stream);
+   SAFE_DELETE(mStream);
 }
 
 void FileObject::close()
 {
-   SAFE_DELETE(stream);
+   SAFE_DELETE(mStream);
    SAFE_DELETE_ARRAY(mFileBuffer);
    mFileBuffer = NULL;
    mBufferSize = mCurPos = 0;
@@ -112,10 +112,10 @@ bool FileObject::openForWrite(const char *fileName, const bool append)
    if( !buffer[ 0 ] )
       return false;
 
-   if((stream = FileStream::createAndOpen( fileName, append ? Torque::FS::File::WriteAppend : Torque::FS::File::Write )) == NULL)
+   if((mStream = FileStream::createAndOpen( fileName, append ? Torque::FS::File::WriteAppend : Torque::FS::File::Write )) == NULL)
       return false;
 
-   stream->setPosition( stream->getStreamSize() );
+   mStream->setPosition(mStream->getStreamSize() );
    return( true );
 }
 
@@ -225,17 +225,17 @@ void FileObject::peekLine( S32 peekLineOffset, U8* line, S32 length )
 
 void FileObject::writeLine(const U8 *line)
 {
-   stream->write(dStrlen((const char *) line), line);
-   stream->write(2, "\r\n");
+   mStream->write(dStrlen((const char *) line), line);
+   mStream->write(2, "\r\n");
 }
 
 void FileObject::writeObject( SimObject* object, const U8* objectPrepend )
 {
    if( objectPrepend == NULL )
-      stream->write(2, "\r\n");
+      mStream->write(2, "\r\n");
    else
-      stream->write(dStrlen((const char *) objectPrepend), objectPrepend );
-   object->write( *stream, 0 );
+      mStream->write(dStrlen((const char *) objectPrepend), objectPrepend );
+   object->write( *mStream, 0 );
 }
 
 DefineEngineMethod( FileObject, openForRead, bool, ( const char* filename ),,

--- a/Engine/source/core/fileObject.h
+++ b/Engine/source/core/fileObject.h
@@ -36,7 +36,7 @@ class FileObject : public SimObject
    U8 *mFileBuffer;
    U32 mBufferSize;
    U32 mCurPos;
-   FileStream *stream;
+   FileStream *mStream;
 public:
    FileObject();
    ~FileObject();
@@ -50,6 +50,8 @@ public:
    bool isEOF();
    void writeLine(const U8 *line);
    void close();
+
+   bool writeObject(Stream* stream) override { Con::errorf("FileObject:Can Not write a file interface object to a file"); return false; }; //Don't allow writing FileObject *to* files
    void writeObject( SimObject* object, const U8* objectPrepend = NULL );
 
    DECLARE_CONOBJECT(FileObject);

--- a/Engine/source/module/moduleDefinition.h
+++ b/Engine/source/module/moduleDefinition.h
@@ -194,6 +194,8 @@ public:
     inline void             setModuleLocked( const bool status )                { mLocked = status; }
     inline bool             getModuleLocked( void ) const                       { return mLocked; }
     inline ModuleManager*   getModuleManager( void ) const                      { return mpModuleManager; }
+
+    using Parent::save;
     bool                    save( void );
 
     /// Declare Console Object.

--- a/Engine/source/persistence/taml/taml.h
+++ b/Engine/source/persistence/taml/taml.h
@@ -111,6 +111,7 @@ private:
     void compileCustomState( TamlWriteNode* pTamlWriteNode );
     void compileCustomNodeState( TamlCustomNode* pCustomNode );
 
+    void write(Stream& stream, U32 tabStop, U32 flags = 0) override { Con::errorf("Taml:Can Not write a file interface object to a file"); }; //Don't allow writing Taml objects *to* files
     bool write( FileStream& stream, SimObject* pSimObject, const TamlFormatMode formatMode );
     SimObject* read( FileStream& stream, const TamlFormatMode formatMode );
     template<typename T> inline T* read( FileStream& stream, const TamlFormatMode formatMode )

--- a/Engine/source/util/settings.h
+++ b/Engine/source/util/settings.h
@@ -52,6 +52,7 @@ public:
    const UTF8 *value(const UTF8 *settingName, const UTF8 *defaultValue = "");
    void remove(const UTF8 *settingName, bool includeDefaults = false);
    void clearAllFields();
+   void write(Stream& stream, U32 tabStop, U32 flags = 0) override { Con::errorf("Settings: Can Not write a file interface object to a file"); }; //Don't allow writing Settings objects *to* files
    bool write();
    bool read();
    void readLayer(SimXMLDocument *document, String groupStack = String(""));


### PR DESCRIPTION
handle clang complaints about hidden virtuals in the context of file writes that have thier own routes and I/O needs.