### PR TITLE
fix light emission point for shapebaseimaged

### DIFF
--- a/Engine/source/T3D/shapeImage.cpp
+++ b/Engine/source/T3D/shapeImage.cpp
@@ -3342,7 +3342,7 @@ void ShapeBase::submitLights( LightManager *lm, bool staticLighting )
             image.lightInfo->setType( LightInfo::Point );
 
          MatrixF imageMat;
-         getRenderImageTransform( i, &imageMat );
+         getRenderMuzzleTransform( i, &imageMat );
 
          image.lightInfo->setTransform( imageMat );
 


### PR DESCRIPTION
light generally comes from the muzzle of a gun, not the ground