### PR TITLE
Add extra increased font size to Windowed Console

### DIFF
--- a/Templates/BaseGame/game/tools/gui/profiles.ed.tscript
+++ b/Templates/BaseGame/game/tools/gui/profiles.ed.tscript
@@ -1569,6 +1569,11 @@ new GuiControlProfile(ToolsGuiConsoleLargeProfile : ToolsGuiConsoleProfile)
 {
    fontSize = $GUI::fontSize[16];
 };
+if(!isObject(ToolsGuiConsoleXLProfile))
+new GuiControlProfile(ToolsGuiConsoleXLProfile : ToolsGuiConsoleProfile)
+{
+   fontSize = $GUI::fontSize[18];
+};
 if(!isObject(ToolsGuiConsoleTextProfile))
 new GuiControlProfile(ToolsGuiConsoleTextProfile)
 {   

--- a/Templates/BaseGame/game/tools/windowConsole/scripts/window_console.tscript
+++ b/Templates/BaseGame/game/tools/windowConsole/scripts/window_console.tscript
@@ -252,6 +252,10 @@ function windowConsoleDlg::incFont()
 {
    switch ($Con::font)
    {
+      case 16:
+         windowConsoleMessageLogView.setProfile(ToolsGuiConsoleXLProfile);
+         $Con::font = 18;
+         windowConsoleMessageLogView.refresh();
       case 14:
          windowConsoleMessageLogView.setProfile(ToolsGuiConsoleLargeProfile);
          $Con::font = 16;
@@ -274,6 +278,10 @@ function windowConsoleDlg::decFont()
       case 16:
          windowConsoleMessageLogView.setProfile(ToolsGuiConsoleMediumProfile);
          $Con::font = 14;
+         windowConsoleMessageLogView.refresh();
+      case 18:
+         windowConsoleMessageLogView.setProfile(ToolsGuiConsoleLargeProfile);
+         $Con::font = 16;
          windowConsoleMessageLogView.refresh();
    }
 }


### PR DESCRIPTION
Added extra large font to the windowed console.  Use the [-A]  [A+] buttons to change the size.

Preferably would introduce "lineSpacing"  to the GuiConsole object for improved readability; as well to store this into the prefs.