### PR TITLE
fix forest editor failing to pop up a create new

### DIFF
--- a/Engine/source/forest/editor/forestEditorCtrl.cpp
+++ b/Engine/source/forest/editor/forestEditorCtrl.cpp
@@ -160,7 +160,7 @@ void ForestEditorCtrl::get3DCursor( GuiCursor *&cursor,
 
 void ForestEditorCtrl::on3DMouseDown( const Gui3DMouseEvent &evt )
 {   
-   if ( !mForest || !updateActiveForest( true ) )
+   if ( !mForest && !updateActiveForest( true ) )
       return;
 
    if ( mTool )


### PR DESCRIPTION
reminder note for if switches in c++, it it fails once in an or evaluation, that's it. it does not try other portions