### PR TITLE
Cubemap Baking DX11

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Cubemap.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Cubemap.cpp
@@ -231,7 +231,7 @@ void GFXD3D11Cubemap::initDynamic(U32 texSize, GFXFormat faceFormat, U32 mipLeve
       miscFlags |= D3D11_RESOURCE_MISC_GENERATE_MIPS;
    }
 
-   D3D11_TEXTURE2D_DESC desc;
+   D3D11_TEXTURE2D_DESC desc = {};
 
    desc.Width = mTexSize;
    desc.Height = mTexSize;
@@ -248,7 +248,7 @@ void GFXD3D11Cubemap::initDynamic(U32 texSize, GFXFormat faceFormat, U32 mipLeve
 
    HRESULT hr = D3D11DEVICE->CreateTexture2D(&desc, NULL, &mTexture);
 
-   D3D11_SHADER_RESOURCE_VIEW_DESC SMViewDesc;
+   D3D11_SHADER_RESOURCE_VIEW_DESC SMViewDesc = {};
    SMViewDesc.Format = GFXD3D11TextureFormat[mFaceFormat];
    SMViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
    SMViewDesc.TextureCube.MipLevels = -1;
@@ -272,13 +272,13 @@ void GFXD3D11Cubemap::initDynamic(U32 texSize, GFXFormat faceFormat, U32 mipLeve
       AssertFatal(false, "GFXD3D11Cubemap::initDynamic - CreateTexture2D call failure");
    }
 
-   D3D11_RENDER_TARGET_VIEW_DESC viewDesc;
-   viewDesc.Format = desc.Format;
-   viewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
-   viewDesc.Texture2DArray.ArraySize = 1;
-   viewDesc.Texture2DArray.MipSlice = 0;
    for (U32 i = 0; i < CubeFaces; i++)
    {
+      D3D11_RENDER_TARGET_VIEW_DESC viewDesc = {};
+      viewDesc.Format = desc.Format;
+      viewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+      viewDesc.Texture2DArray.ArraySize = 1;
+      viewDesc.Texture2DArray.MipSlice = 0;
       viewDesc.Texture2DArray.FirstArraySlice = i;
       hr = D3D11DEVICE->CreateRenderTargetView(mTexture, &viewDesc, &mRTView[i]);
 

--- a/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
@@ -190,12 +190,12 @@ void GFXD3D11TextureTarget::attachTexture( RenderSlot slot, GFXCubemap *tex, U32
    // Mark state as dirty so device can know to update.
    invalidateState();
 
-   // Release what we had, it's definitely going to change.
    SAFE_RELEASE(mTargetViews[slot]);
    SAFE_RELEASE(mTargets[slot]);
    SAFE_RELEASE(mTargetSRViews[slot]);
 
    mResolveTargets[slot] = NULL;
+   mGenMips = false;
 
    // Cast the texture object to D3D...
    AssertFatal(!tex || static_cast<GFXD3D11Cubemap*>(tex), "GFXD3DTextureTarget::attachTexture - invalid cubemap object.");
@@ -214,14 +214,14 @@ void GFXD3D11TextureTarget::attachTexture( RenderSlot slot, GFXCubemap *tex, U32
    }
 
    GFXD3D11Cubemap *cube = static_cast<GFXD3D11Cubemap*>(tex);
-
+   // Grab the surface level.
    mTargets[slot] = cube->get2DTex();
    mTargets[slot]->AddRef();
    mTargetViews[slot] = cube->getRTView(face);
    mTargetViews[slot]->AddRef();
-   mTargetSRViews[slot] = cube->getSRView();
-   mTargetSRViews[slot]->AddRef();
-   
+   /*mTargetSRViews[slot] = cube->getSRView();
+   mTargetSRViews[slot]->AddRef();*/
+
    // Update surface size
    if(slot == Color0)
    {

--- a/Engine/source/gfx/gfxCubemap.cpp
+++ b/Engine/source/gfx/gfxCubemap.cpp
@@ -45,19 +45,7 @@ GFXCubemap::~GFXCubemap()
 
 U32 GFXCubemap::zUpFaceIndex(const U32 index)
 {
-   switch (index)
-   {
-   case 2:
-      return 4;
-   case 3:
-      return 5;
-   case 4:
-      return 2;
-   case 5:
-      return 3;
-   default:
-      return index;
-   };
+   return index;
 }
 
 void GFXCubemap::initNormalize( U32 size )

--- a/Engine/source/math/mMatrix.h
+++ b/Engine/source/math/mMatrix.h
@@ -235,6 +235,14 @@ public:
    
    MatrixF& add( const MatrixF& m );
 
+   /// <summary>
+   /// Turns this matrix into a view matrix that looks at target.
+   /// </summary>
+   /// <param name="eye">The eye position.</param>
+   /// <param name="target">The target position/direction.</param>
+   /// <param name="up">The up direction.</param>
+   void LookAt(const VectorF& eye, const VectorF& target, const VectorF& up);
+
    /// Convenience function to allow people to treat this like an array.
    F32& operator ()(S32 row, S32 col) { return m[idx(col,row)]; }
    F32 operator ()(S32 row, S32 col) const { return m[idx(col,row)]; }
@@ -496,6 +504,35 @@ inline MatrixF& MatrixF::add( const MatrixF& a )
       m[ i ] += a.m[ i ];
       
    return *this;
+}
+
+inline void MatrixF::LookAt(const VectorF& eye, const VectorF& target, const VectorF& up)
+{
+   VectorF yAxis = target - eye;          // Forward
+   yAxis.normalize();
+
+   VectorF xAxis = mCross(up, yAxis);     // Right
+   xAxis.normalize();
+
+   VectorF zAxis = mCross(yAxis, xAxis);  // Up
+
+   // Right vector.
+   setColumn(0, xAxis);
+   m[12] = -mDot(xAxis, eye);
+
+   // Forward vector.
+   setColumn(1, yAxis);
+   m[13] = -mDot(yAxis, eye);
+
+   // Up vector.
+   setColumn(2, zAxis);
+   m[14] = -mDot(zAxis, eye);
+
+   m[3] = 0.0f;
+   m[7] = 0.0f;
+   m[11] = 0.0f;
+   m[15] = 1.0f;
+
 }
 
 inline void MatrixF::getColumn(S32 col, Point4F *cptr) const

--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -622,6 +622,7 @@ void RenderProbeMgr::bakeProbe(ReflectionProbe* probe)
 
       IBLUtilities::GenerateIrradianceMap(renderTarget, cubeRefl.getCubemap(), clientProbe->mIrridianceMap->mCubemap);
       //IBLUtilities::GeneratePrefilterMap(renderTarget, cubeRefl.getCubemap(), prefilterMipLevels, clientProbe->mPrefilterMap->mCubemap);
+      clientProbe->mIrridianceMap->mCubemap->generateMipMaps();
 
       U32 endMSTime = Platform::getRealMilliseconds();
       F32 diffTime = F32(endMSTime - startMSTime);


### PR DESCRIPTION
The key to this issue was to invert the order we were baking the faces. 

Not much of a fix but it works better than before need to get a proper fix. 

The way the issue is copying X+ into every other face but isnt doing it in the reverse order means the RTV for face 0 must be being replicated into all other faces.