### PR TITLE
fix guiwindowCTRL callback

### DIFF
--- a/Engine/source/gui/containers/guiWindowCtrl.cpp
+++ b/Engine/source/gui/containers/guiWindowCtrl.cpp
@@ -66,7 +66,7 @@ IMPLEMENT_CALLBACK( GuiWindowCtrl, onCollapse, void, (), (),
    "Called when the window is collapsed by clicking its title bar." );
 IMPLEMENT_CALLBACK( GuiWindowCtrl, onRestore, void, (), (),
    "Called when the window is restored from minimized, maximized, or collapsed state." );
-IMPLEMENT_CALLBACK(GuiWindowCtrl, onResize, void, (S32 posX, S32 posY, S32 width, S32 height), (0, 0, 0, 0),
+IMPLEMENT_CALLBACK(GuiWindowCtrl, onResize, void, (S32 posX, S32 posY, S32 width, S32 height), (posX, posY, width, height),
    "Called when the window is resized in a regular manner by mouse manipulation.");
 IMPLEMENT_CALLBACK(GuiWindowCtrl, onMouseDragged, void, (), (),
    "Called when the height has changed.");

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -2892,3 +2892,13 @@ function AssetBrowserWindow::releasePanel(%this)
    
    EditorGui.updateSideBar();
 }
+
+function AssetBrowserWindow::onResize(%this, %posX, %posY, %width, %height)
+{
+    if (%width>%height)
+        AssetBrowser-->assetList.fillRowFirst = true;
+    else
+        AssetBrowser-->assetList.fillRowFirst = false;
+        
+    AssetBrowser.doRebuildAssetArray();
+}


### PR DESCRIPTION
also set asset browser to use rows or columns depending on which dimension is longer