### PR TITLE
Windowed Console button close / open / resize

### DIFF
--- a/Templates/BaseGame/game/tools/guiEditor/gui/guiEditor.ed.gui
+++ b/Templates/BaseGame/game/tools/guiEditor/gui/guiEditor.ed.gui
@@ -233,8 +233,37 @@ $guiContent = new GuiControl(GuiEditorGui, EditorGuiGroup) {
                internalName = "AssetBrowserBtn";
                canSave = "1";
                canSaveDynamicFields = "0";
-            };            
-            
+            };        
+            new GuiIconButtonCtrl() {
+               buttonMargin = "0 0";
+               bitmapAsset = "ToolsModule:console_n_image";
+               iconLocation = "Left";
+               sizeIconToButton = "0";
+               makeIconSquare = "0";
+               textLocation = "Center";
+               textMargin = "0";
+               autoSize = "0";
+               groupNum = "-1";
+               buttonType = "PushButton";
+               useMouseEvents = "0";
+               position = "132 0";
+               extent = "32 32";
+               minExtent = "8 2";
+               horizSizing = "right";
+               vertSizing = "bottom";
+               profile = "ToolsGuiDefaultProfile";
+               visible = "1";
+               active = "1";
+               command = "windowConsoleDlg.showWindow();";
+               tooltipProfile = "GuiToolTipProfile";
+               tooltip = "Open the console log in a window.";
+               hovertime = "1000";
+               isContainer = "0";
+               internalName = "ABwindowConsoleButton";
+               canSave = "1";
+               canSaveDynamicFields = "0";
+               buttonMargin = "-2 0";
+            };
             new GuiBitmapCtrl() {
                Enabled = "1";
                Profile = "ToolsGuiDefaultProfile";

--- a/Templates/BaseGame/game/tools/windowConsole/scripts/window_console.tscript
+++ b/Templates/BaseGame/game/tools/windowConsole/scripts/window_console.tscript
@@ -102,10 +102,23 @@ function windowConsoleDlg::hideWindow(%this)
 
 function windowConsoleDlg::showWindow(%this)
 {
-   $WindowConsole::Open = true;
-   Canvas.pushDialog(%this);
-   %this-->Scroll.setVisible(true);
+   if($WindowConsole::Open)
+   {
+      // close the window when it's already opened
+      windowConsoleDlg.hideWindow();
+   }
+   else
+   {
+      // open the console window
+      $WindowConsole::Open = true;
+      Canvas.pushDialog(%this);
+      %this-->Scroll.setVisible(true);
+      // update all the windows (position and size)
+      EditorGui.updateSideBar();
+   }
 }
+
+
 
 //-----------------------------------------------------------------------------
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
@@ -628,6 +628,7 @@ function EditorGui::updateSideBar(%this)
 {   
    if(GuiEditorIsActive())
    {
+      // Update the Asset Browser's size
       if(isObject(AssetBrowserWindow) && isObject(GuiEditorSidebar))
       {
          if(AssetBrowserWindow.docked == true)
@@ -637,6 +638,19 @@ function EditorGui::updateSideBar(%this)
             %browserHeight = AssetBrowserWindow.extent.y;
             %browserPosY = Canvas.extent.y - AssetBrowserWindow.extent.y - 33;
             AssetBrowserWindow.resize(0, %browserPosY, %browserWidth, %browserHeight);
+         }
+      }
+      
+      // Update the Windowed Console's size
+      if(isObject(windowConsoleControl) && isObject(GuiEditorSidebar))
+      {
+         if(windowConsoleControl.docked == true)
+         {
+            // The width is relative to the sidepanel
+            %consoleWidth = Canvas.extent.x - GuiEditorSidebar.extent.x;
+            %consoleHeight = windowConsoleControl.extent.y;
+            %consolePosY = Canvas.extent.y - windowConsoleControl.extent.y - 33;
+            windowConsoleControl.resize(0, %consolePosY, %consoleWidth, %consoleHeight);
          }
       }
       return;
@@ -2763,8 +2777,8 @@ function toggleSnappingOptions( %var )
    }
    else if( %var $= "grid" )
    {
-	  EWorldEditor.UseGridSnap = !EWorldEditor.UseGridSnap;
-	  EditorSettings.setValue("WorldEditor/Tools/UseGridSnap", EWorldEditor.UseGridSnap );
+ 	   EWorldEditor.UseGridSnap = !EWorldEditor.UseGridSnap;
+	   EditorSettings.setValue("WorldEditor/Tools/UseGridSnap", EWorldEditor.UseGridSnap );
       EWorldEditor.setGridSnap( EWorldEditor.UseGridSnap );
    }
    else if( %var $= "byGroup" )

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editors/terrainEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editors/terrainEditor.ed.tscript
@@ -636,7 +636,7 @@ function TerrainPainterContainer::maxSize(%this, %window)
       // --- Windowed Console --------------------------------------------------
       if(isObject(windowConsoleControl))
       {
-         // Only resize the AssetBrowser if it's docked
+         // Only resize the console if it's docked
          if(windowConsoleControl.docked == true)
          {
             // The width is relative to the sidepanel


### PR DESCRIPTION
- Close the windowed console when it's opened and the button is hit.
- Resize/reposition the window after reopening.
- Add a button to the GUI editor.