### PR TITLE
Material Preview Renders a scene

### DIFF
--- a/Engine/source/T3D/aiPlayer.cpp
+++ b/Engine/source/T3D/aiPlayer.cpp
@@ -1322,7 +1322,7 @@ bool AIPlayer::checkInLos(GameBase* target, bool _useMuzzle, bool _checkEnabled)
       eyeMat.getColumn(3, &checkPoint );
    }
 
-   bool hit = !gServerContainer.castRay(checkPoint, target->getBoxCenter(), sAIPlayerLoSMask, &ri);
+   bool hit = !getActiveServerContainer()->castRay(checkPoint, target->getBoxCenter(), sAIPlayerLoSMask, &ri);
    enableCollision();
 
    for (S32 i = 0; i < mountCount; i++)

--- a/Engine/source/T3D/camera.cpp
+++ b/Engine/source/T3D/camera.cpp
@@ -1540,7 +1540,7 @@ void Camera::_validateEyePoint(F32 pos, MatrixF *mat)
                  ItemObjectType |
                  VehicleObjectType;
 
-      SceneContainer* pContainer = isServerObject() ? &gServerContainer : &gClientContainer;
+      SceneContainer* pContainer = isServerObject() ? getActiveServerContainer() : getActiveClientContainer();
       if (!pContainer->castRay(startPos, startPos - dir * 2.5 * pos, mask, &collision))
          endPos = startPos - dir * pos;
       else

--- a/Engine/source/T3D/debris.cpp
+++ b/Engine/source/T3D/debris.cpp
@@ -722,7 +722,7 @@ bool Debris::onAdd()
 
 
    // tell engine the debris exists
-   gClientSceneGraph->addObjectToScene(this);
+   getActiveClientScene()->addObjectToScene(this);
 
    removeFromProcessList();
    ClientProcessList::get()->addObject(this);

--- a/Engine/source/T3D/decal/decalManager.cpp
+++ b/Engine/source/T3D/decal/decalManager.cpp
@@ -660,7 +660,7 @@ DecalInstance* DecalManager::raycast( const Point3F &start, const Point3F &end, 
          
          RayInfo ri;
          bool containsPoint = false;
-         if ( gServerContainer.castRayRendered( start, end, STATIC_COLLISION_TYPEMASK, &ri ) )
+         if ( getActiveServerContainer()->castRayRendered( start, end, STATIC_COLLISION_TYPEMASK, &ri ) )
          {        
             Point2F poly[4];
             poly[0].set( inst->mPosition.x - (inst->mSize / 2), inst->mPosition.y + (inst->mSize / 2));

--- a/Engine/source/T3D/decal/decalManager.cpp
+++ b/Engine/source/T3D/decal/decalManager.cpp
@@ -61,12 +61,12 @@ MODULE_BEGIN( DecalManager )
    MODULE_INIT
    {
       gDecalManager = new DecalManager;
-      gClientSceneGraph->addObjectToScene( gDecalManager );
+      getActiveClientScene()->addObjectToScene( gDecalManager );
    }
    
    MODULE_SHUTDOWN
    {
-      gClientSceneGraph->removeObjectFromScene( gDecalManager );
+      getActiveClientScene()->removeObjectFromScene( gDecalManager );
       SAFE_DELETE( gDecalManager );
    }
 

--- a/Engine/source/T3D/fps/guiCrossHairHud.cpp
+++ b/Engine/source/T3D/fps/guiCrossHairHud.cpp
@@ -143,7 +143,7 @@ void GuiCrossHairHud::onRender(Point2I offset, const RectI &updateRect)
    control->disableCollision();
 
    RayInfo info;
-   if (gClientContainer.castRay(camPos, endPos, losMask, &info)) {
+   if (getActiveClientContainer()->castRay(camPos, endPos, losMask, &info)) {
       // Hit something... but we'll only display health for named
       // ShapeBase objects.  Could mask against the object type here
       // and do a static cast if it's a ShapeBaseObjectType, but this

--- a/Engine/source/T3D/fps/guiCrossHairHud.cpp
+++ b/Engine/source/T3D/fps/guiCrossHairHud.cpp
@@ -134,7 +134,7 @@ void GuiCrossHairHud::onRender(Point2I offset, const RectI &updateRect)
    // Extend the camera vector to create an endpoint for our ray
    Point3F endPos;
    cam.getColumn(1, &endPos);
-   endPos *= gClientSceneGraph->getVisibleDistance();
+   endPos *= getActiveClientScene()->getVisibleDistance();
    endPos += camPos;
 
    // Collision info. We're going to be running LOS tests and we

--- a/Engine/source/T3D/fps/guiShapeNameHud.cpp
+++ b/Engine/source/T3D/fps/guiShapeNameHud.cpp
@@ -188,7 +188,7 @@ void GuiShapeNameHud::onRender( Point2I, const RectI &updateRect)
    camFovCos = mCos(mDegToRad(camFovCos) / 2);
 
    // Visible distance info & name fading
-   F32 visDistance = gClientSceneGraph->getVisibleDistance();
+   F32 visDistance = getActiveClientScene()->getVisibleDistance();
    F32 visDistanceSqr = visDistance * visDistance;
    F32 fadeDistance = visDistance * mDistanceFade;
 

--- a/Engine/source/T3D/fps/guiShapeNameHud.cpp
+++ b/Engine/source/T3D/fps/guiShapeNameHud.cpp
@@ -247,7 +247,7 @@ void GuiShapeNameHud::onRender( Point2I, const RectI &updateRect)
             SceneObject *mount = shape->getObjectMount();
             if (mount)
                mount->disableCollision();
-            bool los = !gClientContainer.castRay(camPos, shapePos,losMask, &info);
+            bool los = !getActiveClientContainer()->castRay(camPos, shapePos,losMask, &info);
             shape->enableCollision();
             if (mount)
                mount->enableCollision();

--- a/Engine/source/T3D/fx/explosion.cpp
+++ b/Engine/source/T3D/fx/explosion.cpp
@@ -1070,7 +1070,7 @@ bool Explosion::onAdd()
       }
    }
 
-   gClientSceneGraph->addObjectToScene(this);
+   getActiveClientScene()->addObjectToScene(this);
 
    removeFromProcessList();
    ClientProcessList::get()->addObject(this);

--- a/Engine/source/T3D/fx/fxFoliageReplicator.cpp
+++ b/Engine/source/T3D/fx/fxFoliageReplicator.cpp
@@ -636,7 +636,7 @@ void fxFoliageReplicator::CreateFoliage(void)
          FoliageEnd.z= -2000.f;
 
          // Perform Ray Cast Collision on Client.
-         CollisionResult = gClientContainer.castRay(	FoliageStart, FoliageEnd, FXFOLIAGEREPLICATOR_COLLISION_MASK, &RayEvent);
+         CollisionResult = getActiveClientContainer()->castRay(	FoliageStart, FoliageEnd, FXFOLIAGEREPLICATOR_COLLISION_MASK, &RayEvent);
 
          // Did we hit anything?
          if (CollisionResult)
@@ -655,7 +655,7 @@ void fxFoliageReplicator::CreateFoliage(void)
             // If we collided with water and are not allowing on the water surface then let's find the
             // terrain underneath and pass this on as the original collision else fail.
             if ((CollisionType & WaterObjectType) && !mFieldData.mAllowWaterSurface &&
-               !gClientContainer.castRay( FoliageStart, FoliageEnd, FXFOLIAGEREPLICATOR_NOWATER_COLLISION_MASK, &RayEvent)) continue;
+               !getActiveClientContainer()->castRay( FoliageStart, FoliageEnd, FXFOLIAGEREPLICATOR_NOWATER_COLLISION_MASK, &RayEvent)) continue;
 
             // We passed with flying colour so carry on.
             CollisionResult = true;

--- a/Engine/source/T3D/fx/fxShapeReplicator.cpp
+++ b/Engine/source/T3D/fx/fxShapeReplicator.cpp
@@ -301,10 +301,10 @@ void fxShapeReplicator::CreateShapes(void)
          // Is this the Server?
          if (isServerObject())
             // Perform Ray Cast Collision on Server Terrain.
-            CollisionResult = gServerContainer.castRay(ShapeStart, ShapeEnd, FXREPLICATOR_COLLISION_MASK, &RayEvent);
+            CollisionResult = getActiveServerContainer()->castRay(ShapeStart, ShapeEnd, FXREPLICATOR_COLLISION_MASK, &RayEvent);
          else
             // Perform Ray Cast Collision on Client Terrain.
-            CollisionResult = gClientContainer.castRay(	ShapeStart, ShapeEnd, FXREPLICATOR_COLLISION_MASK, &RayEvent);
+            CollisionResult = getActiveClientContainer()->castRay(	ShapeStart, ShapeEnd, FXREPLICATOR_COLLISION_MASK, &RayEvent);
 
          // Did we hit anything?
          if (CollisionResult)
@@ -330,12 +330,12 @@ void fxShapeReplicator::CreateShapes(void)
                if (isServerObject())
                {
                   // Yes, so do it on the server container.
-                  if (!gServerContainer.castRay( ShapeStart, ShapeEnd, FXREPLICATOR_NOWATER_COLLISION_MASK, &RayEvent)) continue;
+                  if (!getActiveServerContainer()->castRay( ShapeStart, ShapeEnd, FXREPLICATOR_NOWATER_COLLISION_MASK, &RayEvent)) continue;
                }
                else
                {
                   // No, so do it on the client container.
-                  if (!gClientContainer.castRay( ShapeStart, ShapeEnd, FXREPLICATOR_NOWATER_COLLISION_MASK, &RayEvent)) continue;
+                  if (!getActiveClientContainer()->castRay( ShapeStart, ShapeEnd, FXREPLICATOR_NOWATER_COLLISION_MASK, &RayEvent)) continue;
                }
             }
 

--- a/Engine/source/T3D/fx/lightning.cpp
+++ b/Engine/source/T3D/fx/lightning.cpp
@@ -690,7 +690,7 @@ void Lightning::processEvent(LightningStrikeEvent* pEvent)
          Point3F start = strikePoint;
          start.z = mObjScale.z * 0.5f + getPosition().z;
          strikePoint.z += -mObjScale.z * 0.5f;
-         bool rayHit = gClientContainer.castRay( start, strikePoint,
+         bool rayHit = getActiveClientContainer()->castRay( start, strikePoint,
                                       ((U32)STATIC_COLLISION_TYPEMASK | (U32)WaterObjectType),
                                       &rayInfo);
          if( rayHit )
@@ -807,7 +807,7 @@ void Lightning::strikeRandomPoint()
       start.z = mObjScale.z * 0.5f + getPosition().z;
       Point3F end = objectCenter;
       end.z = -mObjScale.z * 0.5f + getPosition().z;
-      bool rayHit = gServerContainer.castRay( start, end,
+      bool rayHit = getActiveServerContainer()->castRay( start, end,
                                    (0xFFFFFFFF),
                                    &rayInfo);
 

--- a/Engine/source/T3D/fx/particleEmitter.cpp
+++ b/Engine/source/T3D/fx/particleEmitter.cpp
@@ -1464,7 +1464,7 @@ void ParticleEmitter::emitParticles(const Point3F& start,
 
    if( n_parts > 0 && getSceneManager() == NULL )
    {
-      gClientSceneGraph->addObjectToScene(this);
+      getActiveClientScene()->addObjectToScene(this);
       ClientProcessList::get()->addObject(this);
    }
 
@@ -1534,7 +1534,7 @@ void ParticleEmitter::emitParticles(const Point3F& rCenter,
    // Make sure we're part of the world
    if( n_parts > 0 && getSceneManager() == NULL )
    {
-      gClientSceneGraph->addObjectToScene(this);
+      getActiveClientScene()->addObjectToScene(this);
       ClientProcessList::get()->addObject(this);
    }
 

--- a/Engine/source/T3D/fx/splash.cpp
+++ b/Engine/source/T3D/fx/splash.cpp
@@ -410,7 +410,7 @@ bool Splash::onAdd()
    mObjBox.maxExtents = Point3F(  1,  1,  1 );
    resetWorldBox();
 
-   gClientSceneGraph->addObjectToScene(this);
+   getActiveClientScene()->addObjectToScene(this);
 
    removeFromProcessList();
    ClientProcessList::get()->addObject(this);

--- a/Engine/source/T3D/gameFunctions.cpp
+++ b/Engine/source/T3D/gameFunctions.cpp
@@ -132,7 +132,7 @@ DefineEngineFunction( containerFindFirst, const char*, (U32 typeMask, Point3F or
 
    //initialize the list, and do the query
    sgServerQueryList.mList.clear();
-   gServerContainer.findObjects(queryBox, typeMask, SimpleQueryList::insertionCallback, &sgServerQueryList);
+   getActiveServerContainer()->findObjects(queryBox, typeMask, SimpleQueryList::insertionCallback, &sgServerQueryList);
 
    //return the first element
    sgServerQueryIndex = 0;

--- a/Engine/source/T3D/gameFunctions.cpp
+++ b/Engine/source/T3D/gameFunctions.cpp
@@ -342,12 +342,12 @@ bool GameProcessCameraQuery(CameraQuery *query)
    if (connection && connection->getControlCameraTransform(0.032f, &query->cameraMatrix))
    {
       query->object = dynamic_cast<GameBase*>(connection->getCameraObject());
-      query->nearPlane = gClientSceneGraph->getNearClip();
+      query->nearPlane = getActiveClientScene()->getNearClip();
 
       // Scale the normal visible distance by the performance 
       // tuning scale which we never let over 1.
       CameraAndFOV::sVisDistanceScale = mClampF( CameraAndFOV::sVisDistanceScale, 0.01f, 1.0f );
-      query->farPlane = gClientSceneGraph->getVisibleDistance() * CameraAndFOV::sVisDistanceScale;
+      query->farPlane = getActiveClientScene()->getVisibleDistance() * CameraAndFOV::sVisDistanceScale;
 
       // Provide some default values
       query->stereoTargets[0] = 0;
@@ -423,7 +423,7 @@ void GameRenderWorld()
    PROFILE_START(GameRenderWorld);
    FrameAllocator::setWaterMark(0);
 
-   gClientSceneGraph->renderScene( SPT_Diffuse );
+   getActiveClientScene()->renderScene( SPT_Diffuse );
 
    // renderScene leaves some states dirty, which causes problems if GameTSCtrl is the last Gui object rendered
    GFX->updateStates();
@@ -563,7 +563,7 @@ void renderFrame(GFXTextureTargetRef* target, MatrixF transform, Frustum frustum
       // We're going to be displaying this render at size of this control in
       // pixels - let the scene know so that it can calculate e.g. reflections
       // correctly for that final display result.
-      gClientSceneGraph->setDisplayTargetResolution(size);
+      getActiveClientScene()->setDisplayTargetResolution(size);
 
       // Set the GFX world matrix to the world-to-camera transform, but don't 
       // change the cameraMatrix in mLastCameraQuery. This is because 
@@ -590,7 +590,7 @@ void renderFrame(GFXTextureTargetRef* target, MatrixF transform, Frustum frustum
 
       // Set the default non-clip projection as some 
       // objects depend on this even in non-reflect cases.
-      gClientSceneGraph->setNonClipProjection(mSaveProjection);
+      getActiveClientScene()->setNonClipProjection(mSaveProjection);
 
       // Give the post effect manager the worldToCamera, and cameraToScreen matrices
       PFXMGR->setFrameMatrices(mSaveModelview, mSaveProjection);
@@ -599,7 +599,7 @@ void renderFrame(GFXTextureTargetRef* target, MatrixF transform, Frustum frustum
       PROFILE_START(GameFunctions_RenderFrame_RenderWorld);
       FrameAllocator::setWaterMark(0);
 
-      gClientSceneGraph->renderScene(SPT_Reflect, typeMask);
+      getActiveClientScene()->renderScene(SPT_Reflect, typeMask);
 
       // renderScene leaves some states dirty, which causes problems if GameTSCtrl is the last Gui object rendered
       GFX->updateStates();

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -154,28 +154,6 @@ void GuiMaterialPreview::setLightTranslate(S32 modifier, F32 xstep, F32 ystep)
    GuiMaterialPreview::mFakeSun->setDirection(relativeLightDirection);
 }
 
-// This is for panning the viewport camera.
-void GuiMaterialPreview::setTranslate(S32 modifier, F32 xstep, F32 ystep)
-{
-	F32 transstep = (modifier & SI_SHIFT ? mTransStep : (mTransStep*mTranMult));
-
-	F32 nominalDistance = 20.0;
-	Point3F vec = mCameraPos;
-	vec -= mOrbitPos;
-	transstep *= vec.len() / nominalDistance;
-
-	if (modifier & SI_PRIMARY_CTRL)
-	{
-		mOrbitRelPos.x += ( xstep * transstep );
-		mOrbitRelPos.y += ( ystep * transstep );
-	}
-	else
-	{
-		mOrbitRelPos.x += ( xstep * transstep );
-		mOrbitRelPos.z += ( ystep * transstep );
-	}
-}
-
 // Left Click
 void GuiMaterialPreview::onMouseDown(const GuiEvent &event)
 {
@@ -247,37 +225,6 @@ bool GuiMaterialPreview::onMouseWheelDown(const GuiEvent &event)
 {
 	mOrbitDist = (mOrbitDist + 0.10f);
 	return true;
-}
-
-// Mouse Wheel Click
-void GuiMaterialPreview::onMiddleMouseDown(const GuiEvent &event)
-{
-   if (!mActive || !mVisible || !mAwake)
-   {
-      return;
-   }
-   mMouseState = Panning;
-   mLastMousePoint = event.mousePoint;
-   mouseLock();
-}
-
-// Mouse Wheel Click Release
-void GuiMaterialPreview::onMiddleMouseUp(const GuiEvent &event)
-{
-   mouseUnlock();
-   mMouseState = None;
-}
-
-// Mouse Wheel Click Drag
-void GuiMaterialPreview::onMiddleMouseDragged(const GuiEvent &event)
-{
-   if (mMouseState != Panning)
-   {
-      return;
-   }
-   Point2I delta = event.mousePoint - mLastMousePoint;
-   mLastMousePoint = event.mousePoint;
-   setTranslate(event.modifier, delta.x, delta.y);
 }
 
 // This is used to set the model we want to view in the control object.

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -375,16 +375,16 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    mSaveProjection = GFX->getProjectionMatrix();
    mSaveWorldToScreenScale = GFX->getWorldToScreenScale();
 
-   FogData savedFogData = gClientSceneGraph->getFogData();
-   gClientSceneGraph->setFogData( FogData() );  // no fog in preview window
+   FogData savedFogData = getActiveClientScene()->getFogData();
+   getActiveClientScene()->setFogData( FogData() );  // no fog in preview window
 
    if (Skylight::smSkylightProbe.isValid())
       PROBEMGR->submitProbe(Skylight::smSkylightProbe->getProbeInfo());
 
-   RenderPassManager* renderPass = gClientSceneGraph->getDefaultRenderPass();
+   RenderPassManager* renderPass = getActiveClientScene()->getDefaultRenderPass();
    SceneRenderState state
    (
-      gClientSceneGraph,
+      getActiveClientScene(),
       SPT_Diffuse,
       SceneCameraState( GFX->getViewport(), mSaveFrustum, GFX->getWorldMatrix(), GFX->getProjectionMatrix() ),
       renderPass,
@@ -431,7 +431,7 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
       renderSunDirection();
    }
 
-   gClientSceneGraph->setFogData( savedFogData );         // restore fog setting
+   getActiveClientScene()->setFogData( savedFogData );         // restore fog setting
 
    // Make sure to remove our fake sun
    LIGHTMGR->unregisterAllLights();

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -37,11 +37,11 @@
 #include "gfx/gfxDrawUtil.h"
 
 #include "environment/skySphere.h"
+#include "T3D/tsStatic.h"
 
 // GuiMaterialPreview
 GuiMaterialPreview::GuiMaterialPreview()
 :  mMouseState(None),
-   mModel(NULL),
    runThread(0),
    lastRenderTime(0),
    mLastMousePoint(0, 0),
@@ -65,17 +65,32 @@ GuiMaterialPreview::GuiMaterialPreview()
    // By default don't do dynamic reflection
    // updates for this viewport.
    mReflectPriority = 0.0f;
-   mMountedModel = NULL;
    mSkinTag = 0;
 
+   // setup our scene.
    mTempScene = new SceneManager(true);
    mTempScene->setFogData(FogData());
+
+   mBGSky = new SkySphere();
+   mBGSky->_setMaterial("Prototyping:hdrMaterial");
+   mBGSky->_initRender();
+   mBGSky->_updateMaterial();
+   mTempScene->addObjectToScene(mBGSky);
+   
+   mTSShape = new TSStatic();
+   mTempScene->addObjectToScene(mTSShape);
 }
 
 GuiMaterialPreview::~GuiMaterialPreview()
 {
-   SAFE_DELETE(mModel);
    SAFE_DELETE(mFakeSun);
+
+   mTempScene->removeObjectFromScene(mBGSky);
+   SAFE_DELETE(mBGSky);
+
+   if(mTSShape != NULL)
+      deleteModel();
+
    SAFE_DELETE(mTempScene);
 }
 
@@ -265,29 +280,28 @@ void GuiMaterialPreview::onMiddleMouseDragged(const GuiEvent &event)
 // This is used to set the model we want to view in the control object.
 void GuiMaterialPreview::setObjectModel(const char* modelName)
 {
-   deleteModel();
+   if (mTSShape != NULL) {
+      if (dStrcmp(mTSShape->mShapeAssetId, modelName) == 0)
+         return;
 
-   Resource<TSShape> model = ResourceManager::get().load(modelName);
-   if (! bool(model))
-   {
-      Con::warnf(avar("GuiMaterialPreview: Failed to load model %s. Please check your model name and load a valid model.", modelName));
-      return;
+      deleteModel();
    }
 
-   mModel = new TSShapeInstance(model, true);
-   AssertFatal(mModel, avar("GuiMaterialPreview: Failed to load model %s. Please check your model name and load a valid model.", modelName));
-
+   mTSShape = new TSStatic();
+   mTSShape->_setShape(modelName);
+   mTSShape->_createShape();
+   mTempScene->addObjectToScene(mTSShape);
    // Initialize camera values:
-   mOrbitPos = mModel->getShape()->center;
-   mMinOrbitDist = mModel->getShape()->mRadius;
+   mOrbitPos = mTSShape->mShapeInstance->getShape()->center;
+   mMinOrbitDist = mTSShape->mShapeInstance->getShape()->mRadius;
 
    lastRenderTime = Platform::getVirtualMilliseconds();
 }
 
 void GuiMaterialPreview::deleteModel()
 {
-   SAFE_DELETE(mModel);
-   runThread = 0;
+   mTempScene->removeObjectFromScene(mTSShape);
+   SAFE_DELETE(mTSShape);
 }
 
 // This is called whenever there is a change in the camera.
@@ -362,15 +376,9 @@ void GuiMaterialPreview::onMouseLeave(const GuiEvent & event)
 
 void GuiMaterialPreview::renderWorld(const RectI &updateRect)
 {
-   // nothing to render, punt
-   if ( !mModel && !mMountedModel )
-      return;
-
    S32 time = Platform::getVirtualMilliseconds();
    //S32 dt = time - lastRenderTime;
    lastRenderTime = time;
-
-   
 
    F32 left, right, top, bottom, nearPlane, farPlane;
    bool isOrtho;
@@ -380,71 +388,15 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    mSaveProjection = GFX->getProjectionMatrix();
    mSaveWorldToScreenScale = GFX->getWorldToScreenScale();
 
-   // BFW(Big fucking warning) DO NOT MERGE WITH THIS SETUP
-   // WE NEED PROPER SCENE MANAGEMENT NOT THIS TEST!
-   // use the ScopedSceneManager
-   {
-      ScopedSceneManager scopeManager(mTempScene);
+   ScopedSceneManager scopeManager(mTempScene);
 
-      SkySphere* bgSkybox = new SkySphere();
-      bgSkybox->_setMaterial("Prototyping:hdrMaterial");
-      bgSkybox->_initRender();
-      bgSkybox->_updateMaterial();
-      mTempScene->addObjectToScene(bgSkybox);
-      
-      mTempScene->renderScene(SPT_Diffuse);
-
-      mTempScene->removeObjectFromScene(bgSkybox);
-      delete bgSkybox;
-   }
+   LIGHTMGR->unregisterAllLights();
+   LIGHTMGR->setSpecialLight(LightManager::slSunLightType, mFakeSun);
 
    if (Skylight::smSkylightProbe.isValid())
       PROBEMGR->submitProbe(Skylight::smSkylightProbe->getProbeInfo());
 
-   RenderPassManager* renderPass = getActiveClientScene()->getDefaultRenderPass();
-   SceneRenderState state
-   (
-      getActiveClientScene(),
-      SPT_Diffuse,
-      SceneCameraState( GFX->getViewport(), mSaveFrustum, GFX->getWorldMatrix(), GFX->getProjectionMatrix() ),
-      renderPass,
-      true
-   );
-
-   // Set up our TS render state here.
-   TSRenderState rdata;
-   rdata.setSceneState( &state );
-
-   // We might have some forward lit materials
-   // so pass down a query to gather lights.
-   LightQuery query;
-   query.init( SphereF( Point3F::Zero, 1.0f ) );
-   rdata.setLightQuery( &query );
-
-   // Set up pass transforms
-   renderPass->assignSharedXform(RenderPassManager::View, MatrixF::Identity);
-   renderPass->assignSharedXform(RenderPassManager::Projection, GFX->getProjectionMatrix());
-
-   LIGHTMGR->unregisterAllLights();
-   LIGHTMGR->setSpecialLight( LightManager::slSunLightType, mFakeSun );
-
-   if ( mModel )
-      mModel->render( rdata );
-
-   if ( mMountedModel )
-   {
-      // render a weapon
-	   /*
-      MatrixF mat;
-
-      GFX->pushWorldMatrix();
-      GFX->multWorld( mat );
-
-      GFX->popWorldMatrix();
-	  */
-   }
-
-   renderPass->renderPass( &state );
+   mTempScene->renderScene(SPT_Diffuse);
 
    if (mMouseState == MovingLight)
    {
@@ -459,7 +411,7 @@ void GuiMaterialPreview::renderSunDirection() const
 {
    // Render four arrows aiming in the direction of the sun's light
    ColorI color = LinearColorF(mFakeSun->getColor()).toColorI();
-   F32 length = mModel->getShape()->mBounds.len() * 0.8f;
+   F32 length = mTSShape->mShapeInstance->getShape()->mBounds.len() * 0.8f;
 
    // Get the sun's vectors
    Point3F fwd = mFakeSun->getTransform().getForwardVector();
@@ -467,8 +419,8 @@ void GuiMaterialPreview::renderSunDirection() const
    Point3F right = mFakeSun->getTransform().getRightVector() * length / 8;
 
    // Calculate the start and end points of the first arrow (bottom left)
-   Point3F start = mModel->getShape()->center - fwd * length - up / 2 - right / 2;
-   Point3F end = mModel->getShape()->center - fwd * length / 3 - up / 2 - right / 2;
+   Point3F start = mTSShape->mShapeInstance->getShape()->center - fwd * length - up / 2 - right / 2;
+   Point3F end = mTSShape->mShapeInstance->getShape()->center - fwd * length / 3 - up / 2 - right / 2;
 
    GFXStateBlockDesc desc;
    desc.setZReadWrite(true, true);
@@ -494,7 +446,7 @@ void GuiMaterialPreview::resetViewport()
    mCameraRot.set( mDegToRad(30.0f), 0, mDegToRad(-30.0f) );
    mCameraPos.set(0.0f, 1.75f, 1.25f);
    mOrbitDist = 5.0f;
-   mOrbitPos = mModel->getShape()->center;
+   mOrbitPos = mTSShape->mShapeInstance->getShape()->center;
 
    // Reset the viewport's lighting.
    GuiMaterialPreview::mFakeSun->setColor( LinearColorF( 1.0f, 1.0f, 1.0f ) );
@@ -519,7 +471,7 @@ DefineEngineMethod(GuiMaterialPreview, setModel, void, ( const char* shapeName )
    object->setObjectModel(shapeName);
 }
 
-DefineEngineMethod(GuiMaterialPreview, deleteModel, void, (),,
+DefineEngineMethod(GuiMaterialPreview, deleteModel, void, (), ,
    "Deletes the preview model.\n")
 {
    object->deleteModel();

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -31,11 +31,12 @@
 #include "lighting/lightManager.h"
 #include "lighting/lightInfo.h"
 #include "core/resourceManager.h"
-#include "scene/sceneManager.h"
 #include "scene/sceneRenderState.h"
 #include "renderInstance/renderProbeMgr.h"
 #include "T3D/lighting/skylight.h"
 #include "gfx/gfxDrawUtil.h"
+
+#include "environment/skySphere.h"
 
 // GuiMaterialPreview
 GuiMaterialPreview::GuiMaterialPreview()
@@ -66,12 +67,16 @@ GuiMaterialPreview::GuiMaterialPreview()
    mReflectPriority = 0.0f;
    mMountedModel = NULL;
    mSkinTag = 0;
+
+   mTempScene = new SceneManager(true);
+   mTempScene->setFogData(FogData());
 }
 
 GuiMaterialPreview::~GuiMaterialPreview()
 {
    SAFE_DELETE(mModel);
    SAFE_DELETE(mFakeSun);
+   SAFE_DELETE(mTempScene);
 }
 
 bool GuiMaterialPreview::onWake()
@@ -375,8 +380,23 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    mSaveProjection = GFX->getProjectionMatrix();
    mSaveWorldToScreenScale = GFX->getWorldToScreenScale();
 
-   FogData savedFogData = getActiveClientScene()->getFogData();
-   getActiveClientScene()->setFogData( FogData() );  // no fog in preview window
+   // BFW(Big fucking warning) DO NOT MERGE WITH THIS SETUP
+   // WE NEED PROPER SCENE MANAGEMENT NOT THIS TEST!
+   // use the ScopedSceneManager
+   {
+      ScopedSceneManager scopeManager(mTempScene);
+
+      SkySphere* bgSkybox = new SkySphere();
+      bgSkybox->_setMaterial("Prototyping:hdrMaterial");
+      bgSkybox->_initRender();
+      bgSkybox->_updateMaterial();
+      mTempScene->addObjectToScene(bgSkybox);
+      
+      mTempScene->renderScene(SPT_Diffuse);
+
+      mTempScene->removeObjectFromScene(bgSkybox);
+      delete bgSkybox;
+   }
 
    if (Skylight::smSkylightProbe.isValid())
       PROBEMGR->submitProbe(Skylight::smSkylightProbe->getProbeInfo());
@@ -430,8 +450,6 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    {
       renderSunDirection();
    }
-
-   getActiveClientScene()->setFogData( savedFogData );         // restore fog setting
 
    // Make sure to remove our fake sun
    LIGHTMGR->unregisterAllLights();

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -222,10 +222,13 @@ bool GuiMaterialPreview::onMouseWheelDown(const GuiEvent &event)
 // This is used to set the model we want to view in the control object.
 void GuiMaterialPreview::setObjectModel(const char* modelName)
 {
-   ScopedSceneManager scopeManager(mTempScene);
+   
    mTSShape->_setShapeData(mTSShape, "", modelName);
    if (!mTSShape->isProperlyAdded())
+   {
+      ScopedSceneManager scopeManager(mTempScene);
       mTSShape->registerObject();
+   }
 
    // Initialize camera values:
    mOrbitPos = mTSShape->mShapeInstance->getShape()->center;

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -36,9 +36,6 @@
 #include "T3D/lighting/skylight.h"
 #include "gfx/gfxDrawUtil.h"
 
-#include "environment/skySphere.h"
-#include "T3D/tsStatic.h"
-
 // GuiMaterialPreview
 GuiMaterialPreview::GuiMaterialPreview()
 :  mMouseState(None),
@@ -69,19 +66,14 @@ GuiMaterialPreview::GuiMaterialPreview()
 
    // setup our scene.
    mTempScene = new SceneManager(true);
-   
    mTempScene->setFogData(FogData());
 
+   ScopedSceneManager scopeManager(mTempScene);
    mBGSky = new SkySphere();
    mBGSky->_setMaterial("Prototyping:hdrMaterial");
-   mBGSky->_initRender();
-   mBGSky->_updateMaterial();
-   
-   mTempScene->addObjectToScene(mBGSky);
+   mBGSky->registerObject();
    
    mTSShape = new TSStatic();
-   mTempScene->addObjectToScene(mTSShape);
-
 }
 
 GuiMaterialPreview::~GuiMaterialPreview()
@@ -230,17 +222,11 @@ bool GuiMaterialPreview::onMouseWheelDown(const GuiEvent &event)
 // This is used to set the model we want to view in the control object.
 void GuiMaterialPreview::setObjectModel(const char* modelName)
 {
-   if (mTSShape != NULL) {
-      if (dStrcmp(mTSShape->mShapeAssetId, modelName) == 0)
-         return;
+   ScopedSceneManager scopeManager(mTempScene);
+   mTSShape->_setShapeData(mTSShape, "", modelName);
+   if (!mTSShape->isProperlyAdded())
+      mTSShape->registerObject();
 
-      deleteModel();
-   }
-
-   mTSShape = new TSStatic();
-   mTempScene->addObjectToScene(mTSShape);
-   mTSShape->_setShape(modelName);
-   mTSShape->_createShape();
    // Initialize camera values:
    mOrbitPos = mTSShape->mShapeInstance->getShape()->center;
    mMinOrbitDist = mTSShape->mShapeInstance->getShape()->mRadius;
@@ -419,12 +405,6 @@ DefineEngineMethod(GuiMaterialPreview, setModel, void, ( const char* shapeName )
    "@param shapeName Name of the model to display.\n")
 {
    object->setObjectModel(shapeName);
-}
-
-DefineEngineMethod(GuiMaterialPreview, deleteModel, void, (), ,
-   "Deletes the preview model.\n")
-{
-   object->deleteModel();
 }
 
 // Set orbit distance around the model.

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -37,7 +37,6 @@
 #include "gfx/gfxDrawUtil.h"
 
 #include "environment/skySphere.h"
-#include "T3D/tsStatic.h"
 
 // GuiMaterialPreview
 GuiMaterialPreview::GuiMaterialPreview()
@@ -371,6 +370,8 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    //S32 dt = time - lastRenderTime;
    lastRenderTime = time;
 
+   
+
    F32 left, right, top, bottom, nearPlane, farPlane;
    bool isOrtho;
    GFX->getFrustum( &left, &right, &bottom, &top, &nearPlane, &farPlane, &isOrtho);
@@ -379,30 +380,71 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    mSaveProjection = GFX->getProjectionMatrix();
    mSaveWorldToScreenScale = GFX->getWorldToScreenScale();
 
-   ScopedSceneManager scopeManager(mTempScene);
+   // BFW(Big fucking warning) DO NOT MERGE WITH THIS SETUP
+   // WE NEED PROPER SCENE MANAGEMENT NOT THIS TEST!
+   // use the ScopedSceneManager
+   {
+      ScopedSceneManager scopeManager(mTempScene);
 
-   LIGHTMGR->unregisterAllLights();
-   LIGHTMGR->setSpecialLight(LightManager::slSunLightType, mFakeSun);
+      SkySphere* bgSkybox = new SkySphere();
+      bgSkybox->_setMaterial("Prototyping:hdrMaterial");
+      bgSkybox->_initRender();
+      bgSkybox->_updateMaterial();
+      mTempScene->addObjectToScene(bgSkybox);
+      
+      mTempScene->renderScene(SPT_Diffuse);
+
+      mTempScene->removeObjectFromScene(bgSkybox);
+      delete bgSkybox;
+   }
 
    if (Skylight::smSkylightProbe.isValid())
       PROBEMGR->submitProbe(Skylight::smSkylightProbe->getProbeInfo());
 
-   SkySphere* bgSkybox = new SkySphere();
-   bgSkybox->_setMaterial("Prototyping:hdrMaterial");
-   bgSkybox->_initRender();
-   bgSkybox->_updateMaterial();
-   mTempScene->addObjectToScene(bgSkybox);
+   RenderPassManager* renderPass = getActiveClientScene()->getDefaultRenderPass();
+   SceneRenderState state
+   (
+      getActiveClientScene(),
+      SPT_Diffuse,
+      SceneCameraState( GFX->getViewport(), mSaveFrustum, GFX->getWorldMatrix(), GFX->getProjectionMatrix() ),
+      renderPass,
+      true
+   );
 
-   TSStatic* shape = new TSStatic();
-   shape->mShapeInstance = mModel;
-   mTempScene->addObjectToScene(shape);
+   // Set up our TS render state here.
+   TSRenderState rdata;
+   rdata.setSceneState( &state );
 
-   mTempScene->renderScene(SPT_Diffuse);
+   // We might have some forward lit materials
+   // so pass down a query to gather lights.
+   LightQuery query;
+   query.init( SphereF( Point3F::Zero, 1.0f ) );
+   rdata.setLightQuery( &query );
 
-   mTempScene->removeObjectFromScene(bgSkybox);
-   mTempScene->removeObjectFromScene(shape);
-   delete bgSkybox;
-   delete shape;
+   // Set up pass transforms
+   renderPass->assignSharedXform(RenderPassManager::View, MatrixF::Identity);
+   renderPass->assignSharedXform(RenderPassManager::Projection, GFX->getProjectionMatrix());
+
+   LIGHTMGR->unregisterAllLights();
+   LIGHTMGR->setSpecialLight( LightManager::slSunLightType, mFakeSun );
+
+   if ( mModel )
+      mModel->render( rdata );
+
+   if ( mMountedModel )
+   {
+      // render a weapon
+	   /*
+      MatrixF mat;
+
+      GFX->pushWorldMatrix();
+      GFX->multWorld( mat );
+
+      GFX->popWorldMatrix();
+	  */
+   }
+
+   renderPass->renderPass( &state );
 
    if (mMouseState == MovingLight)
    {

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -35,6 +35,8 @@
 #include "renderInstance/renderProbeMgr.h"
 #include "T3D/lighting/skylight.h"
 #include "gfx/gfxDrawUtil.h"
+#include "math/mathUtils.h"
+#include "T3D/groundPlane.h"
 
 // GuiMaterialPreview
 GuiMaterialPreview::GuiMaterialPreview()
@@ -42,20 +44,19 @@ GuiMaterialPreview::GuiMaterialPreview()
    runThread(0),
    lastRenderTime(0),
    mLastMousePoint(0, 0),
-   mFakeSun(NULL),
    mMaxOrbitDist(5.0f),
    mMinOrbitDist(0.0f),
    mOrbitDist(5.0f)
 {
    mActive = true;
    mCameraMatrix.identity();
-   mCameraRot.set( mDegToRad(30.0f), 0, mDegToRad(-30.0f) );
+   mCameraRot.set(mDegToRad(3.0f), 0, mDegToRad(-30.0f) );
    mCameraPos.set(0.0f, 1.75f, 1.25f);
    mCameraMatrix.setColumn(3, mCameraPos);
    mOrbitPos.set(0.0f, 0.0f, 0.0f);
    mTransStep = 0.01f;
    mTranMult = 4.0;
-   mLightTransStep = 0.01f;
+   mLightTransStep = 0.5f;
    mLightTranMult = 4.0;
    mOrbitRelPos = Point3F(0,0,0);
 
@@ -69,19 +70,22 @@ GuiMaterialPreview::GuiMaterialPreview()
    mTempScene->setFogData(FogData());
 
    ScopedSceneManager scopeManager(mTempScene);
-   mBGSky = new SkySphere();
-   mBGSky->_setMaterial("Prototyping:hdrMaterial");
-   mBGSky->registerObject();
+   mRealSun = new Sun();
+   mRealSun->setField("brightness", "2.0");
+   mRealSun->setAzimuth(100.0f);
+   mRealSun->registerObject();
+
+   GroundPlane* plane = new GroundPlane();
+   plane->_setMaterial("ToolsModule:GreyPreview");
+   plane->registerObject();
    
    mTSShape = new TSStatic();
 }
 
 GuiMaterialPreview::~GuiMaterialPreview()
 {
-   SAFE_DELETE(mFakeSun);
-
-   mBGSky->unregisterObject();
-   SAFE_DELETE(mBGSky);
+   mRealSun->unregisterObject();
+   SAFE_DELETE(mRealSun);
 
    if(mTSShape != NULL)
       deleteModel();
@@ -94,14 +98,8 @@ bool GuiMaterialPreview::onWake()
    if( !Parent::onWake() )
       return false;
 
-   if (!mFakeSun)
-      mFakeSun = LightManager::createLightInfo();
-
-   mFakeSun->setColor( LinearColorF( 1.0f, 1.0f, 1.0f ) );
-   mFakeSun->setAmbient( LinearColorF( 0.5f, 0.5f, 0.5f ) );
-   mFakeSun->setDirection( VectorF( 0.0f, 0.707f, -0.707f ) );
-	mFakeSun->setPosition( mFakeSun->getDirection() * -10000.0f );
-   mFakeSun->setRange( 2000000.0f );
+   mRealSun->setColor( LinearColorF( 1.0f, 1.0f, 1.0f ) );
+   mRealSun->setAmbientColor( LinearColorF( 0.5f, 0.5f, 0.5f ) );
 
    return true;
 }
@@ -111,7 +109,7 @@ void GuiMaterialPreview::setAmbientLightColor( F32 r, F32 g, F32 b )
 {
    LinearColorF temp(r, g, b);
    temp.clamp();
-	GuiMaterialPreview::mFakeSun->setAmbient( temp );
+	mRealSun->setAmbientColor( temp );
 }
 
 // This function allows the light's color to be changed. This is exposed to script below.
@@ -119,7 +117,7 @@ void GuiMaterialPreview::setLightColor( F32 r, F32 g, F32 b )
 {
    LinearColorF temp(r, g, b);
    temp.clamp();
-	GuiMaterialPreview::mFakeSun->setColor( temp );
+   mRealSun->setColor( temp );
 }
 
 // This function is for moving the light in the scene. This needs to be adjusted to keep the light
@@ -129,21 +127,16 @@ void GuiMaterialPreview::setLightTranslate(S32 modifier, F32 xstep, F32 ystep)
 {
 	F32 _lighttransstep = (modifier & SI_SHIFT ? mLightTransStep : (mLightTransStep*mLightTranMult));
 
-	Point3F relativeLightDirection = GuiMaterialPreview::mFakeSun->getDirection();
-
-   F32 azimuth = mAtan2(relativeLightDirection.y, relativeLightDirection.x);
-   F32 elevation = mAsin(relativeLightDirection.z);
+   // Convert current direction to spherical coordinates (azimuth and elevation in radians)
+   F32 azimuth = mRealSun->getAzimuth();
+   F32 elevation = mRealSun->getElevation();
 
    // Modify azimuth and elevation based on input
-   azimuth += xstep * _lighttransstep;
-   elevation = mClampF(elevation + ystep * _lighttransstep, -M_2PI_F, M_2PI_F);
+   azimuth -= xstep * _lighttransstep; // Horizontal movement affects azimuth
+   elevation = elevation - ystep * _lighttransstep;
 
-   // Convert back to Cartesian coordinates
-   relativeLightDirection.x = mCos(elevation) * mCos(azimuth);
-   relativeLightDirection.y = mCos(elevation) * mSin(azimuth);
-   relativeLightDirection.z = mSin(elevation);
-
-   GuiMaterialPreview::mFakeSun->setDirection(relativeLightDirection);
+   // Update azimuth and elevation on the sun object
+   mRealSun->setDirection(azimuth, elevation);
 }
 
 // Left Click
@@ -171,9 +164,9 @@ void GuiMaterialPreview::onMouseDragged(const GuiEvent &event)
    // If we are MovingLight...
    else
    {
-   Point2I delta = event.mousePoint - mLastMousePoint;
-   mLastMousePoint = event.mousePoint;
-   setLightTranslate(event.modifier, delta.x, delta.y);
+      Point2I delta = event.mousePoint - mLastMousePoint;
+      mLastMousePoint = event.mousePoint;
+      setLightTranslate(event.modifier, delta.x, delta.y);
    }
 }
 
@@ -227,11 +220,13 @@ void GuiMaterialPreview::setObjectModel(const char* modelName)
    if (!mTSShape->isProperlyAdded())
    {
       ScopedSceneManager scopeManager(mTempScene);
+      mTSShape->setPosition(Point3F(0, 0, 1.5));
       mTSShape->registerObject();
    }
 
    // Initialize camera values:
-   mOrbitPos = mTSShape->mShapeInstance->getShape()->center;
+   mTSShape->setPosition(Point3F(0, 0, mTSShape->mShapeInstance->getShape()->mBounds.len_z() * 0.5f));
+   mOrbitPos = mTSShape->getPosition();
    mMinOrbitDist = mTSShape->mShapeInstance->getShape()->mRadius;
 
    lastRenderTime = Platform::getVirtualMilliseconds();
@@ -329,37 +324,42 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
 
    ScopedSceneManager scopeManager(mTempScene);
 
-   LIGHTMGR->unregisterAllLights();
-   LIGHTMGR->setSpecialLight(LightManager::slSunLightType, mFakeSun);
+   RenderPassManager* renderPass = mTempScene->getDefaultRenderPass();
+   SceneRenderState state
+   (
+      mTempScene,
+      SPT_Diffuse,
+      SceneCameraState::fromGFX(),
+      renderPass,
+      true
+   );
 
    if (Skylight::smSkylightProbe.isValid())
       PROBEMGR->submitProbe(Skylight::smSkylightProbe->getProbeInfo());
 
-   mTempScene->renderScene(SPT_Diffuse);
+   mTempScene->renderScene(&state);
 
    if (mMouseState == MovingLight)
    {
       renderSunDirection();
    }
 
-   // Make sure to remove our fake sun
-   LIGHTMGR->unregisterAllLights();
 }
 
 void GuiMaterialPreview::renderSunDirection() const
 {
    // Render four arrows aiming in the direction of the sun's light
-   ColorI color = LinearColorF(mFakeSun->getColor()).toColorI();
+   ColorI color = LinearColorF(mRealSun->getLight()->getColor()).toColorI();
    F32 length = mTSShape->mShapeInstance->getShape()->mBounds.len() * 0.8f;
 
    // Get the sun's vectors
-   Point3F fwd = mFakeSun->getTransform().getForwardVector();
-   Point3F up = mFakeSun->getTransform().getUpVector() * length / 8;
-   Point3F right = mFakeSun->getTransform().getRightVector() * length / 8;
+   Point3F fwd = mRealSun->getLight()->getTransform().getForwardVector();
+   Point3F up = mRealSun->getLight()->getTransform().getUpVector() * length / 8;
+   Point3F right = mRealSun->getLight()->getTransform().getRightVector() * length / 8;
 
    // Calculate the start and end points of the first arrow (bottom left)
-   Point3F start = mTSShape->mShapeInstance->getShape()->center - fwd * length - up / 2 - right / 2;
-   Point3F end = mTSShape->mShapeInstance->getShape()->center - fwd * length / 3 - up / 2 - right / 2;
+   Point3F start = mTSShape->getPosition() - fwd * length - up / 2 - right / 2;
+   Point3F end = mTSShape->getPosition() - fwd * length / 3 - up / 2 - right / 2;
 
    GFXStateBlockDesc desc;
    desc.setZReadWrite(true, true);
@@ -382,15 +382,14 @@ void GuiMaterialPreview::setOrbitDistance(F32 distance)
 void GuiMaterialPreview::resetViewport()
 {
    // Reset the camera's orientation.
-   mCameraRot.set( mDegToRad(30.0f), 0, mDegToRad(-30.0f) );
+   mCameraRot.set(mDegToRad(3.0f), 0, mDegToRad(-30.0f) );
    mCameraPos.set(0.0f, 1.75f, 1.25f);
    mOrbitDist = 5.0f;
-   mOrbitPos = mTSShape->mShapeInstance->getShape()->center;
+   mOrbitPos = mTSShape->getPosition();
 
    // Reset the viewport's lighting.
-   GuiMaterialPreview::mFakeSun->setColor( LinearColorF( 1.0f, 1.0f, 1.0f ) );
-   GuiMaterialPreview::mFakeSun->setAmbient( LinearColorF( 0.5f, 0.5f, 0.5f ) );
-   GuiMaterialPreview::mFakeSun->setDirection( VectorF( 0.0f, 0.707f, -0.707f ) );
+   GuiMaterialPreview::mRealSun->setColor( LinearColorF( 1.0f, 1.0f, 1.0f ) );
+   GuiMaterialPreview::mRealSun->setAmbientColor( LinearColorF( 0.5f, 0.5f, 0.5f ) );
 }
 
 // Expose the class and functions to the console.

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -69,23 +69,26 @@ GuiMaterialPreview::GuiMaterialPreview()
 
    // setup our scene.
    mTempScene = new SceneManager(true);
+   
    mTempScene->setFogData(FogData());
 
    mBGSky = new SkySphere();
    mBGSky->_setMaterial("Prototyping:hdrMaterial");
    mBGSky->_initRender();
    mBGSky->_updateMaterial();
+   
    mTempScene->addObjectToScene(mBGSky);
    
    mTSShape = new TSStatic();
    mTempScene->addObjectToScene(mTSShape);
+
 }
 
 GuiMaterialPreview::~GuiMaterialPreview()
 {
    SAFE_DELETE(mFakeSun);
 
-   mTempScene->removeObjectFromScene(mBGSky);
+   mBGSky->unregisterObject();
    SAFE_DELETE(mBGSky);
 
    if(mTSShape != NULL)
@@ -288,9 +291,9 @@ void GuiMaterialPreview::setObjectModel(const char* modelName)
    }
 
    mTSShape = new TSStatic();
+   mTempScene->addObjectToScene(mTSShape);
    mTSShape->_setShape(modelName);
    mTSShape->_createShape();
-   mTempScene->addObjectToScene(mTSShape);
    // Initialize camera values:
    mOrbitPos = mTSShape->mShapeInstance->getShape()->center;
    mMinOrbitDist = mTSShape->mShapeInstance->getShape()->mRadius;
@@ -300,7 +303,7 @@ void GuiMaterialPreview::setObjectModel(const char* modelName)
 
 void GuiMaterialPreview::deleteModel()
 {
-   mTempScene->removeObjectFromScene(mTSShape);
+   mTSShape->unregisterObject();
    SAFE_DELETE(mTSShape);
 }
 
@@ -389,6 +392,8 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    mSaveWorldToScreenScale = GFX->getWorldToScreenScale();
 
    ScopedSceneManager scopeManager(mTempScene);
+
+   RenderPassManager* renderPass = mTempScene->getDefaultRenderPass();
 
    LIGHTMGR->unregisterAllLights();
    LIGHTMGR->setSpecialLight(LightManager::slSunLightType, mFakeSun);

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -393,8 +393,6 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
 
    ScopedSceneManager scopeManager(mTempScene);
 
-   RenderPassManager* renderPass = mTempScene->getDefaultRenderPass();
-
    LIGHTMGR->unregisterAllLights();
    LIGHTMGR->setSpecialLight(LightManager::slSunLightType, mFakeSun);
 

--- a/Engine/source/T3D/guiMaterialPreview.cpp
+++ b/Engine/source/T3D/guiMaterialPreview.cpp
@@ -37,6 +37,7 @@
 #include "gfx/gfxDrawUtil.h"
 
 #include "environment/skySphere.h"
+#include "T3D/tsStatic.h"
 
 // GuiMaterialPreview
 GuiMaterialPreview::GuiMaterialPreview()
@@ -370,8 +371,6 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    //S32 dt = time - lastRenderTime;
    lastRenderTime = time;
 
-   
-
    F32 left, right, top, bottom, nearPlane, farPlane;
    bool isOrtho;
    GFX->getFrustum( &left, &right, &bottom, &top, &nearPlane, &farPlane, &isOrtho);
@@ -380,71 +379,30 @@ void GuiMaterialPreview::renderWorld(const RectI &updateRect)
    mSaveProjection = GFX->getProjectionMatrix();
    mSaveWorldToScreenScale = GFX->getWorldToScreenScale();
 
-   // BFW(Big fucking warning) DO NOT MERGE WITH THIS SETUP
-   // WE NEED PROPER SCENE MANAGEMENT NOT THIS TEST!
-   // use the ScopedSceneManager
-   {
-      ScopedSceneManager scopeManager(mTempScene);
+   ScopedSceneManager scopeManager(mTempScene);
 
-      SkySphere* bgSkybox = new SkySphere();
-      bgSkybox->_setMaterial("Prototyping:hdrMaterial");
-      bgSkybox->_initRender();
-      bgSkybox->_updateMaterial();
-      mTempScene->addObjectToScene(bgSkybox);
-      
-      mTempScene->renderScene(SPT_Diffuse);
-
-      mTempScene->removeObjectFromScene(bgSkybox);
-      delete bgSkybox;
-   }
+   LIGHTMGR->unregisterAllLights();
+   LIGHTMGR->setSpecialLight(LightManager::slSunLightType, mFakeSun);
 
    if (Skylight::smSkylightProbe.isValid())
       PROBEMGR->submitProbe(Skylight::smSkylightProbe->getProbeInfo());
 
-   RenderPassManager* renderPass = getActiveClientScene()->getDefaultRenderPass();
-   SceneRenderState state
-   (
-      getActiveClientScene(),
-      SPT_Diffuse,
-      SceneCameraState( GFX->getViewport(), mSaveFrustum, GFX->getWorldMatrix(), GFX->getProjectionMatrix() ),
-      renderPass,
-      true
-   );
+   SkySphere* bgSkybox = new SkySphere();
+   bgSkybox->_setMaterial("Prototyping:hdrMaterial");
+   bgSkybox->_initRender();
+   bgSkybox->_updateMaterial();
+   mTempScene->addObjectToScene(bgSkybox);
 
-   // Set up our TS render state here.
-   TSRenderState rdata;
-   rdata.setSceneState( &state );
+   TSStatic* shape = new TSStatic();
+   shape->mShapeInstance = mModel;
+   mTempScene->addObjectToScene(shape);
 
-   // We might have some forward lit materials
-   // so pass down a query to gather lights.
-   LightQuery query;
-   query.init( SphereF( Point3F::Zero, 1.0f ) );
-   rdata.setLightQuery( &query );
+   mTempScene->renderScene(SPT_Diffuse);
 
-   // Set up pass transforms
-   renderPass->assignSharedXform(RenderPassManager::View, MatrixF::Identity);
-   renderPass->assignSharedXform(RenderPassManager::Projection, GFX->getProjectionMatrix());
-
-   LIGHTMGR->unregisterAllLights();
-   LIGHTMGR->setSpecialLight( LightManager::slSunLightType, mFakeSun );
-
-   if ( mModel )
-      mModel->render( rdata );
-
-   if ( mMountedModel )
-   {
-      // render a weapon
-	   /*
-      MatrixF mat;
-
-      GFX->pushWorldMatrix();
-      GFX->multWorld( mat );
-
-      GFX->popWorldMatrix();
-	  */
-   }
-
-   renderPass->renderPass( &state );
+   mTempScene->removeObjectFromScene(bgSkybox);
+   mTempScene->removeObjectFromScene(shape);
+   delete bgSkybox;
+   delete shape;
 
    if (mMouseState == MovingLight)
    {

--- a/Engine/source/T3D/guiMaterialPreview.h
+++ b/Engine/source/T3D/guiMaterialPreview.h
@@ -71,8 +71,6 @@ protected:
 
    MouseState  mMouseState;
 
-   TSShapeInstance*  mModel;
-   TSShapeInstance*  mMountedModel;
    U32   mSkinTag;
 
    // For Camera Panning.

--- a/Engine/source/T3D/guiMaterialPreview.h
+++ b/Engine/source/T3D/guiMaterialPreview.h
@@ -44,6 +44,13 @@
 #include "scene/scopedSceneManager.h"
 #endif // !1
 
+#ifndef _SKYSPHERE_H_
+#include "environment/skySphere.h"
+#endif
+
+#ifndef _TSSTATIC_H_
+#include "T3D/tsStatic.h"
+#endif
 
 class LightInfo;
 
@@ -90,6 +97,10 @@ protected:
 
    LightInfo*  mFakeSun;
    SceneManager* mTempScene;
+
+   SkySphere* mBGSky;
+   TSStatic* mTSShape;
+
    void renderSunDirection() const;
 public:
    bool onWake() override;

--- a/Engine/source/T3D/guiMaterialPreview.h
+++ b/Engine/source/T3D/guiMaterialPreview.h
@@ -115,13 +115,7 @@ public:
    void onRightMouseDragged(const GuiEvent &event) override;
    bool onMouseWheelUp(const GuiEvent &event) override;
    bool onMouseWheelDown(const GuiEvent &event) override;
-   void onMiddleMouseUp(const GuiEvent &event) override;
-   void onMiddleMouseDown(const GuiEvent &event) override;
-   void onMiddleMouseDragged(const GuiEvent &event) override;
-   
-   // For Camera Panning.
-   void setTranslate(S32 modifier, F32 xstep, F32 ystep);
-   
+
    // For Light Translation.
    void setLightTranslate(S32 modifier, F32 xstep, F32 ystep);
    

--- a/Engine/source/T3D/guiMaterialPreview.h
+++ b/Engine/source/T3D/guiMaterialPreview.h
@@ -52,6 +52,10 @@
 #include "T3D/tsStatic.h"
 #endif
 
+#ifndef _SUN_H_
+#include "environment/sun.h"
+#endif
+
 class LightInfo;
 
 class GuiMaterialPreview : public GuiTSCtrl
@@ -93,10 +97,9 @@ protected:
 
    Point2I     mLastMousePoint;
 
-   LightInfo*  mFakeSun;
    SceneManager* mTempScene;
 
-   SkySphere* mBGSky;
+   Sun* mRealSun;
    TSStatic* mTSShape;
 
    void renderSunDirection() const;

--- a/Engine/source/T3D/guiMaterialPreview.h
+++ b/Engine/source/T3D/guiMaterialPreview.h
@@ -28,8 +28,22 @@
 #ifndef _GUIMATERIALPREVIEW_H_
 #define _GUIMATERIALPREVIEW_H_
 
+#ifndef _GUITSCONTROL_H_
 #include "gui/3d/guiTSControl.h"
+#endif
+
+#ifndef _TSSHAPEINSTANCE_H_
 #include "ts/tsShapeInstance.h"
+#endif
+
+#ifndef _SCENEMANAGER_H_
+#include "scene/sceneManager.h"
+#endif
+
+#ifndef _SCOPED_SCENE_MANAGER_H_
+#include "scene/scopedSceneManager.h"
+#endif // !1
+
 
 class LightInfo;
 
@@ -75,6 +89,7 @@ protected:
    Point2I     mLastMousePoint;
 
    LightInfo*  mFakeSun;
+   SceneManager* mTempScene;
    void renderSunDirection() const;
 public:
    bool onWake() override;

--- a/Engine/source/T3D/guiObjectView.cpp
+++ b/Engine/source/T3D/guiObjectView.cpp
@@ -505,7 +505,7 @@ void GuiObjectView::renderWorld( const RectI& updateRect )
    mv.inverse();
    mv.getColumn( 3, &cp );
 
-   RenderPassManager* renderPass = gClientSceneGraph->getDefaultRenderPass();
+   RenderPassManager* renderPass = getActiveClientScene()->getDefaultRenderPass();
 
    S32 time = Platform::getVirtualMilliseconds();
    S32 dt = time - mLastRenderTime;
@@ -524,7 +524,7 @@ void GuiObjectView::renderWorld( const RectI& updateRect )
 
    SceneRenderState state
    (
-      gClientSceneGraph,
+      getActiveClientScene(),
       SPT_Diffuse,
       SceneCameraState( GFX->getViewport(), frust, MatrixF::Identity, GFX->getProjectionMatrix() ),
       renderPass,
@@ -546,8 +546,8 @@ void GuiObjectView::renderWorld( const RectI& updateRect )
    if (Skylight::smSkylightProbe.isValid())
       PROBEMGR->submitProbe(Skylight::smSkylightProbe->getProbeInfo());
 
-   FogData savedFogData = gClientSceneGraph->getFogData();
-   gClientSceneGraph->setFogData(FogData());  // no fog in preview window
+   FogData savedFogData = getActiveClientScene()->getFogData();
+   getActiveClientScene()->setFogData(FogData());  // no fog in preview window
 
    if(mModelInstance)
    {
@@ -575,7 +575,7 @@ void GuiObjectView::renderWorld( const RectI& updateRect )
 
    renderPass->renderPass( &state );
 
-   gClientSceneGraph->setFogData(savedFogData);         // restore fog setting
+   getActiveClientScene()->setFogData(savedFogData);         // restore fog setting
    // Make sure to remove our fake sun.
    LIGHTMGR->unregisterAllLights();
 }

--- a/Engine/source/T3D/levelInfo.cpp
+++ b/Engine/source/T3D/levelInfo.cpp
@@ -327,7 +327,7 @@ void LevelInfo::_updateSceneGraph()
    if ( mNearClip <= 0.0f )
       mNearClip = 0.001f;
 
-   SceneManager* scene = isClientObject() ? gClientSceneGraph : gServerSceneGraph;
+   SceneManager* scene = isClientObject() ? getActiveClientScene() : getActiveServerScene();
    
    scene->setNearClip( mNearClip );
    scene->setVisibleDistance( mVisibleDistance );

--- a/Engine/source/T3D/lightFlareData.cpp
+++ b/Engine/source/T3D/lightFlareData.cpp
@@ -350,7 +350,7 @@ bool LightFlareData::_testVisibility(const SceneRenderState *state, LightFlareSt
 
       RayInfo rayInfo;
 
-      if ( !gClientContainer.castRay( camPos, lightPos, LosMask, &rayInfo ) )
+      if ( !getActiveClientContainer()->castRay( camPos, lightPos, LosMask, &rayInfo ) )
          *outOcclusionFade = 1.0f;
 
       if ( control && fps )

--- a/Engine/source/T3D/lighting/reflectionProbe.cpp
+++ b/Engine/source/T3D/lighting/reflectionProbe.cpp
@@ -533,7 +533,7 @@ void ReflectionProbe::updateProbeParams()
       mProbeInfo.mPosition = Point3F::Zero;
       mProbeInfo.mTransform = MatrixF::Identity;
 
-      F32 visDist = gClientSceneGraph->getVisibleDistance();
+      F32 visDist = getActiveClientScene()->getVisibleDistance();
       Box3F skylightBounds = Box3F(visDist * 2);
 
       skylightBounds.setCenter(Point3F::Zero);

--- a/Engine/source/T3D/physics/physicsEvents.cpp
+++ b/Engine/source/T3D/physics/physicsEvents.cpp
@@ -73,7 +73,7 @@ void RadialImpulseEvent::unpack( NetConnection *ps, BitStream *bstream )
    
 void RadialImpulseEvent::process(NetConnection *con)
 { 
-   impulse( &gClientContainer, mPosition, mRadius, mMagnitude );   
+   impulse( getActiveClientContainer(), mPosition, mRadius, mMagnitude );   
 }
 
 void RadialImpulseEvent::_impulseCallback( SceneObject *obj, void *key )
@@ -127,7 +127,7 @@ DefineEngineStaticMethod(RadialImpulseEvent, send, void, (const char* inPosition
    dSscanf( inPosition, "%f %f %f", &position.x, &position.y, &position.z );
 
    // Apply server-side.
-   RadialImpulseEvent::impulse( &gServerContainer, position, radius, magnitude );
+   RadialImpulseEvent::impulse( getActiveServerContainer(), position, radius, magnitude );
 
    // Transmit event to each client to perform client-side...
 

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -3654,7 +3654,7 @@ MatrixF * Player::Death::fallToGround(F32 dt, const Point3F& loc, F32 curZ, F32 
 
    PROFILE_SCOPE(ConformToGround);
 
-   if (gClientContainer.castRay(pos, below, sPlayerConformMask, &coll))
+   if (getActiveClientContainer()->castRay(pos, below, sPlayerConformMask, &coll))
    {
       F32      adjust, height = (loc.z - coll.point.z), sink = curSink;
       VectorF  desNormal = coll.normal;
@@ -3682,7 +3682,7 @@ MatrixF * Player::Death::fallToGround(F32 dt, const Point3F& loc, F32 curZ, F32 
 
          // Do the three casts-
          for (c = 0; c < 3; c++)
-            if (gClientContainer.castRay(corners[c], downpts[c], sPlayerConformMask, &coll))
+            if (getActiveClientContainer()->castRay(corners[c], downpts[c], sPlayerConformMask, &coll))
                downpts[c] = coll.point;
             else
                break;
@@ -3936,7 +3936,7 @@ void Player::updateActionThread()
          mat.getColumn( 1, &rot );
          mat.mulP( Point3F( offset, 0.0f, 0.0f), &pos );
 
-         if( gClientContainer.castRay( Point3F( pos.x, pos.y, pos.z + 0.01f ),
+         if( getActiveClientContainer()->castRay( Point3F( pos.x, pos.y, pos.z + 0.01f ),
                Point3F( pos.x, pos.y, pos.z - 2.0f ),
                (U32)STATIC_COLLISION_TYPEMASK | (U32)VehicleObjectType, &rInfo ) )
          {
@@ -4767,7 +4767,7 @@ void Player::updateAttachment(){
     RayInfo rInfo;
     MatrixF mat = getTransform();
     mat.getColumn(3, &pos);
-    if (gServerContainer.castRay(Point3F(pos.x, pos.y, pos.z + 0.1f),
+    if (getActiveServerContainer()->castRay(Point3F(pos.x, pos.y, pos.z + 0.1f),
         Point3F(pos.x, pos.y, pos.z - 1.0f ),
         PathShapeObjectType, &rInfo))
     {
@@ -7080,7 +7080,7 @@ void Player:: playImpactSound()
       MatrixF mat = getTransform();
       mat.mulP(Point3F(mDataBlock->decalOffset,0.0f,0.0f), &pos);
 
-      if( gClientContainer.castRay( Point3F( pos.x, pos.y, pos.z + 0.01f ),
+      if( getActiveClientContainer()->castRay( Point3F( pos.x, pos.y, pos.z + 0.01f ),
                                     Point3F( pos.x, pos.y, pos.z - 2.0f ),
                                     (U32)STATIC_COLLISION_TYPEMASK | (U32)VehicleObjectType,
                                     &rInfo ) )
@@ -7132,7 +7132,7 @@ void Player::updateSplash()
 
 
          RayInfo rInfo;
-         if (gClientContainer.castRay(mLastPos, curPos,
+         if (getActiveClientContainer()->castRay(mLastPos, curPos,
                WaterObjectType, &rInfo)) {
             createSplash( rInfo.point, speed );
             mBubbleEmitterTime = 0.0;

--- a/Engine/source/T3D/projectile.cpp
+++ b/Engine/source/T3D/projectile.cpp
@@ -936,7 +936,7 @@ bool Projectile::pointInWater(const Point3F &point)
       // but using the actual defined container when possible is the right
       // thing to do.  DAW
       AssertFatal(isClientObject(), "Server projectile has not been properly added");
-      gClientContainer.findObjects( boundsBox, WaterObjectType, findRouter, &info );
+      getActiveClientContainer()->findObjects( boundsBox, WaterObjectType, findRouter, &info );
    }
 
    return ( info.waterCoverage > 0.0f );
@@ -967,7 +967,7 @@ void Projectile::emitParticles(const Point3F& from, const Point3F& to, const Poi
    {
       // cast the ray to get the surface point of the water
       RayInfo rInfo;
-      if (gClientContainer.castRay(from, to, WaterObjectType, &rInfo))
+      if (getActiveClientContainer()->castRay(from, to, WaterObjectType, &rInfo))
       {
          MatrixF trans = getTransform();
          trans.setPosition(rInfo.point);
@@ -995,7 +995,7 @@ void Projectile::emitParticles(const Point3F& from, const Point3F& to, const Poi
       // cast the ray in the opposite direction since that point is out of the water, otherwise
       //  we hit water immediately and wont get the appropriate surface point
       RayInfo rInfo;
-      if (gClientContainer.castRay(to, from, WaterObjectType, &rInfo))
+      if (getActiveClientContainer()->castRay(to, from, WaterObjectType, &rInfo))
       {
          MatrixF trans = getTransform();
          trans.setPosition(rInfo.point);

--- a/Engine/source/T3D/rigidShape.cpp
+++ b/Engine/source/T3D/rigidShape.cpp
@@ -1457,7 +1457,7 @@ only be called on the server.
 void RigidShape::checkTriggers()
 {
    Box3F bbox = mConvex.getBoundingBox(getTransform(), getScale());
-   gServerContainer.findObjects(bbox,sTriggerMask,findCallback,this);
+   getActiveServerContainer()->findObjects(bbox,sTriggerMask,findCallback,this);
 }
 
 /** The callback used in by the checkTriggers() method.
@@ -1713,7 +1713,7 @@ bool RigidShape::collidingWithWater( Point3F &waterHeight )
    F32 height = mFabs( mObjBox.maxExtents.z - mObjBox.minExtents.z );
 
    RayInfo rInfo;
-   if( gClientContainer.castRay( curPos + Point3F(0.0, 0.0, height), curPos, WaterObjectType, &rInfo) )
+   if( getActiveClientContainer()->castRay( curPos + Point3F(0.0, 0.0, height), curPos, WaterObjectType, &rInfo) )
    {
       waterHeight = rInfo.point;
       return true;

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -693,7 +693,7 @@ DefineEngineMethod( ShapeBaseData, checkDeployPos, bool, ( TransformF txfm ),,
       polyList.mPlaneList[i] = temp;
    }
 
-   if (gServerContainer.buildPolyList(PLC_Collision, wBox, StaticShapeObjectType, &polyList))
+   if (getActiveServerContainer()->buildPolyList(PLC_Collision, wBox, StaticShapeObjectType, &polyList))
       return false;
    return true;
 }
@@ -4514,7 +4514,7 @@ DefineEngineMethod( ShapeBase, getLookAtPoint, const char*, ( F32 distance, U32 
    VectorF end = eyePos + eyeVector;
    
    RayInfo ri;
-   if( !gServerContainer.castRay( start, end, typeMask, &ri ) || !ri.object )
+   if( !getActiveServerContainer()->castRay( start, end, typeMask, &ri ) || !ri.object )
       return ""; // No hit.
    
    // Gather hit info.

--- a/Engine/source/T3D/tsStatic.h
+++ b/Engine/source/T3D/tsStatic.h
@@ -135,6 +135,8 @@ public:
       VisibleMesh = 3      ///< Rendered mesh polygons
    };
 
+   bool _createShape();
+
 protected:
    bool mUseAlphaFade;
    F32  mAlphaFadeStart;
@@ -163,7 +165,7 @@ protected:
    bool buildExportPolyList(ColladaUtils::ExportData* exportData, const Box3F& box, const SphereF&) override;
    void buildConvex(const Box3F& box, Convex* convex) override;
 
-   bool _createShape();
+   
 
    void _updatePhysics();
 

--- a/Engine/source/T3D/turret/aiTurretShape.cpp
+++ b/Engine/source/T3D/turret/aiTurretShape.cpp
@@ -730,7 +730,7 @@ void AITurretShape::_performScan()
       obj->disableCollision();
    }
 
-   gServerContainer.findObjects( mTransformedScanBox, sScanTypeMask, _scanCallback, (void*)this );
+   getActiveServerContainer()->findObjects( mTransformedScanBox, sScanTypeMask, _scanCallback, (void*)this );
 
    for ( SimSetIterator iter(&mIgnoreObjects); *iter; ++iter )
    {
@@ -968,7 +968,7 @@ bool AITurretShape::_testTargetLineOfSight(Point3F& aimPoint, ShapeBase* target,
    
    // First check for a clear line of sight to the target's center
    Point3F testPoint =  targetCenter;
-   hit = gServerContainer.castRay(aimPoint, testPoint, sAimTypeMask, &ri);
+   hit = getActiveServerContainer()->castRay(aimPoint, testPoint, sAimTypeMask, &ri);
    if (hit)
    {
       // No clear line of sight to center, so try to the target's right.  Players holding
@@ -984,14 +984,14 @@ bool AITurretShape::_testTargetLineOfSight(Point3F& aimPoint, ShapeBase* target,
 
       testPoint = targetCenter + toTurretRight * radius;
 
-      hit = gServerContainer.castRay(aimPoint, testPoint, sAimTypeMask, &ri);
+      hit = getActiveServerContainer()->castRay(aimPoint, testPoint, sAimTypeMask, &ri);
 
       if (hit)
       {
          // No clear line of sight to right, so try the target's left
          VectorF toTurretLeft = toTurretRight * -1.0f;
          testPoint = targetCenter + toTurretLeft * radius;
-         hit = gServerContainer.castRay(aimPoint, testPoint, sAimTypeMask, &ri);
+         hit = getActiveServerContainer()->castRay(aimPoint, testPoint, sAimTypeMask, &ri);
       }
 
       if (hit)
@@ -999,7 +999,7 @@ bool AITurretShape::_testTargetLineOfSight(Point3F& aimPoint, ShapeBase* target,
          // No clear line of sight to left, so try the target's top
          testPoint = targetCenter;
          testPoint.z += targetBounds.len_z() * 0.5f;
-         hit = gServerContainer.castRay(aimPoint, testPoint, sAimTypeMask, &ri);
+         hit = getActiveServerContainer()->castRay(aimPoint, testPoint, sAimTypeMask, &ri);
       }
 
       if (hit)
@@ -1007,7 +1007,7 @@ bool AITurretShape::_testTargetLineOfSight(Point3F& aimPoint, ShapeBase* target,
          // No clear line of sight to top, so try the target's bottom
          testPoint = targetCenter;
          testPoint.z -= targetBounds.len_z() * 0.5f;
-         hit = gServerContainer.castRay(aimPoint, testPoint, sAimTypeMask, &ri);
+         hit = getActiveServerContainer()->castRay(aimPoint, testPoint, sAimTypeMask, &ri);
       }
    }
    

--- a/Engine/source/afx/afxCamera.cpp
+++ b/Engine/source/afx/afxCamera.cpp
@@ -243,7 +243,7 @@ void afxCamera::validateEyePoint(F32 pos, MatrixF *mat)
       disableCollision();
       RayInfo collision;
 
-      SceneContainer* pContainer = isServerObject() ? &gServerContainer : &gClientContainer;
+      SceneContainer* pContainer = isServerObject() ? getActiveServerContainer() : getActiveClientContainer();
       if (!pContainer->castRay(startPos, startPos - dir * 2.5 * pos, afxCameraData::sCameraCollisionMask, &collision))
          endPos = startPos - dir * pos;
       else

--- a/Engine/source/afx/afxConstraint.cpp
+++ b/Engine/source/afx/afxConstraint.cpp
@@ -1034,7 +1034,7 @@ void afxConstraintMgr::initConstraintDefs(Vector<afxConstraintDef>& all_defs, bo
     mScoping_dist_sq = scoping_dist*scoping_dist;
   else
   {
-    SceneManager* sg = (on_server) ? gServerSceneGraph : gClientSceneGraph;
+    SceneManager* sg = (on_server) ? getActiveServerScene() : getActiveClientScene();
     F32 vis_dist = (sg) ? sg->getVisibleDistance() : 1000.0f;
 	mScoping_dist_sq = vis_dist*vis_dist;
   }

--- a/Engine/source/afx/afxMagicMissile.cpp
+++ b/Engine/source/afx/afxMagicMissile.cpp
@@ -1211,7 +1211,7 @@ bool afxMagicMissile::pointInWater(const Point3F &point)
       // but using the actual defined container when possible is the right
       // thing to do.  DAW
       AssertFatal(isClientObject(), "Server projectile has not been properly added");
-      gClientContainer.findObjects( boundsBox, WaterObjectType, findRouter, &info );
+      getActiveClientContainer()->findObjects( boundsBox, WaterObjectType, findRouter, &info );
    }
 
    return ( info.waterCoverage > 0.0f );
@@ -1244,7 +1244,7 @@ void afxMagicMissile::emitParticles(const Point3F& from, const Point3F& to, cons
    {
       // cast the ray to get the surface point of the water
       RayInfo rInfo;
-      if (gClientContainer.castRay(from, to, WaterObjectType, &rInfo))
+      if (getActiveClientContainer()->castRay(from, to, WaterObjectType, &rInfo))
       {
          create_splash(rInfo.point);
 
@@ -1261,7 +1261,7 @@ void afxMagicMissile::emitParticles(const Point3F& from, const Point3F& to, cons
       // cast the ray in the opposite direction since that point is out of the water, otherwise
       //  we hit water immediately and wont get the appropriate surface point
       RayInfo rInfo;
-      if (gClientContainer.castRay(to, from, WaterObjectType, &rInfo))
+      if (getActiveClientContainer()->castRay(to, from, WaterObjectType, &rInfo))
       {
       create_splash(rInfo.point);
 
@@ -1434,7 +1434,7 @@ void afxMagicMissile::processTick(const Move* move)
       if (ht < ht_min)
          ht = ht_min;
 
-      SceneContainer* container = (isServerObject()) ? &gServerContainer : &gClientContainer;
+      SceneContainer* container = (isServerObject()) ? getActiveServerContainer() : getActiveClientContainer();
       Point3F above_pos = new_pos; above_pos.z += 10000;
       Point3F below_pos = new_pos; below_pos.z -= 10000;
       RayInfo rInfo;

--- a/Engine/source/afx/arcaneFX.cpp
+++ b/Engine/source/afx/arcaneFX.cpp
@@ -476,7 +476,7 @@ S32 arcaneFX::rolloverRayCast(Point3F start, Point3F end, U32 mask)
   SceneObject* picked_obj = 0;
 
   RayInfo hit_info;
-  if (gClientContainer.castRay(start, end, mask, &hit_info))
+  if (getActiveClientContainer()->castRay(start, end, mask, &hit_info))
     picked_obj = dynamic_cast<SceneObject*>(hit_info.object);
 
   if (ctrl_obj)
@@ -503,7 +503,7 @@ bool arcaneFX::freeTargetingRayCast(Point3F start, Point3F end, U32 mask)
   sIsFreeTargeting = true;
 
   RayInfo hit_info;
-  if (!gClientContainer.castRay(start, end, mask, &hit_info))
+  if (!getActiveClientContainer()->castRay(start, end, mask, &hit_info))
   {
     sFreeTargetPosValid = false;
     return false;

--- a/Engine/source/afx/ce/afxModel.cpp
+++ b/Engine/source/afx/ce/afxModel.cpp
@@ -573,7 +573,7 @@ bool afxModel::onAdd()
   }
 
   // tell engine the model exists
-  gClientSceneGraph->addObjectToScene(this);
+  getActiveClientScene()->addObjectToScene(this);
   removeFromProcessList();
   ClientProcessList::get()->addObject(this);
   conn->addObject(this);

--- a/Engine/source/afx/ce/afxParticleEmitter.cpp
+++ b/Engine/source/afx/ce/afxParticleEmitter.cpp
@@ -1015,7 +1015,7 @@ void afxParticleEmitter::afx_emitParticles(const Point3F& start, const Point3F& 
 
   if( n_parts > 0 && mSceneManager == NULL )
   {
-     gClientSceneGraph->addObjectToScene(this);
+     getActiveClientScene()->addObjectToScene(this);
      ClientProcessList::get()->addObject(this);
   }
 

--- a/Engine/source/afx/ce/afxParticleEmitter.cpp
+++ b/Engine/source/afx/ce/afxParticleEmitter.cpp
@@ -1499,12 +1499,12 @@ void afxParticleEmitterPath::groundConformPoint(Point3F& point, const MatrixF& m
     
     Point3F above_pos(point); above_pos.z += 0.1f;
     Point3F below_pos(point); below_pos.z -= 10000;
-    hit = gClientContainer.castRay(above_pos, below_pos, mask, &rInfo);
+    hit = getActiveClientContainer()->castRay(above_pos, below_pos, mask, &rInfo);
     if (!hit)
     {
       above_pos.z = point.z + 10000;
       below_pos.z = point.z - 0.1f;
-      hit = gClientContainer.castRay(below_pos, above_pos, mask, &rInfo);
+      hit = getActiveClientContainer()->castRay(below_pos, above_pos, mask, &rInfo);
     }
   }
   else if (mDataBlock->ground_conform_terrain)
@@ -1512,7 +1512,7 @@ void afxParticleEmitterPath::groundConformPoint(Point3F& point, const MatrixF& m
     U32 mask = TerrainObjectType | TerrainLikeObjectType;
     Point3F above_pos(point); above_pos.z += 10000;
     Point3F below_pos(point); below_pos.z -= 10000;
-    hit = gClientContainer.castRay(above_pos, below_pos, mask, &rInfo);
+    hit = getActiveClientContainer()->castRay(above_pos, below_pos, mask, &rInfo);
   }
 
   if (hit)

--- a/Engine/source/afx/ea/afxEA_AreaDamage.cpp
+++ b/Engine/source/afx/ea/afxEA_AreaDamage.cpp
@@ -142,11 +142,11 @@ void afxEA_AreaDamage::do_runtime_substitutions()
 void afxEA_AreaDamage::deal_area_damage()
 { 
   // initContainerRadiusSearch -- afterwards Container::mSearchList contains objects within radius sorted by distance
-  gServerContainer.initRadiusSearch(impact_pos, damage_data->radius, ShapeBaseObjectType);
+  getActiveServerContainer()->initRadiusSearch(impact_pos, damage_data->radius, ShapeBaseObjectType);
   
   F32 halfradius = damage_data->radius*0.5f;
 
-  const Vector<SimObjectPtr<SceneObject>*>& list = gServerContainer.getRadiusSearchList();
+  const Vector<SimObjectPtr<SceneObject>*>& list = getActiveServerContainer()->getRadiusSearchList();
   for (S32 i = 0; i < list.size(); i++)
   {
     if (!list[i]->isNull())

--- a/Engine/source/afx/ui/afxGuiTextHud.cpp
+++ b/Engine/source/afx/ui/afxGuiTextHud.cpp
@@ -24,7 +24,7 @@
 //~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~//~~~~~~~~~~~~~~~~~~~~~//
 
 #include "afx/arcaneFX.h"
-
+#include "scene/sceneManager.h"
 #include "gui/3d/guiTSControl.h"
 #include "gfx/gfxDrawUtil.h"
 #include "T3D/gameBase/gameConnection.h"
@@ -131,7 +131,7 @@ void afxGuiTextHud::onRender( Point2I, const RectI &updateRect)
    camFovCos = mCos(mDegToRad(camFovCos) / 2);
 
    // Visible distance info & name fading
-   F32 visDistance = gClientSceneGraph->getVisibleDistance();
+   F32 visDistance = getActiveClientScene()->getVisibleDistance();
    F32 visDistanceSqr = visDistance * visDistance;
    F32 fadeDistance = visDistance * mDistanceFade;
 

--- a/Engine/source/afx/ui/afxGuiTextHud.cpp
+++ b/Engine/source/afx/ui/afxGuiTextHud.cpp
@@ -201,7 +201,7 @@ void afxGuiTextHud::onRender( Point2I, const RectI &updateRect)
            SceneObject *mount = shape->getObjectMount();
            if (mount)
              mount->disableCollision();
-           bool los = !gClientContainer.castRay(camPos, shapePos,losMask, &info);
+           bool los = !getActiveClientContainer()->castRay(camPos, shapePos,losMask, &info);
            shape->enableCollision();
            if (mount)
              mount->enableCollision();
@@ -253,7 +253,7 @@ void afxGuiTextHud::onRender( Point2I, const RectI &updateRect)
        RayInfo info;
        if (spec->obj)
          spec->obj->disableCollision();
-       bool los = !gClientContainer.castRay(camPos, spec->pos, losMask, &info);
+       bool los = !getActiveClientContainer()->castRay(camPos, spec->pos, losMask, &info);
        if (spec->obj)
          spec->obj->enableCollision();
        if (!los)

--- a/Engine/source/afx/xm/afxXM_AltitudeConform.cpp
+++ b/Engine/source/afx/xm/afxXM_AltitudeConform.cpp
@@ -158,7 +158,7 @@ afxXM_AltitudeConform::afxXM_AltitudeConform(afxXM_AltitudeConformData* db, afxE
 : afxXM_WeightedBase(db, fxw) 
 { 
   mConformData = db;
-  mContainer = (on_server) ? &gServerContainer : &gClientContainer;
+  mContainer = (on_server) ? getActiveServerContainer() : getActiveClientContainer();
   mDo_freeze = db->do_freeze;
   mIs_frozen = false;
   mTerrain_alt = -1.0f;

--- a/Engine/source/afx/xm/afxXM_GroundConform.cpp
+++ b/Engine/source/afx/xm/afxXM_GroundConform.cpp
@@ -150,7 +150,7 @@ afxXM_GroundConform::afxXM_GroundConform(afxXM_GroundConformData* db, afxEffectW
 : afxXM_WeightedBase(db, fxw) 
 { 
   this->db = db;
-  this->container = (on_server) ? &gServerContainer : &gClientContainer;
+  this->container = (on_server) ? getActiveServerContainer() : getActiveClientContainer();
 }
 
 void afxXM_GroundConform::updateParams(F32 dt, F32 elapsed, afxXM_Params& params)

--- a/Engine/source/environment/VolumetricFogRTManager.cpp
+++ b/Engine/source/environment/VolumetricFogRTManager.cpp
@@ -46,12 +46,12 @@ MODULE_SHUTDOWN_BEFORE(Scene)
 MODULE_INIT
 {
    gVolumetricFogRTManager = new VolumetricFogRTManager;
-   gClientSceneGraph->addObjectToScene(gVolumetricFogRTManager);
+   getActiveClientScene()->addObjectToScene(gVolumetricFogRTManager);
 }
    
 MODULE_SHUTDOWN
 {
-   gClientSceneGraph->removeObjectFromScene(gVolumetricFogRTManager);
+   getActiveClientScene()->removeObjectFromScene(gVolumetricFogRTManager);
    SAFE_DELETE(gVolumetricFogRTManager);
 }
    

--- a/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
@@ -461,7 +461,7 @@ void GuiMeshRoadEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
    Point3F endPnt = event.pos + event.vec * 2000.0f;
    RayInfo ri;   
 
-   if ( gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
+   if ( getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
       endPnt = ri.point;
 
    DebugDrawer *ddraw = DebugDrawer::get();
@@ -497,7 +497,7 @@ void GuiMeshRoadEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
    }
 
    /*
-   else if ( gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
+   else if ( getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
    {
       MeshRoad *pRoad = NULL;
       pRoad = dynamic_cast<MeshRoad*>(ri.object);
@@ -870,7 +870,7 @@ void GuiMeshRoadEditorCtrl::on3DMouseMove(const Gui3DMouseEvent & event)
 
       RayInfo ri;   
 
-      if ( gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
+      if ( getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
       {         
          MeshRoad *pRoad = NULL;
          pRoad = dynamic_cast<MeshRoad*>(ri.object);         
@@ -1441,7 +1441,7 @@ bool GuiMeshRoadEditorCtrl::getStaticPos( const Gui3DMouseEvent & event, Point3F
    RayInfo ri;
    bool hit;         
          
-   hit = gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri);    
+   hit = getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri);    
    tpos = ri.point;
    
    return hit;

--- a/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRiverEditorCtrl.cpp
@@ -259,7 +259,7 @@ void GuiRiverEditorCtrl::_process3DMouseDown( const Gui3DMouseEvent& event )
 
    RayInfo ri;   
 
-   if ( gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
+   if ( getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
       endPnt = ri.point;
 
    River *riverPtr = NULL;
@@ -649,7 +649,7 @@ void GuiRiverEditorCtrl::on3DMouseMove(const Gui3DMouseEvent & event)
 
       RayInfo ri;   
 
-      if ( gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
+      if ( getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri) )
          endPnt = ri.point;
 
       River *pRiver = NULL;
@@ -1096,7 +1096,7 @@ bool GuiRiverEditorCtrl::getStaticPos( const Gui3DMouseEvent & event, Point3F &t
    RayInfo ri;
    bool hit;         
          
-   hit = gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri);    
+   hit = getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri);    
    tpos = ri.point;
    
    return hit;

--- a/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
@@ -569,7 +569,7 @@ void GuiRoadEditorCtrl::on3DMouseMove(const Gui3DMouseEvent & event)
       Point3F startPnt = event.pos;
       Point3F endPnt = event.pos + event.vec * 1000.0f;
       RayInfo ri;   
-      if ( gServerContainer.castRay(startPnt, endPnt, TerrainObjectType, &ri) )
+      if ( getActiveServerContainer()->castRay(startPnt, endPnt, TerrainObjectType, &ri) )
       {
          mSelRoad->setNodePosition( mSelNode, ri.point );
          mIsDirty = true;
@@ -588,7 +588,7 @@ void GuiRoadEditorCtrl::on3DMouseMove(const Gui3DMouseEvent & event)
 
       RayInfo ri;   
 
-      if ( gServerContainer.castRay(startPnt, endPnt, TerrainObjectType, &ri) )
+      if ( getActiveServerContainer()->castRay(startPnt, endPnt, TerrainObjectType, &ri) )
       {         
          DecalRoad *pRoad = NULL;
 
@@ -872,7 +872,7 @@ bool GuiRoadEditorCtrl::getTerrainPos( const Gui3DMouseEvent & event, Point3F &t
    RayInfo ri;
    bool hit;         
          
-   hit = gServerContainer.castRay(startPnt, endPnt, TerrainObjectType, &ri);    
+   hit = getActiveServerContainer()->castRay(startPnt, endPnt, TerrainObjectType, &ri);    
    tpos = ri.point;
    
    return hit;

--- a/Engine/source/environment/sun.cpp
+++ b/Engine/source/environment/sun.cpp
@@ -408,6 +408,21 @@ void Sun::setColor( const LinearColorF &color )
    setMaskBits( UpdateMask ); // TODO: Break out the masks to save some space!
 }
 
+void Sun::setAmbientColor(const LinearColorF& color)
+{
+   mLightAmbient = color;
+   _conformLights();
+   setMaskBits(UpdateMask); // TODO: Break out the masks to save some space!
+}
+
+void Sun::setDirection(F32 azimuth, F32 elevation)
+{
+   mSunAzimuth = azimuth;
+   mSunElevation = elevation;
+   _conformLights();
+   setMaskBits(UpdateMask); // TODO: Break out the masks to save some space!
+}
+
 void Sun::animate( F32 duration, F32 startAzimuth, F32 endAzimuth, F32 startElevation, F32 endElevation )
 {
    mAnimateSun = true;
@@ -424,8 +439,8 @@ void Sun::animate( F32 duration, F32 startAzimuth, F32 endAzimuth, F32 startElev
 void Sun::_conformLights()
 {
    // Build the light direction from the azimuth and elevation.
-   F32 yaw = mDegToRad(mClampF(mSunAzimuth,0,359));
-   F32 pitch = mDegToRad(mClampF(mSunElevation,-360,+360));
+   F32 yaw = mDegToRad(mWrapF(mSunAzimuth,0,359));
+   F32 pitch = mDegToRad(mWrapF(mSunElevation,-180,+180));
    VectorF lightDirection;
    MathUtils::getVectorFromAngles(lightDirection, yaw, pitch);
    lightDirection.normalize();

--- a/Engine/source/environment/sun.h
+++ b/Engine/source/environment/sun.h
@@ -49,7 +49,7 @@ class Sun : public SceneObject, public ISceneLight
 protected:
 
    F32 mSunAzimuth;
-   
+
    F32 mSunElevation;
 
    LinearColorF mLightColor;
@@ -70,9 +70,9 @@ protected:
    S32 mStaticRefreshFreq;
    S32 mDynamicRefreshFreq;
 
-   LightInfo *mLight;
+   LightInfo* mLight;
 
-   LightFlareData *mFlareData;
+   LightFlareData* mFlareData;
    LightFlareState mFlareState;
    F32 mFlareScale;
 
@@ -81,8 +81,8 @@ protected:
    DECLARE_MATERIALASSET(Sun, CoronaMaterial);
    DECLARE_ASSET_NET_SETGET(Sun, CoronaMaterial, UpdateMask);
 
-   BaseMatInstance *mCoronaMatInst;
-   MatrixSet *mMatrixSet;   
+   BaseMatInstance* mCoronaMatInst;
+   MatrixSet* mMatrixSet;
    F32 mCoronaScale;
    LinearColorF mCoronaTint;
    bool mCoronaUseLightColor;
@@ -94,14 +94,14 @@ protected:
 
    void _conformLights();
    void _initCorona();
-   void _renderCorona( ObjectRenderInst *ri, SceneRenderState *state, BaseMatInstance *overrideMat );
-   void _updateTimeOfDay( TimeOfDay *timeOfDay, F32 time );
+   void _renderCorona(ObjectRenderInst* ri, SceneRenderState* state, BaseMatInstance* overrideMat);
+   void _updateTimeOfDay(TimeOfDay* timeOfDay, F32 time);
 
    // SimObject.
    void _onSelected() override;
    void _onUnselected() override;
 
-   enum NetMaskBits 
+   enum NetMaskBits
    {
       UpdateMask = BIT(0)
    };
@@ -122,27 +122,35 @@ public:
    void inspectPostApply() override;
 
    // NetObject
-   U32 packUpdate( NetConnection *conn, U32 mask, BitStream *stream ) override;
-   void unpackUpdate( NetConnection *conn, BitStream *stream ) override; 
+   U32 packUpdate(NetConnection* conn, U32 mask, BitStream* stream) override;
+   void unpackUpdate(NetConnection* conn, BitStream* stream) override;
 
    // ISceneLight
-   void submitLights( LightManager *lm, bool staticLighting ) override;
-   LightInfo* getLight() override { return mLight; }   
+   void submitLights(LightManager* lm, bool staticLighting) override;
+   LightInfo* getLight() override { return mLight; }
 
    // SceneObject   
-   void prepRenderImage( SceneRenderState* state ) override;
+   void prepRenderImage(SceneRenderState* state) override;
 
    // ProcessObject
-   void advanceTime( F32 dt ) override;
+   void advanceTime(F32 dt) override;
 
    ///
-   void setAzimuth( F32 azimuth );
+   void setAzimuth(F32 azimuth);
+   F32 getAzimuth() { return mSunAzimuth; }
 
    ///
-   void setElevation( F32 elevation );
+   void setElevation(F32 elevation);
+   F32 getElevation() { return mSunElevation; }
 
    ///
    void setColor( const LinearColorF &color );
+
+   ///
+   void setAmbientColor(const LinearColorF& color);
+
+   ///
+   void setDirection(F32 azimuth, F32 elevation);
 
    ///
    void animate( F32 duration, F32 startAzimuth, F32 endAzimuth, F32 startElevation, F32 endElevation );

--- a/Engine/source/environment/waterBlock.cpp
+++ b/Engine/source/environment/waterBlock.cpp
@@ -238,7 +238,7 @@ void WaterBlock::setupVertexBlock( U32 width, U32 height, U32 rowOffset )
          // currently just testing for terrain and atlas
          // objects, but potentially any object that responds
          // to a ray cast could detected.
-         if(gClientContainer.castRay(start, end, 
+         if(getActiveClientContainer()->castRay(start, end, 
             //StaticObjectType | 
             //InteriorObjectType | 
             //ShapeBaseObjectType | 
@@ -275,7 +275,7 @@ void WaterBlock::setupVertexBlock( U32 width, U32 height, U32 rowOffset )
          // Cast a ray to do some AO-style shadowing.
          F32 &shadow = vert->depthData.y;
 
-         if(gClientContainer.castRay(worldPoint, worldPoint + sunVector * 9000.f, 
+         if(getActiveClientContainer()->castRay(worldPoint, worldPoint + sunVector * 9000.f, 
             //StaticObjectType | 
             //InteriorObjectType | 
             //ShapeBaseObjectType | 

--- a/Engine/source/forest/editor/forestBrushTool.cpp
+++ b/Engine/source/forest/editor/forestBrushTool.cpp
@@ -229,7 +229,7 @@ void ForestBrushTool::onRender2D()
       end.x = start.x = mLastBrushPoint.x + vec.x * mSize;
       end.y = start.y = mLastBrushPoint.y + vec.y * mSize;
 
-      bool hit = gServerContainer.castRay( start, end, TerrainObjectType | StaticShapeObjectType, &ri );
+      bool hit = getActiveServerContainer()->castRay( start, end, TerrainObjectType | StaticShapeObjectType, &ri );
 
       if ( hit )
          pointList.push_back( ri.point );
@@ -557,7 +557,7 @@ bool ForestBrushTool::_updateBrushPoint( const Gui3DMouseEvent &event_ )
       mForest->disableCollision();
 
    RayInfo rinfo;
-   mDrawBrush = gServerContainer.castRay( start, end, mask, &rinfo );
+   mDrawBrush = getActiveServerContainer()->castRay( start, end, mask, &rinfo );
 
    if ( mForest )
       mForest->enableCollision();
@@ -673,7 +673,7 @@ bool ForestBrushTool::getGroundAt( const Point3F &worldPt, F32 *zValueOut, Vecto
    // the bottom of our brush radius.
 
    RayInfo rinfo;   
-   bool hit = gServerContainer.castRay( start, end, mask, &rinfo );
+   bool hit = getActiveServerContainer()->castRay( start, end, mask, &rinfo );
 
    if ( mForest )
       mForest->enableCollision();

--- a/Engine/source/forest/editor/forestEditorCtrl.cpp
+++ b/Engine/source/forest/editor/forestEditorCtrl.cpp
@@ -373,7 +373,7 @@ void FindDirtyForests( SceneObject *obj, void *key )
 bool ForestEditorCtrl::isDirty()
 {   
    bool foundDirty = false;
-   gServerContainer.findObjects( EnvironmentObjectType, FindDirtyForests, (void*)&foundDirty );
+   getActiveServerContainer()->findObjects( EnvironmentObjectType, FindDirtyForests, (void*)&foundDirty );
 
    return foundDirty;   
 }

--- a/Engine/source/gui/3d/guiTSControl.cpp
+++ b/Engine/source/gui/3d/guiTSControl.cpp
@@ -401,7 +401,7 @@ void GuiTSCtrl::_internalRender(RectI guiViewport, RectI renderViewport, Frustum
    // We're going to be displaying this render at size of this control in
    // pixels - let the scene know so that it can calculate e.g. reflections
    // correctly for that final display result.
-   gClientSceneGraph->setDisplayTargetResolution(renderSize);
+   getActiveClientScene()->setDisplayTargetResolution(renderSize);
 
    // Set the GFX world matrix to the world-to-camera transform, but don't 
    // change the cameraMatrix in mLastCameraQuery. This is because 
@@ -421,7 +421,7 @@ void GuiTSCtrl::_internalRender(RectI guiViewport, RectI renderViewport, Frustum
 
    // Set the default non-clip projection as some 
    // objects depend on this even in non-reflect cases.
-   gClientSceneGraph->setNonClipProjection(mSaveProjection);
+   getActiveClientScene()->setNonClipProjection(mSaveProjection);
 
    // Give the post effect manager the worldToCamera, and cameraToScreen matrices
    PFXMGR->setFrameMatrices(mSaveModelview, mSaveProjection);

--- a/Engine/source/gui/controls/guiMaterialCtrl.cpp
+++ b/Engine/source/gui/controls/guiMaterialCtrl.cpp
@@ -148,10 +148,10 @@ void GuiMaterialCtrl::onRender( Point2I offset, const RectI &updateRect )
 
    SceneRenderState state
    (
-      gClientSceneGraph,
+      getActiveClientScene(),
       SPT_Diffuse,
       SceneCameraState( GFX->getViewport(), frust, GFX->getWorldMatrix(), GFX->getProjectionMatrix() ),
-      gClientSceneGraph->getDefaultRenderPass(),
+      getActiveClientScene()->getDefaultRenderPass(),
       false
    );
 

--- a/Engine/source/gui/editor/guiShapeEdPreview.cpp
+++ b/Engine/source/gui/editor/guiShapeEdPreview.cpp
@@ -1408,14 +1408,14 @@ void GuiShapeEdPreview::renderWorld(const RectI &updateRect)
    mSaveProjection = GFX->getProjectionMatrix();
    mSaveWorldToScreenScale = GFX->getWorldToScreenScale();
 
-   FogData savedFogData = gClientSceneGraph->getFogData();
-   gClientSceneGraph->setFogData( FogData() );  // no fog in preview window
+   FogData savedFogData = getActiveClientScene()->getFogData();
+   getActiveClientScene()->setFogData( FogData() );  // no fog in preview window
 
    if (Skylight::smSkylightProbe.isValid())
       PROBEMGR->submitProbe(Skylight::smSkylightProbe->getProbeInfo());
    SceneRenderState state
    (
-      gClientSceneGraph,
+      getActiveClientScene(),
       SPT_Diffuse,
       SceneCameraState( GFX->getViewport(), mSaveFrustum,
                         GFX->getWorldMatrix(), GFX->getProjectionMatrix() )
@@ -1554,7 +1554,7 @@ void GuiShapeEdPreview::renderWorld(const RectI &updateRect)
       }
    }
 
-   gClientSceneGraph->setFogData( savedFogData );         // restore fog setting
+   getActiveClientScene()->setFogData( savedFogData );         // restore fog setting
 }
 
 void GuiShapeEdPreview::renderGui(Point2I offset, const RectI& updateRect)

--- a/Engine/source/gui/shaderEditor/guiShaderEditor.h
+++ b/Engine/source/gui/shaderEditor/guiShaderEditor.h
@@ -118,7 +118,6 @@ public:
    void onRemove() override;
 
    void onPreRender() override;
-   void drawThickLine(const Point2I& pt1, const Point2I& pt2, U32 thickness = 2, ColorI col1 = ColorI(255, 255, 255), ColorI col2 = ColorI(255, 255, 255));
    void onRender(Point2I offset, const RectI& updateRect) override;
 
    // interaction

--- a/Engine/source/gui/worldEditor/editTSCtrl.cpp
+++ b/Engine/source/gui/worldEditor/editTSCtrl.cpp
@@ -1072,7 +1072,7 @@ void EditTSCtrl::computeSceneBounds(Box3F& bounds)
    bounds.maxExtents.set(-1e10, -1e10, -1e10);
 
    // Calculate the scene bounds
-   gClientContainer.findObjects(~(smSceneBoundsMask), sceneBoundsCalcCallback, &bounds);
+   getActiveClientContainer()->findObjects(~(smSceneBoundsMask), sceneBoundsCalcCallback, &bounds);
 }
 
 bool EditTSCtrl::processCameraQuery(CameraQuery * query)

--- a/Engine/source/gui/worldEditor/editTSCtrl.cpp
+++ b/Engine/source/gui/worldEditor/editTSCtrl.cpp
@@ -772,35 +772,35 @@ void EditTSCtrl::renderWorld(const RectI & updateRect)
 
    updateGizmo();
 
-   gClientSceneGraph->setDisplayTargetResolution(getExtent());
+   getActiveClientScene()->setDisplayTargetResolution(getExtent());
 
    // Use a render instance to do editor 3D scene 
    // rendering after HDR is processed and while the depth 
    // buffer is still intact.
-   RenderPassManager *rpm = gClientSceneGraph->getDefaultRenderPass();
+   RenderPassManager *rpm = getActiveClientScene()->getDefaultRenderPass();
    ObjectRenderInst *inst = rpm->allocInst<ObjectRenderInst>();
    inst->type = RenderPassManager::RIT_Editor;
    inst->renderDelegate.bind(this, &EditTSCtrl::_renderScene);
    rpm->addInst(inst);
 
    if( mDisplayType == DisplayTypePerspective )
-      gClientSceneGraph->renderScene( SPT_Diffuse );
+      getActiveClientScene()->renderScene( SPT_Diffuse );
    else
    {
       // If we are in an orthographic mode, do a special render
       // with AL, fog, and PostFX disabled.
 
-      FogData savedFogData = gClientSceneGraph->getFogData();
-      gClientSceneGraph->setFogData( FogData() );
+      FogData savedFogData = getActiveClientScene()->getFogData();
+      getActiveClientScene()->setFogData( FogData() );
 
       SceneRenderState renderState
       (
-         gClientSceneGraph,
+         getActiveClientScene(),
          SPT_Diffuse
       );
 
-      gClientSceneGraph->renderScene( &renderState );
-      gClientSceneGraph->setFogData( savedFogData );
+      getActiveClientScene()->renderScene( &renderState );
+      getActiveClientScene()->setFogData( savedFogData );
    }
 }
 
@@ -1088,8 +1088,8 @@ bool EditTSCtrl::processCameraQuery(CameraQuery * query)
 
    if (getCameraTransform(&query->cameraMatrix))
    {
-      query->farPlane = gClientSceneGraph->getVisibleDistance() * smVisibleDistanceScale;
-      query->nearPlane = gClientSceneGraph->getNearClip();
+      query->farPlane = getActiveClientScene()->getVisibleDistance() * smVisibleDistanceScale;
+      query->nearPlane = getActiveClientScene()->getNearClip();
       query->fov = mDegToRad(smCamFOV);
 
       if(query->ortho)

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
@@ -1778,7 +1778,7 @@ bool GuiConvexEditorCtrl::_cursorCast( const Gui3DMouseEvent &event, ConvexShape
 {
    RayInfo ri;
    
-   if ( gServerContainer.castRay( event.pos, event.pos + event.vec * 10000.0f, StaticShapeObjectType, &ri, &GuiConvexEditorCtrl::_cursorCastCallback ) &&
+   if ( getActiveServerContainer()->castRay( event.pos, event.pos + event.vec * 10000.0f, StaticShapeObjectType, &ri, &GuiConvexEditorCtrl::_cursorCastCallback ) &&
         dynamic_cast< ConvexShape* >( ri.object ) )
    {
       // Do not select or edit ConvexShapes that are within a Prefab.
@@ -2233,7 +2233,7 @@ ConvexEditorTool::EventResult ConvexEditorCreateTool::on3DMouseDown( const Gui3D
       Point3F end( event.pos + event.vec * 10000.0f );      
       RayInfo ri;
       
-      bool hit = gServerContainer.castRay( event.pos, end, STATIC_COLLISION_TYPEMASK, &ri );
+      bool hit = getActiveServerContainer()->castRay( event.pos, end, STATIC_COLLISION_TYPEMASK, &ri );
 
       MatrixF objMat( true );
 

--- a/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
@@ -604,7 +604,7 @@ bool GuiDecalEditorCtrl::getRayInfo( const Gui3DMouseEvent & event, RayInfo *rIn
 
    bool hit;         
          
-   hit = gServerContainer.castRayRendered( startPnt, endPnt, STATIC_COLLISION_TYPEMASK, rInfo );    
+   hit = getActiveServerContainer()->castRayRendered( startPnt, endPnt, STATIC_COLLISION_TYPEMASK, rInfo );    
    
    return hit;
 }

--- a/Engine/source/gui/worldEditor/terrainEditor.cpp
+++ b/Engine/source/gui/worldEditor/terrainEditor.cpp
@@ -520,7 +520,7 @@ void BoxBrush::_renderOutline()
          start.x = end.x = mousePos.x + tmp.x * squareSize * 0.5f * (F32)mSize.x;
          start.y = end.y = mousePos.y + tmp.y * squareSize * 0.5f * (F32)mSize.y;
 
-         hit = gServerContainer.castRay( start, end, TerrainObjectType, &ri );
+         hit = getActiveServerContainer()->castRay( start, end, TerrainObjectType, &ri );
 
          if ( hit )
             pointList.push_back( ri.point );
@@ -637,7 +637,7 @@ void EllipseBrush::_renderOutline()
       start.x = end.x = mousePos.x + vec.x * squareSize * (F32)mSize.x * 0.5f;
       start.y = end.y = mousePos.y + vec.y * squareSize * (F32)mSize.y * 0.5f;
 
-      hit = gServerContainer.castRay( start, end, TerrainObjectType, &ri );
+      hit = getActiveServerContainer()->castRay( start, end, TerrainObjectType, &ri );
 
       if ( hit )
          pointList.push_back( ri.point );
@@ -1204,7 +1204,7 @@ TerrainBlock* TerrainEditor::collide(const Gui3DMouseEvent & evt, Point3F & pos)
    Point3F end( evt.pos + ( evt.vec * 10000.0f ) );
 
    RayInfo rinfo;
-   bool hit = gServerContainer.castRay( start, end, mask, &rinfo );
+   bool hit = getActiveServerContainer()->castRay( start, end, mask, &rinfo );
 
    if ( !hit )
       return NULL;

--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -777,7 +777,7 @@ void WorldEditor::dropBelowSelection(Selection*  sel, const Point3F & centroid, 
    sel->disableCollision(); // Make sure we don't hit ourselves.
 
    RayInfo ri;
-   bool hit = gServerContainer.castRay(start, end, STATIC_COLLISION_TYPEMASK, &ri);
+   bool hit = getActiveServerContainer()->castRay(start, end, STATIC_COLLISION_TYPEMASK, &ri);
       
    sel->enableCollision();
 
@@ -816,9 +816,9 @@ void WorldEditor::terrainSnapSelection(Selection* sel, U8 modifier, Point3F gizm
    RayInfo ri;
    bool hit;
    if(mBoundingBoxCollision)
-      hit = gServerContainer.collideBox(start, end, TerrainObjectType, &ri);
+      hit = getActiveServerContainer()->collideBox(start, end, TerrainObjectType, &ri);
    else
-      hit = gServerContainer.castRay(start, end, TerrainObjectType, &ri);
+      hit = getActiveServerContainer()->castRay(start, end, TerrainObjectType, &ri);
       
    sel->enableCollision();
 
@@ -925,7 +925,7 @@ void WorldEditor::softSnapSelection(Selection* sel, U8 modifier, Point3F gizmoPo
 
    SphereF sphere(gizmoPos, mSoftSnapPreBounds.len()*0.5f);
 
-   gServerContainer.findObjectList(mSoftSnapPreBounds, 0xFFFFFFFF, &foundobjs);
+   getActiveServerContainer()->findObjectList(mSoftSnapPreBounds, 0xFFFFFFFF, &foundobjs);
 
    sel->enableCollision();
 
@@ -1123,7 +1123,7 @@ bool WorldEditor::collide( const Gui3DMouseEvent &event, SceneObject **hitObj )
       Point3F endPnt = event.pos + event.vec * smProjectDistance;
       RayInfo ri;
 
-      bool hit = gServerContainer.collideBox(startPnt, endPnt, 0xFFFFFFFF, &ri);
+      bool hit = getActiveServerContainer()->collideBox(startPnt, endPnt, 0xFFFFFFFF, &ri);
 
       if ( controlObj )
          controlObj->enableCollision();
@@ -1154,7 +1154,7 @@ bool WorldEditor::collide( const Gui3DMouseEvent &event, SceneObject **hitObj )
       Point3F endPnt = event.pos + event.vec * smProjectDistance;
       RayInfo ri;
 
-      bool hit = gServerContainer.castRayRendered(startPnt, endPnt, 0xFFFFFFFF, &ri);
+      bool hit = getActiveServerContainer()->castRayRendered(startPnt, endPnt, 0xFFFFFFFF, &ri);
       if(hit && ri.object && ( ri.object->getTypeMask() & (TerrainObjectType) || dynamic_cast< GroundPlane* >( ri.object )))
       {
          // We don't want to mesh select terrain
@@ -2693,7 +2693,7 @@ void WorldEditor::renderScene( const RectI &updateRect )
          data.mPolyList.mPlaneList.push_back(planes[i]);
 
          // Invert the planes as the poly list routines require a different
-         // facing from gServerContainer.findObjects().
+         // facing from getActiveServerContainer()->findObjects().
          data.mPolyList.mPlaneList.last().invert();
       }
       
@@ -2706,7 +2706,7 @@ void WorldEditor::renderScene( const RectI &updateRect )
          
       // Find objects in the region.
 
-      gServerContainer.findObjects( gDragFrustum, 0xFFFFFFFF, findDragMeshCallback, &data);
+      getActiveServerContainer()->findObjects( gDragFrustum, 0xFFFFFFFF, findDragMeshCallback, &data);
       for ( U32 i = 0; i < data.mObjects.size(); i++ )
       {
          SceneObject *obj = data.mObjects[i];
@@ -2736,7 +2736,7 @@ void WorldEditor::renderScene( const RectI &updateRect )
 
    // Cull Objects and perform icon rendering
    Vector<SceneObject *> objects;
-   gServerContainer.findObjects( frustum, 0xFFFFFFFF, findObjectsCallback, &objects);
+   getActiveServerContainer()->findObjects( frustum, 0xFFFFFFFF, findObjectsCallback, &objects);
    for ( U32 i = 0; i < objects.size(); i++ )
    {
       SceneObject *obj = objects[i];

--- a/Engine/source/lighting/advanced/advancedLightManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightManager.cpp
@@ -96,13 +96,13 @@ bool AdvancedLightManager::isCompatible() const
    return true;
 }
 
-void AdvancedLightManager::activate( SceneManager *sceneManager )
+void AdvancedLightManager::activate()
 {
-   Parent::activate( sceneManager );
+   Parent::activate(  );
 
    GFXShader::addGlobalMacro( "TORQUE_ADVANCED_LIGHTING" );
 
-   sceneManager->setPostEffectFog( true );
+   getActiveClientScene()->setPostEffectFog( true );
 
    SHADOWMGR->activate();
 
@@ -126,7 +126,7 @@ void AdvancedLightManager::activate( SceneManager *sceneManager )
       deferredBin = new RenderDeferredMgr(true, blendTargetFormat);
       deferredBin->assignName("AL_DeferredBin");
       deferredBin->registerObject();
-      getSceneManager()->getDefaultRenderPass()->addManager(deferredBin);
+      getActiveClientScene()->getDefaultRenderPass()->addManager(deferredBin);
       mDeferredRenderBin = deferredBin;
    }
 
@@ -138,7 +138,7 @@ void AdvancedLightManager::activate( SceneManager *sceneManager )
 
    // Insert our light bin manager.
    mLightBinManager->setRenderOrder( deferredBin->getRenderOrder() + 0.01f );
-   getSceneManager()->getDefaultRenderPass()->addManager( mLightBinManager );
+   getActiveClientScene()->getDefaultRenderPass()->addManager( mLightBinManager );
 
    AdvancedLightingFeatures::registerFeatures(mDeferredRenderBin->getTargetFormat(), blendTargetFormat);
 

--- a/Engine/source/lighting/advanced/advancedLightManager.h
+++ b/Engine/source/lighting/advanced/advancedLightManager.h
@@ -75,7 +75,7 @@ public:
 
    // LightManager
    bool isCompatible() const override;
-   void activate( SceneManager *sceneManager ) override;
+   void activate() override;
    void deactivate() override;
    void registerGlobalLight(LightInfo *light, SimObject *obj) override;
    void unregisterAllLights() override;

--- a/Engine/source/lighting/basic/basicLightManager.cpp
+++ b/Engine/source/lighting/basic/basicLightManager.cpp
@@ -154,9 +154,9 @@ bool BasicLightManager::isCompatible() const
    return GFX->getPixelShaderVersion() > 1.0;
 }
 
-void BasicLightManager::activate( SceneManager *sceneManager )
+void BasicLightManager::activate()
 {
-   Parent::activate( sceneManager );
+   Parent::activate();
 
    if( GFX->getAdapterType() == OpenGL )
    {
@@ -211,7 +211,7 @@ void BasicLightManager::activate( SceneManager *sceneManager )
 
    // If there is a deferred bin
    MATMGR->setDeferredEnabled( mDeferredRenderBin.isValid() );
-   sceneManager->setPostEffectFog( mDeferredRenderBin.isValid() && mDeferredRenderBin->getTargetChainLength() > 0  );
+   getActiveClientScene()->setPostEffectFog( mDeferredRenderBin.isValid() && mDeferredRenderBin->getTargetChainLength() > 0  );
 
    // Tell the material manager that we don't use deferred.
    MATMGR->setDeferredEnabled( false );
@@ -219,7 +219,7 @@ void BasicLightManager::activate( SceneManager *sceneManager )
    GFXShader::addGlobalMacro( "TORQUE_BASIC_LIGHTING" );
 
    // Hook into the SceneManager prerender signal.
-   sceneManager->getPreRenderSignal().notify( this, &BasicLightManager::_onPreRender );
+   getActiveClientScene()->getPreRenderSignal().notify( this, &BasicLightManager::_onPreRender );
 
    // Last thing... let everyone know we're active.
    smActivateSignal.trigger( getId(), true );
@@ -246,7 +246,7 @@ void BasicLightManager::deactivate()
    GFXShader::removeGlobalMacro( "TORQUE_BASIC_LIGHTING" );
 
    // Remove us from the prerender signal.
-   getSceneManager()->getPreRenderSignal().remove( this, &BasicLightManager::_onPreRender );
+   getActiveClientScene()->getPreRenderSignal().remove( this, &BasicLightManager::_onPreRender );
 
    // Now let everyone know we've deactivated.
    smActivateSignal.trigger( getId(), false );

--- a/Engine/source/lighting/basic/basicLightManager.h
+++ b/Engine/source/lighting/basic/basicLightManager.h
@@ -57,7 +57,7 @@ public:
 
    // LightManager
    bool isCompatible() const override;
-   void activate( SceneManager *sceneManager ) override;
+   void activate() override;
    void deactivate() override;
    void setLightInfo(ProcessedMaterial* pmat, const Material* mat, const SceneData& sgData, const SceneRenderState *state, U32 pass, GFXShaderConstBuffer* shaderConsts) override;
    bool setTextureStage(const SceneData& sgData, const U32 currTexFlag, const U32 textureSlot, GFXShaderConstBuffer* shaderConsts, ShaderConstHandles* handles) override { return false; }

--- a/Engine/source/lighting/basic/basicSceneObjectLightingPlugin.cpp
+++ b/Engine/source/lighting/basic/basicSceneObjectLightingPlugin.cpp
@@ -223,7 +223,7 @@ void BasicSceneObjectPluginFactory::addLightPlugin(SceneObject* obj)
 void BasicSceneObjectPluginFactory::addToExistingObjects()
 {
    SimpleQueryList sql;  
-   gClientContainer.findObjects( shadowObjectTypeMask, SimpleQueryList::insertionCallback, &sql);
+   getActiveClientContainer()->findObjects( shadowObjectTypeMask, SimpleQueryList::insertionCallback, &sql);
    for (SceneObject** i = sql.mList.begin(); i != sql.mList.end(); i++)
       addLightPlugin(*i);
 }

--- a/Engine/source/lighting/common/blobShadow.cpp
+++ b/Engine/source/lighting/common/blobShadow.cpp
@@ -256,7 +256,7 @@ void BlobShadow::buildPartition(const Point3F & p, const Point3F & lightDir, F32
 
    // get polys
 
-   gClientContainer.findObjects(STATIC_COLLISION_TYPEMASK, BlobShadow::collisionCallback, this);
+   getActiveClientContainer()->findObjects(STATIC_COLLISION_TYPEMASK, BlobShadow::collisionCallback, this);
 
    // setup partition list
    gBlobShadowPoly[0].set(-radius,0,-radius);

--- a/Engine/source/lighting/common/sceneLighting.cpp
+++ b/Engine/source/lighting/common/sceneLighting.cpp
@@ -651,7 +651,7 @@ bool SceneLighting::lightScene(const char * callback, BitSet32 flags)
    gConnectionMissionCRC = con->getMissionCRC();
 
    // assumes we are in the world that needs lighting...
-   mSceneManager = gClientSceneGraph;
+   mSceneManager = getActiveClientScene();
 
    if(!light(flags))
    {

--- a/Engine/source/lighting/common/sceneLighting.cpp
+++ b/Engine/source/lighting/common/sceneLighting.cpp
@@ -494,7 +494,7 @@ bool SceneLighting::light(BitSet32 flags)
 
    // get all the objects and create proxy's for them
    SimpleQueryList objects;	
-   gClientContainer.findObjects(mLightingInterfaces->mAvailableObjectTypes, &SimpleQueryList::insertionCallback, &objects);
+   getActiveClientContainer()->findObjects(mLightingInterfaces->mAvailableObjectTypes, &SimpleQueryList::insertionCallback, &objects);
 
    for(SceneObject ** itr = objects.mList.begin(); itr != objects.mList.end(); itr++)
    {

--- a/Engine/source/lighting/lightManager.cpp
+++ b/Engine/source/lighting/lightManager.cpp
@@ -48,7 +48,6 @@ LightManager::LightManager( const char *name, const char *id )
       mId( id ),
       mIsActive( false ),
       mDefaultLight( NULL ),
-      mSceneManager( NULL ),
       mCullPos( Point3F::Zero ),
       mAvailableSLInterfaces( NULL )
 { 
@@ -124,14 +123,12 @@ IMPLEMENT_GLOBAL_CALLBACK( onLightManagerActivate, void, ( const char *name ), (
    "@param name The name of the light manager being activated.\n"
    "@ingroup Lighting\n" );
 
-void LightManager::activate( SceneManager *sceneManager )
+void LightManager::activate( )
 {
-   AssertFatal( sceneManager, "LightManager::activate() - Got null scene manager!" );
    AssertFatal( mIsActive == false, "LightManager::activate() - Already activated!" );
    AssertFatal( smActiveLM == NULL, "LightManager::activate() - A previous LM is still active!" );
 
    mIsActive = true;
-   mSceneManager = sceneManager;
    smActiveLM = this;
 
    onLightManagerActivate_callback( getName() );
@@ -151,7 +148,6 @@ void LightManager::deactivate()
       onLightManagerDeactivate_callback( getName() );
 
    mIsActive = false;
-   mSceneManager = NULL;
    smActiveLM = NULL;
 
    // Just in case... make sure we're all clear.
@@ -220,12 +216,12 @@ void LightManager::registerGlobalLights( const Frustum *frustum, bool staticLigh
    {
       // We're processing static lighting or want all the lights
       // in the container registerd...  so no culling.
-      getSceneManager()->getContainer()->findObjectList( lightMask, &activeLights );
+      getActiveClientScene()->getContainer()->findObjectList(lightMask, &activeLights);
    }
    else
    {
       // Cull the lights using the frustum.
-      getSceneManager()->getContainer()->findObjectList(*frustum, lightMask, &activeLights);
+      getActiveClientScene()->getContainer()->findObjectList(*frustum, lightMask, &activeLights);
       /*
       for (U32 i = 0; i < activeLights.size(); ++i)
       {
@@ -531,7 +527,7 @@ bool LightManager::lightScene( const char* callback, const char* param )
 
 RenderDeferredMgr* LightManager::_findDeferredRenderBin()
 {
-   RenderPassManager* rpm = getSceneManager()->getDefaultRenderPass();
+   RenderPassManager* rpm = getActiveClientScene()->getDefaultRenderPass();
    for( U32 i = 0; i < rpm->getManagerCount(); i++ )
    {
       RenderBinManager *bin = rpm->getManager( i );
@@ -597,7 +593,6 @@ DefineEngineFunction( resetLightManager, void, (),,
    if ( !lm )
       return;
 
-   SceneManager *sm = lm->getSceneManager();
    lm->deactivate();
-   lm->activate( sm );
+   lm->activate();
 }

--- a/Engine/source/lighting/lightManager.cpp
+++ b/Engine/source/lighting/lightManager.cpp
@@ -549,7 +549,7 @@ DefineEngineFunction( setLightManager, bool, ( const char *name ),,
    "@return Returns true if the light manager is found and activated.\n"
    "@ingroup Lighting\n" )
 {
-   return gClientSceneGraph->setLightManager( name );
+   return getActiveClientScene()->setLightManager( name );
 }
 
 DefineEngineFunction( lightScene, bool, ( const char *completeCallbackFn, const char *mode ), ( nullAsType<const char*>(), nullAsType<const char*>() ),

--- a/Engine/source/lighting/lightManager.h
+++ b/Engine/source/lighting/lightManager.h
@@ -98,15 +98,12 @@ public:
    /// for filename use.
    const char* getId() const { return mId.c_str(); }
 
-   // Returns the scene manager passed at activation.
-   SceneManager* getSceneManager() { return mSceneManager; }
-
    // Should return true if this light manager is compatible
    // on the current platform and GFX device.
    virtual bool isCompatible() const = 0;
 
    // Called when the lighting manager should become active
-   virtual void activate( SceneManager *sceneManager );
+   virtual void activate();
 
    // Called when we don't want the light manager active (should clean up)
    virtual void deactivate();
@@ -225,8 +222,6 @@ protected:
    /// Is true if this light manager has been activated.
    bool mIsActive;
 
-   /// The scene graph the light manager is associated with.
-   SceneManager *mSceneManager;
 };
 
 /// Returns the current active light manager.

--- a/Engine/source/lighting/shadowManager.cpp
+++ b/Engine/source/lighting/shadowManager.cpp
@@ -40,7 +40,7 @@ bool ShadowManager::canActivate()
 
 void ShadowManager::activate()
 {
-   mSceneManager = gClientSceneGraph; //;getWorld()->findWorldManager<SceneManager>();
+   mSceneManager = getActiveClientScene(); //;getWorld()->findWorldManager<SceneManager>();
 }
 
 //------------------------------------------------------------------------------

--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -378,7 +378,7 @@ void ProcessedShaderMaterial::_determineFeatures(  U32 stageNum,
    fd.features.addFeature( MFT_Visibility );
 
    if (  lastStage && 
-         (  !gClientSceneGraph->usePostEffectFog() ||
+         (  !getActiveClientScene()->usePostEffectFog() ||
             fd.features.hasFeature( MFT_IsTranslucent ) ||
             fd.features.hasFeature( MFT_ForwardShading )) )
       fd.features.addFeature( MFT_Fog );

--- a/Engine/source/navigation/guiNavEditorCtrl.cpp
+++ b/Engine/source/navigation/guiNavEditorCtrl.cpp
@@ -281,7 +281,7 @@ bool GuiNavEditorCtrl::get3DCentre(Point3F &pos)
    unproject(screen, &end);
 
    RayInfo ri;
-   if(gServerContainer.castRay(start, end, StaticObjectType, &ri))
+   if(getActiveServerContainer()->castRay(start, end, StaticObjectType, &ri))
    {
       pos = ri.point;
       return true;
@@ -313,7 +313,7 @@ void GuiNavEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
 
    if(mMode == mLinkMode && !mMesh.isNull())
    {
-      if(gServerContainer.castRay(startPnt, endPnt, StaticObjectType, &ri))
+      if(getActiveServerContainer()->castRay(startPnt, endPnt, StaticObjectType, &ri))
       {
          U32 link = mMesh->getLink(ri.point);
          if(link != -1)
@@ -358,7 +358,7 @@ void GuiNavEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
 
    if(mMode == mTileMode && !mMesh.isNull())
    {
-      if(gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri))
+      if(getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri))
       {
          mTile = mMesh->getTile(ri.point);
          dd.clear();
@@ -371,7 +371,7 @@ void GuiNavEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
       // Spawn new character
       if(ctrl)
       {
-         if(gServerContainer.castRay(startPnt, endPnt, StaticObjectType, &ri))
+         if(getActiveServerContainer()->castRay(startPnt, endPnt, StaticObjectType, &ri))
             spawnPlayer(ri.point);
       }
       // Deselect character
@@ -383,7 +383,7 @@ void GuiNavEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
       // Select/move character
       else
       {
-         if(gServerContainer.castRay(startPnt, endPnt, PlayerObjectType, &ri))
+         if(getActiveServerContainer()->castRay(startPnt, endPnt, PlayerObjectType, &ri))
          {
             if(dynamic_cast<AIPlayer*>(ri.object))
             {
@@ -391,7 +391,7 @@ void GuiNavEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
                Con::executef(this, "onPlayerSelected", Con::getIntArg(mPlayer->mLinkTypes.getFlags()));
             }
          }
-         else if(!mPlayer.isNull() && gServerContainer.castRay(startPnt, endPnt, StaticObjectType, &ri))
+         else if(!mPlayer.isNull() && getActiveServerContainer()->castRay(startPnt, endPnt, StaticObjectType, &ri))
             mPlayer->setPathDestination(ri.point);
       }
    }
@@ -417,7 +417,7 @@ void GuiNavEditorCtrl::on3DMouseMove(const Gui3DMouseEvent & event)
 
    if(mMode == mLinkMode && !mMesh.isNull())
    {
-      if(gServerContainer.castRay(startPnt, endPnt, StaticObjectType, &ri))
+      if(getActiveServerContainer()->castRay(startPnt, endPnt, StaticObjectType, &ri))
       {
          U32 link = mMesh->getLink(ri.point);
          if(link != -1)
@@ -447,7 +447,7 @@ void GuiNavEditorCtrl::on3DMouseMove(const Gui3DMouseEvent & event)
    // Select a tile from our current NavMesh.
    if(mMode == mTileMode && !mMesh.isNull())
    {
-      if(gServerContainer.castRay(startPnt, endPnt, StaticObjectType, &ri))
+      if(getActiveServerContainer()->castRay(startPnt, endPnt, StaticObjectType, &ri))
          mCurTile = mMesh->getTile(ri.point);
       else
          mCurTile = -1;
@@ -455,7 +455,7 @@ void GuiNavEditorCtrl::on3DMouseMove(const Gui3DMouseEvent & event)
 
    if(mMode == mTestMode)
    {
-      if(gServerContainer.castRay(startPnt, endPnt, PlayerObjectType, &ri))
+      if(getActiveServerContainer()->castRay(startPnt, endPnt, PlayerObjectType, &ri))
          mCurPlayer = dynamic_cast<AIPlayer*>(ri.object);
       else
          mCurPlayer = NULL;
@@ -584,7 +584,7 @@ bool GuiNavEditorCtrl::getStaticPos(const Gui3DMouseEvent & event, Point3F &tpos
    RayInfo ri;
    bool hit;
 
-   hit = gServerContainer.castRay(startPnt, endPnt, StaticShapeObjectType, &ri);
+   hit = getActiveServerContainer()->castRay(startPnt, endPnt, StaticShapeObjectType, &ri);
    tpos = ri.point;
 
    return hit;

--- a/Engine/source/renderInstance/renderDeferredMgr.cpp
+++ b/Engine/source/renderInstance/renderDeferredMgr.cpp
@@ -225,8 +225,8 @@ void RenderDeferredMgr::addElement( RenderInst *inst )
    PROFILE_SCOPE( RenderDeferredMgr_addElement )
 
    // Skip out if this bin is disabled.
-   if (  gClientSceneGraph->getCurrentRenderState() &&
-         gClientSceneGraph->getCurrentRenderState()->disableAdvancedLightingBins() )
+   if (  getActiveClientScene()->getCurrentRenderState() &&
+         getActiveClientScene()->getCurrentRenderState()->disableAdvancedLightingBins() )
       return;
 
    // First what type of render instance is it?

--- a/Engine/source/renderInstance/renderPassManager.h
+++ b/Engine/source/renderInstance/renderPassManager.h
@@ -221,7 +221,7 @@ public:
    SceneManager* getSceneManager()
    {
       if ( !mSceneManager )
-         mSceneManager = gClientSceneGraph;
+         mSceneManager = getActiveClientScene();
 
       return mSceneManager;
    }

--- a/Engine/source/renderInstance/renderPassManager.h
+++ b/Engine/source/renderInstance/renderPassManager.h
@@ -220,9 +220,8 @@ public:
    /// Get scene manager which this render pass belongs to.
    SceneManager* getSceneManager()
    {
-      if ( !mSceneManager )
-         mSceneManager = getActiveClientScene();
-
+      // always update to the activeClientScene.
+      mSceneManager = getActiveClientScene();
       return mSceneManager;
    }
 

--- a/Engine/source/scene/reflector.cpp
+++ b/Engine/source/scene/reflector.cpp
@@ -346,6 +346,8 @@ void CubeReflector::updateReflection( const ReflectParams &params, Point3F expli
    // this for objects like SkyBox which will use it during a reflect pass.
    getActiveClientScene()->setNonClipProjection(GFX->getProjectionMatrix());
 
+   GFX->pushActiveRenderTarget();
+
    for (S32 i = 5; i >= 0; i--) {
       updateFace(params, i, explicitPostion);
    }
@@ -436,7 +438,7 @@ void CubeReflector::updateFace( const ReflectParams &params, U32 faceidx, Point3
 
    // We don't use a special clipping projection, but still need to initialize 
    // this for objects like SkyBox which will use it during a reflect pass.
-   gClientSceneGraph->setNonClipProjection(GFX->getProjectionMatrix());
+   getActiveClientScene()->setNonClipProjection(GFX->getProjectionMatrix());
 
    // render scene
    LIGHTMGR->registerGlobalLights( &reflectRenderState.getCullingFrustum(), false );

--- a/Engine/source/scene/reflector.cpp
+++ b/Engine/source/scene/reflector.cpp
@@ -328,8 +328,8 @@ void CubeReflector::updateReflection( const ReflectParams &params, Point3F expli
 
    mDepthBuff = LightShadowMap::_getDepthTarget(texDim, texDim);
    mRenderTarget->attachTexture(GFXTextureTarget::DepthStencil, mDepthBuff);
-   F32 oldVisibleDist = gClientSceneGraph->getVisibleDistance();
-   gClientSceneGraph->setVisibleDistance( mDesc->farDist );   
+   F32 oldVisibleDist = getActiveClientScene()->getVisibleDistance();
+   getActiveClientScene()->setVisibleDistance( mDesc->farDist );   
 
    F32 detailAdjustBackup = TSShapeInstance::smDetailAdjust;
    TSShapeInstance::smDetailAdjust *= mDesc->detailAdjust;
@@ -342,7 +342,10 @@ void CubeReflector::updateReflection( const ReflectParams &params, Point3F expli
    MathUtils::makeFrustum(&left, &right, &top, &bottom, M_HALFPI_F, 1.0f, mDesc->nearDist);
    GFX->setFrustum(left, right, bottom, top, mDesc->nearDist, mDesc->farDist);
 
-   GFX->pushActiveRenderTarget();
+   // We don't use a special clipping projection, but still need to initialize 
+   // this for objects like SkyBox which will use it during a reflect pass.
+   getActiveClientScene()->setNonClipProjection(GFX->getProjectionMatrix());
+
    for (S32 i = 5; i >= 0; i--) {
       updateFace(params, i, explicitPostion);
    }
@@ -353,7 +356,7 @@ void CubeReflector::updateReflection( const ReflectParams &params, Point3F expli
    mCubemap->generateMipMaps();
 
 
-   gClientSceneGraph->setVisibleDistance(oldVisibleDist);
+   getActiveClientScene()->setVisibleDistance(oldVisibleDist);
 
    mIsRendering = false;
    mLastTexSize = texDim;
@@ -423,7 +426,7 @@ void CubeReflector::updateFace( const ReflectParams &params, U32 faceidx, Point3
 
    SceneRenderState reflectRenderState
    (
-      gClientSceneGraph,
+      getActiveClientScene(),
       SPT_Reflect,
       SceneCameraState::fromGFX()
    );
@@ -437,7 +440,7 @@ void CubeReflector::updateFace( const ReflectParams &params, U32 faceidx, Point3
 
    // render scene
    LIGHTMGR->registerGlobalLights( &reflectRenderState.getCullingFrustum(), false );
-   gClientSceneGraph->renderSceneNoLights( &reflectRenderState, mDesc->objectTypeMask );
+   getActiveClientScene()->renderSceneNoLights( &reflectRenderState, mDesc->objectTypeMask );
    LIGHTMGR->unregisterAllLights();
 
    // Clean up.
@@ -628,14 +631,14 @@ void PlaneReflector::updateReflection( const ReflectParams &params, Point3F expl
    // In the future we may want to fix this instead by having the scatterSky
    // render a skirt or something in its lower half.
    //
-   LinearColorF clearColor = gClientSceneGraph->getAmbientLightColor();
+   LinearColorF clearColor = getActiveClientScene()->getAmbientLightColor();
    GFX->clear( GFXClearZBuffer | GFXClearStencil | GFXClearTarget, clearColor, 0.0f, 0 );
 
    if(GFX->getCurrentRenderStyle() == GFXDevice::RS_StereoSideBySide)
    {
       // Store previous values
       RectI originalVP = GFX->getViewport();
-      MatrixF origNonClipProjection = gClientSceneGraph->getNonClipProjection();
+      MatrixF origNonClipProjection = getActiveClientScene()->getNonClipProjection();
       PFXFrameState origPFXState = PFXMGR->getFrameState();
 
      MatrixF inverseEyeTransforms[2];
@@ -670,7 +673,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params, Point3F expl
 
      SceneRenderState renderStateLeft
       (
-        gClientSceneGraph,
+        getActiveClientScene(),
         SPT_Reflect,
         SceneCameraState::fromGFX()
       );
@@ -680,7 +683,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params, Point3F expl
      renderStateLeft.setDiffuseCameraTransform(params.query->headMatrix);
      //renderStateLeft.disableAdvancedLightingBins(true);
 
-      gClientSceneGraph->renderSceneNoLights( &renderStateLeft, objTypeFlag );
+      getActiveClientScene()->renderSceneNoLights( &renderStateLeft, objTypeFlag );
 
      //
       // Render right half of display
@@ -696,7 +699,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params, Point3F expl
 
      SceneRenderState renderStateRight
      (
-        gClientSceneGraph,
+        getActiveClientScene(),
         SPT_Reflect,
         SceneCameraState::fromGFX()
      );
@@ -706,12 +709,12 @@ void PlaneReflector::updateReflection( const ReflectParams &params, Point3F expl
       renderStateRight.setDiffuseCameraTransform( params.query->headMatrix );
       //renderStateRight.disableAdvancedLightingBins(true);
 
-      gClientSceneGraph->renderSceneNoLights( &renderStateRight, objTypeFlag );
+      getActiveClientScene()->renderSceneNoLights( &renderStateRight, objTypeFlag );
 
       // Restore previous values
       GFX->setFrustum(frustum);
       GFX->setViewport(originalVP);
-      gClientSceneGraph->setNonClipProjection(origNonClipProjection);
+      getActiveClientScene()->setNonClipProjection(origNonClipProjection);
       PFXMGR->setFrameState(origPFXState);
      GFX->setCurrentStereoTarget(-1);
    }
@@ -719,7 +722,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params, Point3F expl
    {
       SceneRenderState reflectRenderState
       (
-         gClientSceneGraph,
+         getActiveClientScene(),
          SPT_Reflect,
          SceneCameraState::fromGFX()
       );
@@ -727,7 +730,7 @@ void PlaneReflector::updateReflection( const ReflectParams &params, Point3F expl
       reflectRenderState.getMaterialDelegate().bind( REFLECTMGR, &ReflectionManager::getReflectionMaterial );
       reflectRenderState.setDiffuseCameraTransform( params.query->headMatrix );
 
-      gClientSceneGraph->renderSceneNoLights( &reflectRenderState, objTypeFlag );
+      getActiveClientScene()->renderSceneNoLights( &reflectRenderState, objTypeFlag );
    }
 
    LIGHTMGR->unregisterAllLights();
@@ -770,7 +773,7 @@ void PlaneReflector::setGFXMatrices( const MatrixF &camTrans )
 	  objTrans.inverse();
 
       // set new projection matrix
-      gClientSceneGraph->setNonClipProjection( (MatrixF&) GFX->getProjectionMatrix() );
+      getActiveClientScene()->setNonClipProjection( (MatrixF&) GFX->getProjectionMatrix() );
       MatrixF clipProj = getFrustumClipProj(objTrans);
       GFX->setProjectionMatrix( clipProj );
    }    
@@ -782,7 +785,7 @@ void PlaneReflector::setGFXMatrices( const MatrixF &camTrans )
       GFX->setWorldMatrix( camReflectTrans );
 
       // set new projection matrix
-      gClientSceneGraph->setNonClipProjection( (MatrixF&) GFX->getProjectionMatrix() );
+      getActiveClientScene()->setNonClipProjection( (MatrixF&) GFX->getProjectionMatrix() );
       MatrixF clipProj = getFrustumClipProj( camReflectTrans );
       GFX->setProjectionMatrix( clipProj );
    }   

--- a/Engine/source/scene/sceneContainer.cpp
+++ b/Engine/source/scene/sceneContainer.cpp
@@ -37,9 +37,28 @@
 //  - FindCallback should return a bool so it's possible to use the findObjectXXX methods to look
 //    for the first object matching a certain criteria
 
+static SceneContainer* activeClientContainer = NULL;
+static SceneContainer* activeServerContainer = NULL;
 
-SceneContainer gServerContainer;
-SceneContainer gClientContainer;
+SceneContainer* getActiveClientContainer()
+{
+   return activeClientContainer;
+}
+
+void setActiveClientContainer(SceneContainer* sceneContainer)
+{
+   activeClientContainer = sceneContainer;
+}
+
+SceneContainer* getActiveServerContainer()
+{
+   return activeServerContainer;
+}
+
+void setActiveServerContainer(SceneContainer* sceneContainer)
+{
+   activeServerContainer = sceneContainer;
+}
 
 const U32 SceneContainer::csmNumAxisBins = 16; // 16*16 = 256 possible bins
 const F32 SceneContainer::csmBinSize = 64;
@@ -1518,7 +1537,7 @@ DefineEngineFunction( containerBoxEmpty, bool,
    polyList.mPlaneList[4].set(B.minExtents, VectorF(0,0,-1));
    polyList.mPlaneList[5].set(B.maxExtents, VectorF(0,0,1));
 
-   SceneContainer* pContainer = useClientContainer ? &gClientContainer : &gServerContainer;
+   SceneContainer* pContainer = useClientContainer ? getActiveClientContainer() : getActiveServerContainer();
    if (ignoreObj)
       ignoreObj->disableCollision();
    bool ret = !pContainer->buildPolyList(PLC_Collision, B, mask, &polyList);
@@ -1541,7 +1560,7 @@ DefineEngineFunction( initContainerRadiusSearch, void, ( Point3F pos, F32 radius
    "@see containerSearchNext\n" 
    "@ingroup Game")
 {
-   SceneContainer* pContainer = useClientContainer ? &gClientContainer : &gServerContainer;
+   SceneContainer* pContainer = useClientContainer ? getActiveClientContainer() : getActiveServerContainer();
 
    pContainer->initRadiusSearch( pos, radius, mask );
 }
@@ -1558,7 +1577,7 @@ DefineEngineFunction( initContainerTypeSearch, void, ( U32 mask, bool useClientC
    "@see containerSearchNext\n" 
    "@ingroup Game")
 {
-   SceneContainer* pContainer = useClientContainer ? &gClientContainer : &gServerContainer;
+   SceneContainer* pContainer = useClientContainer ? getActiveClientContainer() : getActiveServerContainer();
 
    pContainer->initTypeSearch( mask );
 }
@@ -1589,7 +1608,7 @@ DefineEngineFunction( containerSearchNext, SceneObject*, ( bool useClientContain
    "@see initContainerTypeSearch()\n"
    "@ingroup Game")
 {
-   SceneContainer* pContainer = useClientContainer ? &gClientContainer : &gServerContainer;
+   SceneContainer* pContainer = useClientContainer ? getActiveClientContainer() : getActiveServerContainer();
 
    return pContainer->containerSearchNextObject();
 }
@@ -1608,7 +1627,7 @@ DefineEngineFunction( containerSearchCurrDist, F32, ( bool useClientContainer ),
    "@see containerSearchNext\n"
    "@ingroup Game")
 {
-   SceneContainer* pContainer = useClientContainer ? &gClientContainer : &gServerContainer;
+   SceneContainer* pContainer = useClientContainer ? getActiveClientContainer() : getActiveServerContainer();
 
    return pContainer->containerSearchCurrDist();
 }
@@ -1627,7 +1646,7 @@ DefineEngineFunction( containerSearchCurrRadiusDist, F32, ( bool useClientContai
    "@see containerSearchNext\n" 
    "@ingroup Game")
 {
-   SceneContainer* pContainer = useClientContainer ? &gClientContainer : &gServerContainer;
+   SceneContainer* pContainer = useClientContainer ? getActiveClientContainer() : getActiveServerContainer();
 
    return pContainer->containerSearchCurrRadiusDist();
 }
@@ -1660,7 +1679,7 @@ DefineEngineFunction( containerRayCast, const char*,
    if (pExempt)
       pExempt->disableCollision();
 
-   SceneContainer* pContainer = useClientContainer ? &gClientContainer : &gServerContainer;
+   SceneContainer* pContainer = useClientContainer ? getActiveClientContainer() : getActiveServerContainer();
 
    RayInfo rinfo;
    S32 ret = 0;
@@ -1713,7 +1732,7 @@ DefineEngineFunction(materialRayCast, const char*,
    if (pExempt)
       pExempt->disableCollision();
 
-   SceneContainer* pContainer = useClientContainer ? &gClientContainer : &gServerContainer;
+   SceneContainer* pContainer = useClientContainer ? getActiveClientContainer() : getActiveServerContainer();
 
    RayInfo rinfo;
    S32 ret = 0;

--- a/Engine/source/scene/sceneContainer.h
+++ b/Engine/source/scene/sceneContainer.h
@@ -780,6 +780,10 @@ inline bool SceneBinRange::shouldOverflow() const
 //-----------------------------------------------------------------------------
 
 extern SceneContainer gServerContainer;
-extern SceneContainer gClientContainer;
+SceneContainer* getActiveClientContainer();
+void setActiveClientContainer(SceneContainer* sceneContainer);
+SceneContainer* getActiveServerContainer();
+void setActiveServerContainer(SceneContainer* sceneContainer);
+
 
 #endif // !_SCENECONTAINER_H_

--- a/Engine/source/scene/sceneManager.cpp
+++ b/Engine/source/scene/sceneManager.cpp
@@ -722,7 +722,7 @@ bool SceneManager::_setLightManager( LightManager* lm )
    mLightManager = lm;
 
    if ( mLightManager )
-      mLightManager->activate( this );
+      mLightManager->activate();
 
    return true;
 }

--- a/Engine/source/scene/sceneManager.cpp
+++ b/Engine/source/scene/sceneManager.cpp
@@ -137,6 +137,8 @@ SceneManager::SceneManager( bool isClient )
      mVisibleGhostDistance( 0 ),
      mNearClip( 0.1f ),
      mLightManager( NULL ),
+     mClientSide( NULL ),
+     mServerSide( NULL ),
      mAmbientLightColor( LinearColorF( 0.1f, 0.1f, 0.1f, 1.0f ) ),
      mDefaultRenderPass( NULL )
 {
@@ -153,10 +155,12 @@ SceneManager::SceneManager( bool isClient )
       addObjectToScene( mZoneManager->getRootZone() );
 
       mServerSide = new SceneManager(false);
+      mServerSide->mClientSide = this;
    }
    else
    {
       mSceneContainer = new SceneContainer();
+      mServerSide = NULL;
    }
 }
 

--- a/Engine/source/scene/sceneManager.cpp
+++ b/Engine/source/scene/sceneManager.cpp
@@ -57,7 +57,10 @@ MODULE_BEGIN( Scene )
    MODULE_INIT
    {
       setActiveClientScene(new SceneManager(true));
-      setActiveServerScene(new SceneManager(false));
+      setActiveServerScene(activeClientScene->mServerSide);
+
+      setActiveClientContainer(activeClientScene->mSceneContainer);
+      setActiveServerContainer(activeServerScene->mSceneContainer);
 
       Con::addVariable( "$Scene::lockCull", TypeBool, &SceneManager::smLockDiffuseFrustum,
          "Debug tool which locks the frustum culling to the current camera location.\n"
@@ -91,7 +94,6 @@ MODULE_BEGIN( Scene )
    MODULE_SHUTDOWN
    {
       SAFE_DELETE(activeClientScene);
-      SAFE_DELETE(activeServerScene);
    }
 
 MODULE_END;
@@ -144,22 +146,34 @@ SceneManager::SceneManager( bool isClient )
 
    if( isClient )
    {
-      mZoneManager = new SceneZoneSpaceManager( getContainer() );
+      mSceneContainer = new SceneContainer();
+      mZoneManager = new SceneZoneSpaceManager(mSceneContainer);
 
       // Add the root zone to the scene.
-
       addObjectToScene( mZoneManager->getRootZone() );
+
+      mServerSide = new SceneManager(false);
+   }
+   else
+   {
+      mSceneContainer = new SceneContainer();
    }
 }
 
 //-----------------------------------------------------------------------------
 
 SceneManager::~SceneManager()
-{   
-   SAFE_DELETE( mZoneManager );
+{
+   if (mIsClient) {
+      SAFE_DELETE(mZoneManager);
+      SAFE_DELETE(mServerSide);
+   }
+      
 
    if( mLightManager )
-      mLightManager->deactivate();   
+      mLightManager->deactivate();
+
+   SAFE_DELETE(mSceneContainer);
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/scene/sceneManager.cpp
+++ b/Engine/source/scene/sceneManager.cpp
@@ -45,6 +45,8 @@
 
 extern bool gEditingMission;
 
+static SceneManager* activeClientScene = NULL;
+static SceneManager* activeServerScene = NULL;
 
 MODULE_BEGIN( Scene )
 
@@ -54,11 +56,8 @@ MODULE_BEGIN( Scene )
    
    MODULE_INIT
    {
-      // Client scene.
-      gClientSceneGraph = new SceneManager( true );
-
-      // Server scene.
-      gServerSceneGraph = new SceneManager( false );
+      setActiveClientScene(new SceneManager(true));
+      setActiveServerScene(new SceneManager(false));
 
       Con::addVariable( "$Scene::lockCull", TypeBool, &SceneManager::smLockDiffuseFrustum,
          "Debug tool which locks the frustum culling to the current camera location.\n"
@@ -91,8 +90,8 @@ MODULE_BEGIN( Scene )
    
    MODULE_SHUTDOWN
    {
-      SAFE_DELETE( gClientSceneGraph );
-      SAFE_DELETE( gServerSceneGraph );
+      SAFE_DELETE(activeClientScene);
+      SAFE_DELETE(activeServerScene);
    }
 
 MODULE_END;
@@ -102,11 +101,29 @@ bool SceneManager::smRenderBoundingBoxes;
 bool SceneManager::smLockDiffuseFrustum = false;
 SceneCameraState SceneManager::smLockedDiffuseCamera = SceneCameraState( RectI(), Frustum(), MatrixF(), MatrixF() );
 
-SceneManager* gClientSceneGraph = NULL;
-SceneManager* gServerSceneGraph = NULL;
-
-
 //-----------------------------------------------------------------------------
+
+// Client Scene Accessors
+SceneManager* getActiveClientScene()
+{
+   return activeClientScene;
+}
+
+void setActiveClientScene(SceneManager* scene)
+{
+   activeClientScene = scene;
+}
+
+// Server Scene Accessors
+SceneManager* getActiveServerScene()
+{
+   return activeServerScene;
+}
+
+void setActiveServerScene(SceneManager* scene)
+{
+   activeServerScene = scene;
+}
 
 SceneManager::SceneManager( bool isClient )
    : mIsClient( isClient ),
@@ -350,7 +367,7 @@ void SceneManager::renderSceneNoLights( SceneRenderState* renderState, U32 objec
 
 void SceneManager::_renderScene( SceneRenderState* state, U32 objectMask, SceneZoneSpace* baseObject, U32 baseZone )
 {
-   AssertFatal( this == gClientSceneGraph, "SceneManager::_buildSceneGraph - Only the client scenegraph can support this call!" );
+   AssertFatal( this == getActiveClientScene(), "SceneManager::_buildSceneGraph - Only the client scenegraph can support this call!");
 
    PROFILE_SCOPE( SceneGraph_batchRenderImages );
 
@@ -723,13 +740,13 @@ DefineEngineFunction( sceneDumpZoneStates, void, ( bool updateFirst ), ( true ),
    "@note Only valid on the client.\n"
    "@ingroup Game" )
 {
-   if( !gClientSceneGraph )
+   if( !getActiveClientScene() )
    {
       Con::errorf( "sceneDumpZoneStates - Only valid on client!" );
       return;
    }
 
-   SceneZoneSpaceManager* manager = gClientSceneGraph->getZoneManager();
+   SceneZoneSpaceManager* manager = getActiveClientScene()->getZoneManager();
    if( !manager )
    {
       Con::errorf( "sceneDumpZoneStates - Scene is not using zones!" );
@@ -748,13 +765,13 @@ DefineEngineFunction( sceneGetZoneOwner, SceneObject*, ( U32 zoneId ),,
    "@note Only valid on the client.\n"
    "@ingroup Game" )
 {
-   if( !gClientSceneGraph )
+   if( !getActiveClientScene() )
    {
       Con::errorf( "sceneGetZoneOwner - Only valid on client!" );
       return NULL;
    }
 
-   SceneZoneSpaceManager* manager = gClientSceneGraph->getZoneManager();
+   SceneZoneSpaceManager* manager = getActiveClientScene()->getZoneManager();
    if( !manager )
    {
       Con::errorf( "sceneGetZoneOwner - Scene is not using zones!" );

--- a/Engine/source/scene/sceneManager.h
+++ b/Engine/source/scene/sceneManager.h
@@ -212,7 +212,7 @@ class SceneManager
       ~SceneManager();
 
       /// Return the SceneContainer for this scene.
-      SceneContainer* getContainer() const { return mIsClient ? getActiveClientContainer() : getActiveServerContainer(); }
+      SceneContainer* getContainer() const { return mSceneContainer; }
 
       /// Return the manager for the zones in this scene.
       /// @note Only client scenes have a zone manager as for the server, no zoning data is kept.

--- a/Engine/source/scene/sceneManager.h
+++ b/Engine/source/scene/sceneManager.h
@@ -127,6 +127,7 @@ class SceneManager
 
       SceneContainer* mSceneContainer;
       SceneManager* mServerSide;
+      SceneManager* mClientSide;
 
    protected:
 

--- a/Engine/source/scene/sceneManager.h
+++ b/Engine/source/scene/sceneManager.h
@@ -363,16 +363,10 @@ class SceneManager
       const MatrixF& getNonClipProjection() const { return mNonClipProj; }
 };
 
-//-----------------------------------------------------------------------------
+SceneManager* getActiveClientScene();
+void setActiveClientScene(SceneManager* scene);
 
-//TODO: these two need to go
-
-/// The client-side scene graph.  Not used if the engine is running
-/// as a dedicated server.
-extern SceneManager* gClientSceneGraph;
-
-/// The server-side scene graph.  Not used if the engine is running
-/// as a pure client.
-extern SceneManager* gServerSceneGraph;
+SceneManager* getActiveServerScene();
+void setActiveServerScene(SceneManager* scene);
 
 #endif //_SCENEMANAGER_H_

--- a/Engine/source/scene/sceneManager.h
+++ b/Engine/source/scene/sceneManager.h
@@ -125,6 +125,9 @@ class SceneManager
       //visibility of objects later.
       Vector< SceneObject* > mRenderedObjectsList;
 
+      SceneContainer* mSceneContainer;
+      SceneManager* mServerSide;
+
    protected:
 
       /// Whether this is the client-side scene.
@@ -209,7 +212,7 @@ class SceneManager
       ~SceneManager();
 
       /// Return the SceneContainer for this scene.
-      SceneContainer* getContainer() const { return mIsClient ? &gClientContainer : &gServerContainer; }
+      SceneContainer* getContainer() const { return mIsClient ? getActiveClientContainer() : getActiveServerContainer(); }
 
       /// Return the manager for the zones in this scene.
       /// @note Only client scenes have a zone manager as for the server, no zoning data is kept.

--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -353,9 +353,9 @@ void SceneObject::addToScene()
       return;
 
    if( isClientObject() )
-      gClientSceneGraph->addObjectToScene( this );
+      getActiveClientScene()->addObjectToScene( this );
    else
-      gServerSceneGraph->addObjectToScene( this );
+      getActiveServerScene()->addObjectToScene( this );
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -807,7 +807,7 @@ void SceneObject::onCameraScopeQuery( NetConnection* connection, CameraScopeQuer
    if( getSceneManager() )
       getSceneManager()->scopeScene( query, connection );
    else
-      gServerContainer.findObjects( 0xFFFFFFFF, scopeCallback, connection );
+      getActiveServerContainer()->findObjects( 0xFFFFFFFF, scopeCallback, connection );
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -352,8 +352,11 @@ void SceneObject::addToScene()
    if( mSceneManager )
       return;
 
-   if( isClientObject() )
-      getActiveClientScene()->addObjectToScene( this );
+   if (isClientObject())
+      if (getServerObject())
+         static_cast<SceneObject*>(getServerObject())->mSceneManager->mClientSide->addObjectToScene(this);
+      else
+         getActiveClientScene()->addObjectToScene(this);
    else
       getActiveServerScene()->addObjectToScene( this );
 }

--- a/Engine/source/scene/sceneTracker.cpp
+++ b/Engine/source/scene/sceneTracker.cpp
@@ -112,9 +112,9 @@ void SceneTracker::init()
 
    SceneContainer* container;
    if( isClientTracker() )
-      container = &gClientContainer;
+      container = getActiveClientContainer();
    else
-      container = &gServerContainer;
+      container = getActiveServerContainer();
 
    container->findObjects( getObjectTypeMask(),
                            ( SceneContainer::FindCallback ) &_containerFindCallback,

--- a/Engine/source/scene/scopedSceneManager.h
+++ b/Engine/source/scene/scopedSceneManager.h
@@ -1,0 +1,48 @@
+#pragma once
+#ifndef _SCOPED_SCENE_MANAGER_H_
+#define _SCOPED_SCENE_MANAGER_H_
+
+#ifndef _SCENEMANAGER_H_
+#include "scene/sceneManager.h"
+#endif
+
+/// <summary>
+/// Simple class for a scoped scene, place the reference to this class in a function
+/// or inbetween { } and it will automatically delete
+/// </summary>
+class ScopedSceneManager
+{
+private:
+
+   /// <summary>
+   /// The scene to restore when we are out of scope.
+   /// </summary>
+   SceneManager* mPrevScene;
+public:
+
+   /// <summary>
+   /// Constructor for the scopedSceneManager, if you new this class be sure to delete it
+   /// in the same function.
+   /// </summary>
+   /// <param name="tempScene">The scene to replace the current scene.</param>
+   /// <param name="isClient">Whether this is a replacement for the client (defaults: True).</param>
+   ScopedSceneManager(SceneManager* tempScene)
+   {
+      mPrevScene = getActiveClientScene();
+
+      setActiveClientScene(tempScene);
+      setActiveServerScene(tempScene->mServerSide);
+      setActiveClientContainer(tempScene->mSceneContainer);
+      setActiveServerContainer(tempScene->mServerSide->mSceneContainer);
+   }
+
+   ~ScopedSceneManager()
+   {
+      setActiveClientScene(mPrevScene);
+      setActiveServerScene(mPrevScene->mServerSide);
+      setActiveClientContainer(mPrevScene->mSceneContainer);
+      setActiveServerContainer(mPrevScene->mServerSide->mSceneContainer);
+   }
+};
+
+#endif

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -103,7 +103,7 @@ TerrainBlock* getTerrainUnderWorldPoint(const Point3F & wPos)
 	F32 nearT = 1.0f;
 
 	SimpleQueryList queryList;
-	gServerContainer.findObjects( TerrainObjectType, SimpleQueryList::insertionCallback, &queryList);
+	getActiveServerContainer()->findObjects( TerrainObjectType, SimpleQueryList::insertionCallback, &queryList);
 
 	for (U32 i = 0; i < queryList.mList.size(); i++)
 	{

--- a/Engine/source/testing/sceneContainerTest.cpp
+++ b/Engine/source/testing/sceneContainerTest.cpp
@@ -751,7 +751,7 @@ TEST_F(SceneContainerTest, findObjects)
    // Should find all 3 objects we put there in the setup
 
    SceneContainer::ObjectList outList;
-   gServerSceneGraph->getContainer()->findObjectList(MarkerObjectType, &outList);
+   getActiveServerScene()->getContainer()->findObjectList(MarkerObjectType, &outList);
 
    EXPECT_EQ(outList.size(), 3);
 
@@ -763,7 +763,7 @@ TEST_F(SceneContainerTest, findObjects)
 
    // Won't find other objects
 
-   gServerSceneGraph->getContainer()->findObjectList(PlayerObjectType, &outList);
+   getActiveServerScene()->getContainer()->findObjectList(PlayerObjectType, &outList);
 
    EXPECT_EQ(outList.size(), 0);
 
@@ -790,16 +790,16 @@ TEST_F(SceneContainerTest, polyhedronFindObjects)
    so1->setTypeMask(MarkerObjectType);
    so1->setTransform(m);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
    static Vector<SceneObject*> foundList;
    foundList.clear();
    RayInfo info;
-   gClientSceneGraph->getContainer()->polyhedronFindObjects(shape, MarkerObjectType, [](SceneObject* object, void* key) {
+   getActiveClientScene()->getContainer()->polyhedronFindObjects(shape, MarkerObjectType, [](SceneObject* object, void* key) {
 
       });
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 TEST_F(SceneContainerTest, findObjectList)
@@ -814,23 +814,23 @@ TEST_F(SceneContainerTest, findObjectList)
    so1->setTypeMask(MarkerObjectType);
    so1->setTransform(m);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
    Vector<SceneObject*> foundList;
    PolyListContext ctx;
    Box3F box(Point3F(0, 0, 0), Point3F(0, 100, 0));
    RayInfo info;
-   gClientSceneGraph->getContainer()->findObjectList(box, MarkerObjectType, &foundList);
+   getActiveClientScene()->getContainer()->findObjectList(box, MarkerObjectType, &foundList);
 
    EXPECT_EQ(foundList.size(), 0);
 
    foundList.clear();
    box = Box3F(Point3F(0, 0, 0), Point3F(100, 100, 0));
-   gClientSceneGraph->getContainer()->findObjectList(box, MarkerObjectType, &foundList);
+   getActiveClientScene()->getContainer()->findObjectList(box, MarkerObjectType, &foundList);
 
    EXPECT_EQ(foundList.size(), 1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 TEST_F(SceneContainerTest, castRay)
@@ -846,21 +846,21 @@ TEST_F(SceneContainerTest, castRay)
    so1->setTransform(m);
    so1->setWorldBox(Box3F(m.getPosition(), m.getPosition() + Point3F(SceneContainer::csmBinSize-2, SceneContainer::csmBinSize-2, 10)));
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
    Point3F start(0, 0, 0);
    Point3F end(0, 100, 0);
    RayInfo info;
-   bool castCheck = gClientSceneGraph->getContainer()->castRay(start, end, MarkerObjectType, &info);
+   bool castCheck = getActiveClientScene()->getContainer()->castRay(start, end, MarkerObjectType, &info);
 
    EXPECT_EQ(so1->mNumCastRayCalls, 0);
 
    start = Point3F(SceneContainer::csmBinSize + 1, SceneContainer::csmBinSize + 1, 0);
-   castCheck = gClientSceneGraph->getContainer()->castRay(start, end, MarkerObjectType, &info);
+   castCheck = getActiveClientScene()->getContainer()->castRay(start, end, MarkerObjectType, &info);
 
    EXPECT_EQ(so1->mNumCastRayCalls, 1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 
@@ -884,8 +884,8 @@ TEST_F(SceneContainerTest, castRay_order)
    so1->mReturnCastRay = true;
    so2->mReturnCastRay = true;
 
-   gClientSceneGraph->getContainer()->addObject(so1);
-   gClientSceneGraph->getContainer()->addObject(so2);
+   getActiveClientScene()->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so2);
 
    // Here we need to ensure that so1 or so2 will be picked based on shortest distance
    RayInfo closeInfo = {};
@@ -904,7 +904,7 @@ TEST_F(SceneContainerTest, castRay_order)
       Point3F start(0, 0, 0);
       Point3F end(0, 0, -100);
       RayInfo info;
-      bool castCheck = gClientSceneGraph->getContainer()->castRay(start, end, MarkerObjectType, &info);
+      bool castCheck = getActiveClientScene()->getContainer()->castRay(start, end, MarkerObjectType, &info);
 
       EXPECT_EQ(castCheck, true);
       EXPECT_EQ(so1->mNumCastRayCalls, 1);
@@ -924,7 +924,7 @@ TEST_F(SceneContainerTest, castRay_order)
       Point3F start(0, 0, 0);
       Point3F end(0, 0, -100);
       RayInfo info;
-      bool castCheck = gClientSceneGraph->getContainer()->castRay(start, end, MarkerObjectType, &info);
+      bool castCheck = getActiveClientScene()->getContainer()->castRay(start, end, MarkerObjectType, &info);
 
       EXPECT_EQ(castCheck, true);
       EXPECT_EQ(so1->mNumCastRayCalls, 2);
@@ -934,8 +934,8 @@ TEST_F(SceneContainerTest, castRay_order)
       EXPECT_EQ(info.object, so1);
    }
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
-   gClientSceneGraph->getContainer()->removeObject(so2);
+   getActiveClientScene()->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so2);
 }
 
 
@@ -952,21 +952,21 @@ TEST_F(SceneContainerTest, castRayRendered)
    so1->setTransform(m);
    so1->setWorldBox(Box3F(m.getPosition(), m.getPosition() + Point3F(SceneContainer::csmBinSize - 2, SceneContainer::csmBinSize - 2, 10)));
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
    Point3F start(0, 0, 0);
    Point3F end(0, 100, 0);
    RayInfo info;
-   bool castCheck = gClientSceneGraph->getContainer()->castRayRendered(start, end, MarkerObjectType, &info);
+   bool castCheck = getActiveClientScene()->getContainer()->castRayRendered(start, end, MarkerObjectType, &info);
 
    EXPECT_EQ(so1->mNumCastRayRenderedCalls, 0);
 
    start = Point3F(SceneContainer::csmBinSize + 1, SceneContainer::csmBinSize + 1, 0);
-   castCheck = gClientSceneGraph->getContainer()->castRayRendered(start, end, MarkerObjectType, &info);
+   castCheck = getActiveClientScene()->getContainer()->castRayRendered(start, end, MarkerObjectType, &info);
 
    EXPECT_EQ(so1->mNumCastRayRenderedCalls, 1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 TEST_F(SceneContainerTest, collideBox)
@@ -981,21 +981,21 @@ TEST_F(SceneContainerTest, collideBox)
    so1->setTypeMask(MarkerObjectType);
    so1->setTransform(m);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
    Point3F start(0, 0, 0);
    Point3F end(0, 100, 0);
    RayInfo info;
-   bool castCheck = gClientSceneGraph->getContainer()->collideBox(start, end, 0xFFFFFFFF, &info);
+   bool castCheck = getActiveClientScene()->getContainer()->collideBox(start, end, 0xFFFFFFFF, &info);
 
    EXPECT_EQ(so1->mNumCollideBoxCalls, 0);
 
    start = Point3F(SceneContainer::csmBinSize + 1, SceneContainer::csmBinSize + 1, 0);
-   castCheck = gClientSceneGraph->getContainer()->collideBox(start, end, 0xFFFFFFFF, &info);
+   castCheck = getActiveClientScene()->getContainer()->collideBox(start, end, 0xFFFFFFFF, &info);
 
    EXPECT_EQ(so1->mNumCollideBoxCalls, 1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 TEST_F(SceneContainerTest, buildPolyList)
@@ -1010,21 +1010,21 @@ TEST_F(SceneContainerTest, buildPolyList)
    so1->setTypeMask(MarkerObjectType);
    so1->setTransform(m);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
    ClippedPolyList polyList;
    Box3F box(Point3F(0, 0, 0), Point3F(10, 10, 0));
    RayInfo info;
-   bool castCheck = gClientSceneGraph->getContainer()->buildPolyList(PLC_Collision, box, 0xFFFFFFFF, &polyList);
+   bool castCheck = getActiveClientScene()->getContainer()->buildPolyList(PLC_Collision, box, 0xFFFFFFFF, &polyList);
 
    EXPECT_EQ(so1->mNumBuildPolyListCalls, 0);
 
    box = Box3F(Point3F(0, 0, 0), Point3F(100, 100, 0));
-   castCheck = gClientSceneGraph->getContainer()->buildPolyList(PLC_Collision, box, 0xFFFFFFFF, &polyList);
+   castCheck = getActiveClientScene()->getContainer()->buildPolyList(PLC_Collision, box, 0xFFFFFFFF, &polyList);
 
    EXPECT_EQ(so1->mNumBuildPolyListCalls, 1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 TEST_F(SceneContainerTest, addObject)
@@ -1059,17 +1059,17 @@ TEST_F(SceneContainerTest, addObject)
    m.setPosition(Point3F(SceneContainer::csmBinSize * 2, SceneContainer::csmBinSize * 2, 0));
    so4->setTransform(m);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
-   gClientSceneGraph->getContainer()->addObject(so2);
-   gClientSceneGraph->getContainer()->addObject(so3);
-   gClientSceneGraph->getContainer()->addObject(so4);
-   gClientSceneGraph->getContainer()->addObject(so5);
+   getActiveClientScene()->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so2);
+   getActiveClientScene()->getContainer()->addObject(so3);
+   getActiveClientScene()->getContainer()->addObject(so4);
+   getActiveClientScene()->getContainer()->addObject(so5);
 
-   EXPECT_EQ(so1->getContainer(), gClientSceneGraph->getContainer());
-   EXPECT_EQ(so2->getContainer(), gClientSceneGraph->getContainer());
-   EXPECT_EQ(so3->getContainer(), gClientSceneGraph->getContainer());
-   EXPECT_EQ(so4->getContainer(), gClientSceneGraph->getContainer());
-   EXPECT_EQ(so5->getContainer(), gClientSceneGraph->getContainer());
+   EXPECT_EQ(so1->getContainer(), getActiveClientScene()->getContainer());
+   EXPECT_EQ(so2->getContainer(), getActiveClientScene()->getContainer());
+   EXPECT_EQ(so3->getContainer(), getActiveClientScene()->getContainer());
+   EXPECT_EQ(so4->getContainer(), getActiveClientScene()->getContainer());
+   EXPECT_EQ(so5->getContainer(), getActiveClientScene()->getContainer());
 
    // Should be put in correct bins
 
@@ -1109,15 +1109,15 @@ TEST_F(SceneContainerTest, addObject)
 
    // Check a bin
    Vector<SceneObject*> list;
-   gClientSceneGraph->getContainer()->dumpBin(1, 0, list);
+   getActiveClientScene()->getContainer()->dumpBin(1, 0, list);
    EXPECT_EQ(list.size(), 1);
    EXPECT_EQ(list[0], so1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
-   gClientSceneGraph->getContainer()->removeObject(so2);
-   gClientSceneGraph->getContainer()->removeObject(so3);
-   gClientSceneGraph->getContainer()->removeObject(so4);
-   gClientSceneGraph->getContainer()->removeObject(so5);
+   getActiveClientScene()->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so2);
+   getActiveClientScene()->getContainer()->removeObject(so3);
+   getActiveClientScene()->getContainer()->removeObject(so4);
+   getActiveClientScene()->getContainer()->removeObject(so5);
 }
 
 TEST_F(SceneContainerTest, removeObject)
@@ -1141,22 +1141,22 @@ TEST_F(SceneContainerTest, removeObject)
    m.setPosition(Point3F(SceneContainer::csmBinSize * 2, 0, 0));
    so3->setTransform(m);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
-   gClientSceneGraph->getContainer()->addObject(so2);
-   gClientSceneGraph->getContainer()->addObject(so3);
+   getActiveClientScene()->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so2);
+   getActiveClientScene()->getContainer()->addObject(so3);
 
-   EXPECT_EQ(so1->getContainer(), gClientSceneGraph->getContainer());
-   EXPECT_EQ(so2->getContainer(), gClientSceneGraph->getContainer());
-   EXPECT_EQ(so3->getContainer(), gClientSceneGraph->getContainer());
+   EXPECT_EQ(so1->getContainer(), getActiveClientScene()->getContainer());
+   EXPECT_EQ(so2->getContainer(), getActiveClientScene()->getContainer());
+   EXPECT_EQ(so3->getContainer(), getActiveClientScene()->getContainer());
 
    // Should get removed correctly
-   gClientSceneGraph->getContainer()->removeObject(so2);
-   EXPECT_EQ(so1->getContainer(), gClientSceneGraph->getContainer());
+   getActiveClientScene()->getContainer()->removeObject(so2);
+   EXPECT_EQ(so1->getContainer(), getActiveClientScene()->getContainer());
    EXPECT_EQ(so2->getContainer(), (SceneContainer*)NULL);
-   EXPECT_EQ(so3->getContainer(), gClientSceneGraph->getContainer());
+   EXPECT_EQ(so3->getContainer(), getActiveClientScene()->getContainer());
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
-   gClientSceneGraph->getContainer()->removeObject(so3);
+   getActiveClientScene()->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so3);
 
    EXPECT_EQ(so1->getContainer(), (SceneContainer*)NULL);
    EXPECT_EQ(so2->getContainer(), (SceneContainer*)NULL);
@@ -1195,11 +1195,11 @@ TEST_F(SceneContainerTest, insertIntoBins)
    m.setPosition(Point3F(SceneContainer::csmBinSize*2, SceneContainer::csmBinSize*2, 0));
    so4->setTransform(m);
 
-   gClientSceneGraph->getContainer()->insertIntoBins(so1);
-   gClientSceneGraph->getContainer()->insertIntoBins(so2);
-   gClientSceneGraph->getContainer()->insertIntoBins(so3);
-   gClientSceneGraph->getContainer()->insertIntoBins(so4);
-   gClientSceneGraph->getContainer()->insertIntoBins(so5);
+   getActiveClientScene()->getContainer()->insertIntoBins(so1);
+   getActiveClientScene()->getContainer()->insertIntoBins(so2);
+   getActiveClientScene()->getContainer()->insertIntoBins(so3);
+   getActiveClientScene()->getContainer()->insertIntoBins(so4);
+   getActiveClientScene()->getContainer()->insertIntoBins(so5);
 
    EXPECT_EQ(so1->getContainer(), (SceneContainer*)NULL);
    EXPECT_EQ(so2->getContainer(), (SceneContainer*)NULL);
@@ -1238,15 +1238,15 @@ TEST_F(SceneContainerTest, insertIntoBins)
 
    // Check a bin
    Vector<SceneObject*> list;
-   gClientSceneGraph->getContainer()->dumpBin(1, 0, list);
+   getActiveClientScene()->getContainer()->dumpBin(1, 0, list);
    EXPECT_EQ(list.size(), 1);
    EXPECT_EQ(list[0], so1);
 
-   gClientSceneGraph->getContainer()->removeFromBins(so1);
-   gClientSceneGraph->getContainer()->removeFromBins(so2);
-   gClientSceneGraph->getContainer()->removeFromBins(so3);
-   gClientSceneGraph->getContainer()->removeFromBins(so4);
-   gClientSceneGraph->getContainer()->removeFromBins(so5);
+   getActiveClientScene()->getContainer()->removeFromBins(so1);
+   getActiveClientScene()->getContainer()->removeFromBins(so2);
+   getActiveClientScene()->getContainer()->removeFromBins(so3);
+   getActiveClientScene()->getContainer()->removeFromBins(so4);
+   getActiveClientScene()->getContainer()->removeFromBins(so5);
 
    EXPECT_EQ(so1->getContainer(), (SceneContainer*)NULL);
    EXPECT_EQ(so2->getContainer(), (SceneContainer*)NULL);
@@ -1287,17 +1287,17 @@ TEST_F(SceneContainerTest, removeFromBins)
    m.setPosition(Point3F(SceneContainer::csmBinSize * 2, SceneContainer::csmBinSize * 2, 0));
    so4->setTransform(m);
 
-   gClientSceneGraph->getContainer()->insertIntoBins(so1);
-   gClientSceneGraph->getContainer()->insertIntoBins(so2);
-   gClientSceneGraph->getContainer()->insertIntoBins(so3);
-   gClientSceneGraph->getContainer()->insertIntoBins(so4);
-   gClientSceneGraph->getContainer()->insertIntoBins(so5);
+   getActiveClientScene()->getContainer()->insertIntoBins(so1);
+   getActiveClientScene()->getContainer()->insertIntoBins(so2);
+   getActiveClientScene()->getContainer()->insertIntoBins(so3);
+   getActiveClientScene()->getContainer()->insertIntoBins(so4);
+   getActiveClientScene()->getContainer()->insertIntoBins(so5);
 
-   gClientSceneGraph->getContainer()->removeFromBins(so1);
-   gClientSceneGraph->getContainer()->removeFromBins(so2);
-   gClientSceneGraph->getContainer()->removeFromBins(so3);
-   gClientSceneGraph->getContainer()->removeFromBins(so4);
-   gClientSceneGraph->getContainer()->removeFromBins(so5);
+   getActiveClientScene()->getContainer()->removeFromBins(so1);
+   getActiveClientScene()->getContainer()->removeFromBins(so2);
+   getActiveClientScene()->getContainer()->removeFromBins(so3);
+   getActiveClientScene()->getContainer()->removeFromBins(so4);
+   getActiveClientScene()->getContainer()->removeFromBins(so5);
 
    EXPECT_EQ(so1->getContainer(), (SceneContainer*)NULL);
    EXPECT_EQ(so2->getContainer(), (SceneContainer*)NULL);
@@ -1317,9 +1317,9 @@ TEST_F(SceneContainerTest, checkBins)
    m.setPosition(Point3F(SceneContainer::csmBinSize, 0, 0));
    so1->setTransform(m);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
-   EXPECT_EQ(so1->getContainer(), gClientSceneGraph->getContainer());
+   EXPECT_EQ(so1->getContainer(), getActiveClientScene()->getContainer());
 
    // Should be put in correct bins
 
@@ -1332,7 +1332,7 @@ TEST_F(SceneContainerTest, checkBins)
 
    // Check a bin
    Vector<SceneObject*> list;
-   gClientSceneGraph->getContainer()->dumpBin(1, 0, list);
+   getActiveClientScene()->getContainer()->dumpBin(1, 0, list);
    EXPECT_EQ(list.size(), 1);
    EXPECT_EQ(list[0], so1);
 
@@ -1340,7 +1340,7 @@ TEST_F(SceneContainerTest, checkBins)
    m.setPosition(Point3F(SceneContainer::csmBinSize*2, 0, 0));
    so1->setTransform(m);
 
-   gClientSceneGraph->getContainer()->checkBins(so1);
+   getActiveClientScene()->getContainer()->checkBins(so1);
    lookup.mRange.minCoord[0] = 2;
    lookup.mRange.maxCoord[0] = 2;
    lookup.mRange.minCoord[1] = 0;
@@ -1348,11 +1348,11 @@ TEST_F(SceneContainerTest, checkBins)
    EXPECT_EQ(so1->getContainerLookupInfo().mRange, lookup.mRange);
 
 
-   gClientSceneGraph->getContainer()->dumpBin(2, 0, list);
+   getActiveClientScene()->getContainer()->dumpBin(2, 0, list);
    EXPECT_EQ(list.size(), 1);
    EXPECT_EQ(list[0], so1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 TEST_F(SceneContainerTest, initRadiusSearch)
@@ -1367,7 +1367,7 @@ TEST_F(SceneContainerTest, initRadiusSearch)
    so1->setTransform(m);
    so1->setTypeMask(MarkerObjectType);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
    // Should be put in correct bins
 
@@ -1380,11 +1380,11 @@ TEST_F(SceneContainerTest, initRadiusSearch)
 
    // Check a bin
    Vector<SceneObject*> list;
-   gClientSceneGraph->getContainer()->initRadiusSearch(Point3F(0,0,0), 100.0f, MarkerObjectType);
-   EXPECT_EQ(gClientSceneGraph->getContainer()->getRadiusSearchList().size(), 1);
-   EXPECT_EQ(gClientSceneGraph->getContainer()->getRadiusSearchList()[0]->getPointer(), so1);
+   getActiveClientScene()->getContainer()->initRadiusSearch(Point3F(0,0,0), 100.0f, MarkerObjectType);
+   EXPECT_EQ(getActiveClientScene()->getContainer()->getRadiusSearchList().size(), 1);
+   EXPECT_EQ(getActiveClientScene()->getContainer()->getRadiusSearchList()[0]->getPointer(), so1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 TEST_F(SceneContainerTest, initTypeSearch)
@@ -1399,15 +1399,15 @@ TEST_F(SceneContainerTest, initTypeSearch)
    so1->setTransform(m);
    so1->setTypeMask(MarkerObjectType);
 
-   gClientSceneGraph->getContainer()->addObject(so1);
+   getActiveClientScene()->getContainer()->addObject(so1);
 
    // Check
    Vector<SceneObject*> list;
-   gClientSceneGraph->getContainer()->initTypeSearch(MarkerObjectType);
-   EXPECT_EQ(gClientSceneGraph->getContainer()->getRadiusSearchList().size(), 1);
-   EXPECT_EQ(gClientSceneGraph->getContainer()->getRadiusSearchList()[0]->getPointer(), so1);
+   getActiveClientScene()->getContainer()->initTypeSearch(MarkerObjectType);
+   EXPECT_EQ(getActiveClientScene()->getContainer()->getRadiusSearchList().size(), 1);
+   EXPECT_EQ(getActiveClientScene()->getContainer()->getRadiusSearchList()[0]->getPointer(), so1);
 
-   gClientSceneGraph->getContainer()->removeObject(so1);
+   getActiveClientScene()->getContainer()->removeObject(so1);
 }
 
 TEST_F(SceneContainerTest, getBinRange)

--- a/Engine/source/util/imposterCapture.cpp
+++ b/Engine/source/util/imposterCapture.cpp
@@ -412,7 +412,7 @@ void ImposterCapture::begin(  TSShapeInstance *shapeInst,
    // Set up scene state.
 
    mState = new SceneRenderState(
-      gClientSceneGraph,
+      getActiveClientScene(),
       SPT_Diffuse,
       SceneCameraState( viewport, frust, GFX->getWorldMatrix(),GFX->getProjectionMatrix() ),
       mRenderPass,

--- a/Templates/BaseGame/game/data/Prototyping/Materials/rogland_clear_night_4k_image.asset.taml
+++ b/Templates/BaseGame/game/data/Prototyping/Materials/rogland_clear_night_4k_image.asset.taml
@@ -1,0 +1,4 @@
+<ImageAsset
+    AssetName="rogland_clear_night_4k_image"
+    imageFile="@assetFile=rogland_clear_night_4k.hdr"
+    isHDRImage="true"/>

--- a/Templates/BaseGame/game/data/Prototyping/Materials/rogland_clear_night_4k_image.asset.taml
+++ b/Templates/BaseGame/game/data/Prototyping/Materials/rogland_clear_night_4k_image.asset.taml
@@ -1,4 +1,0 @@
-<ImageAsset
-    AssetName="rogland_clear_night_4k_image"
-    imageFile="@assetFile=rogland_clear_night_4k.hdr"
-    isHDRImage="true"/>

--- a/Templates/BaseGame/game/tools/materialEditor/gui/GreyPreview.asset.taml
+++ b/Templates/BaseGame/game/tools/materialEditor/gui/GreyPreview.asset.taml
@@ -1,0 +1,14 @@
+<MaterialAsset
+    AssetName="GreyPreview"
+    materialDefinitionName="GreyPreview"
+    VersionId="1">
+    <Material
+        Name="GreyPreview"
+        mapTo="GreyPreview"
+        originalAssetName="GreyPreview">
+        <Material.Stages>
+            <Stages_beginarray
+                DiffuseColor="0.5 0.5 0.5 1"/>
+        </Material.Stages>
+    </Material>
+</MaterialAsset>

--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -48,7 +48,7 @@ function MaterialEditorGui::establishMaterials(%this)
       };
    }
 
-   if(!isObject(materialEd_justAlphaMaterial))
+   if(!isObject(materialEd_previewMaterial))
    {
       singleton CustomMaterial( materialEd_justAlphaMaterial )
       {
@@ -57,7 +57,7 @@ function MaterialEditorGui::establishMaterials(%this)
       };
    }
 
-   if(!isObject(materialEd_justAlphaShader))
+   if(!isObject(materialEd_previewMaterial))
    {
       //Custom shader to allow the display of just the alpha channel. 
       singleton ShaderData( materialEd_justAlphaShader )
@@ -144,29 +144,19 @@ function MaterialEditorGui::open(%this)
    
    //Sift through the RootGroup and find all loaded material items.
    MaterialEditorGui.updateAllFields();
-
-   // this is a hacky piece of shit script, but it means that updates will continue.
-   matEd_previewObjectView.setModel("ToolsModule:cubepreview");
-   matEd_previewObjectView.setModel("ToolsModule:spherepreview");
-   matEd_previewObjectView.setModel("ToolsModule:pyramidpreview");
-   matEd_previewObjectView.setModel("ToolsModule:cylinderpreview");
-   matEd_previewObjectView.setModel("ToolsModule:toruspreview");
-   matEd_previewObjectView.setModel("ToolsModule:torusknotpreview");
-
    MaterialEditorGui.updatePreviewObject();
 
    // If no selected object; go to material mode. And edit the last selected material
    MaterialEditorGui.setMode();
    
-   MaterialEditorGui.preventUndo = true;   
+   MaterialEditorGui.preventUndo = true;
    
    if( MaterialEditorGui.currentMode $= "Mesh" )
       MaterialEditorGui.prepareActiveObject( true );
    else
       MaterialEditorGui.prepareActiveMaterial( "", true );
-      
+
    MaterialEditorGui.preventUndo = false;   
-      
 }
 
 function MaterialEditorGui::quit(%this)
@@ -178,11 +168,6 @@ function MaterialEditorGui::quit(%this)
       MaterialEditorGui.copyMaterials( notDirtyMaterial, materialEd_previewMaterial );
       MaterialEditorGui.copyMaterials( notDirtyMaterial, MaterialEditorGui.currentMaterial );
       MaterialEditorGui.guiSync( materialEd_previewMaterial );
-      
-      materialEd_previewMaterial.flush();
-      materialEd_previewMaterial.reload();
-      MaterialEditorGui.currentMaterial.flush();
-      MaterialEditorGui.currentMaterial.reload();
    }
    
    if( isObject(MaterialEditorGui.currentMaterial) )
@@ -549,22 +534,6 @@ function SubMaterialSelector::onSelect( %this )
          %assetDef = AssetDatabase.acquireAsset(%material);
          %material = %assetDef.materialDefinitionName;  
       }
-      /*// look for a newMaterial name to grab
-      // addiitonally, convert "." to "_" in case we have something like: "base.texname" as a material name   
-      // at the end we will have generated material name: "base_texname_mat"   
-      %material = getUniqueName( strreplace(%material, ".", "_") @ "_mat" );
-
-      new Material(%material) 
-      {
-         diffuseMap[0] = %origMat;   
-         mapTo = %origMat;
-         parentGroup = RootGroup;
-      };
-      
-      eval( "MaterialEditorGui.currentObject." @ strreplace(%this.getText(),".","_") @ " = " @ %material @ ";");
-      
-      if( MaterialEditorGui.currentObject.isMethod("postApply") )
-         MaterialEditorGui.currentObject.postApply();*/
    }
    else
    {
@@ -572,11 +541,12 @@ function SubMaterialSelector::onSelect( %this )
       if(%materialAssetId !$= "" && %materialAssetId !$= $Core::NoMaterialAssetFallback)
       {
          MaterialEditorGui.currentMaterialAsset = %materialAssetId;
-         %assetDef = AssetDatabase.acquireAsset(%material);
+         %assetDef = AssetDatabase.acquireAsset(%materialAssetId);
+         %material = %assetDef.materialDefinitionName;  
       }
    }
 
-   MaterialEditorGui.prepareActiveMaterial( %material.getId() );
+   MaterialEditorGui.prepareActiveMaterial( %material.getId());
 }
 
 //==============================================================================
@@ -655,10 +625,11 @@ function MaterialEditorGui::prepareActiveObject( %this, %override )
    }
    
    %id = SubMaterialSelector.findText( MaterialEditorGui.currentMaterial.mapTo );
+   
    if( %id != -1 )
       SubMaterialSelector.setSelected( %id );
    else
-      SubMaterialSelector.setSelected(0);	   
+      SubMaterialSelector.setSelected(0);
 }
 
 //==============================================================================
@@ -749,11 +720,6 @@ function MaterialEditorGui::setActiveMaterial( %this, %material )
 
    MaterialEditorGui.currentMaterial = %material;
    MaterialEditorGui.lastMaterial = %material;
-   
-   // we create or recreate a material to hold in a pristine state
-   // or, this crashes the ap. fix properly - BJR
-   if(isObject(notDirtyMaterial))
-      notDirtyMaterial.delete();
       
    singleton Material(notDirtyMaterial)
    {
@@ -768,16 +734,10 @@ function MaterialEditorGui::setActiveMaterial( %this, %material )
    %this.originalName = MaterialEditorGui.currentMaterial.name;
 
    // Copy materials over to other references
-   MaterialEditorGui.copyMaterials( MaterialEditorGui.currentMaterial, materialEd_previewMaterial );
    MaterialEditorGui.copyMaterials( MaterialEditorGui.currentMaterial, notDirtyMaterial );
-   MaterialEditorGui.guiSync( materialEd_previewMaterial );   
-     
-   // Necessary functionality in order to render correctly
-   materialEd_previewMaterial.flush();
-   materialEd_previewMaterial.reload();
-   MaterialEditorGui.currentMaterial.flush();
-   MaterialEditorGui.currentMaterial.reload();
-      
+   MaterialEditorGui.copyMaterials( MaterialEditorGui.currentMaterial, materialEd_previewMaterial );
+   MaterialEditorGui.guiSync( materialEd_previewMaterial );
+
    MaterialEditorGui.setMaterialNotDirty();
 }
 
@@ -994,9 +954,6 @@ function MaterialEditorGui::updateLivePreview(%this,%preview)
       MaterialEditorGui.copyMaterials( materialEd_previewMaterial, MaterialEditorGui.currentMaterial );
    else
       MaterialEditorGui.copyMaterials( notDirtyMaterial, MaterialEditorGui.currentMaterial );
-   
-   MaterialEditorGui.currentMaterial.flush();
-   MaterialEditorGui.currentMaterial.reload();
 }
 
 function MaterialEditorGui::copyMaterials( %this, %copyFrom, %copyTo)
@@ -1006,6 +963,8 @@ function MaterialEditorGui::copyMaterials( %this, %copyFrom, %copyTo)
    %copyTo.assignFieldsFrom( %copyFrom );
    %copyTo.mapTo = %mapTo;
 
+   %copyTo.flush();
+   %copyTo.reload();
 }
 
 function MaterialEditorGui::guiSync( %this, %material )
@@ -1053,7 +1012,7 @@ function MaterialEditorGui::guiSync( %this, %material )
         case "preMul": %selectedNum = 1;
         case "LerpAlpha": %selectedNum = 2;
         case "Mul": %selectedNum = 3;
-        case "": %selectedNum = 4;
+        case "Add": %selectedNum = 4;
         case "AddAlpha": %selectedNum = 5;
         case "Sub": %selectedNum = 6;
    }
@@ -1340,16 +1299,16 @@ function MaterialEditorGui::updateActiveMaterial(%this, %propertyField, %value, 
       MaterialEditorGui.submitUndo( %action );
    }
    
-   materialEd_previewMaterial.setFieldValue(%propertyField, %value);
-   materialEd_previewMaterial.flush();
-   materialEd_previewMaterial.reload();
-   
    if (MaterialEditorGui.livePreview == true)
    {
       MaterialEditorGui.currentMaterial.setFieldValue(%propertyField, %value);
       MaterialEditorGui.currentMaterial.flush();
       MaterialEditorGui.currentMaterial.reload();
    }
+
+   materialEd_previewMaterial.setFieldValue(%propertyField, %value);
+   materialEd_previewMaterial.flush();
+   materialEd_previewMaterial.reload();
 }
 
 function MaterialEditorGui::updateActiveMaterialName(%this, %name)
@@ -2191,11 +2150,6 @@ function MaterialEditorGui::saveDialogDontSave( %this, %material )
    MaterialEditorGui.copyMaterials( notDirtyMaterial, materialEd_previewMaterial );
    MaterialEditorGui.guiSync( materialEd_previewMaterial );
    
-   materialEd_previewMaterial.flush();
-   materialEd_previewMaterial.reload();
-   MaterialEditorGui.currentMaterial.flush();
-   MaterialEditorGui.currentMaterial.reload();
-   
    MaterialEditorGui.setMaterialNotDirty();
    
    if(AssetDatabase.isDeclaredAsset(%material))
@@ -2228,7 +2182,7 @@ function MaterialEditorGui::save( %this )
    }
    
    // Update the live object regardless in this case
-   MaterialEditorGui.updateLivePreview(true);
+   //MaterialEditorGui.updateLivePreview(true);
    
    %currentMaterial = MaterialEditorGui.currentMaterial;
    if( %currentMaterial == -1 )
@@ -2298,46 +2252,7 @@ function MaterialEditorGui::deleteMaterial( %this )
    %action = %this.createUndo(ActionDeleteMaterial, "Delete Material");
    %action.object = MaterialEditorGui.currentObject;
    %action.currentMode = MaterialEditorGui.currentMode;
-   
-   /*
-   if( MaterialEditorGui.currentMode $= "Mesh" )
-   {
-      %materialTarget = SubMaterialSelector.text;
-      %action.materialTarget = %materialTarget;   
-      
-      //create the stub material
-      %toMaterial = getUniqueName( "newMaterial" );
-      new Material(%toMaterial) 
-      {
-         diffuseMap[0] = "core/rendering/images/warnmat";
-         mapTo = "unmapped_mat";
-         parentGroup = RootGroup;
-      };
-         
-      %action.toMaterial = %toMaterial.getId();   
-      %action.fromMaterial = MaterialEditorGui.currentMaterial;
-      %action.fromMaterialOldFname = MaterialEditorGui.currentMaterial.getFilename();
-   }
-   else
-   {
-      // Grab first material we see; if theres not one, create one
-      %toMaterial = MaterialSet.getObject(0);
-      if( !isObject( %toMaterial ) )
-      {
-         %toMaterial = getUniqueName( "newMaterial" );
-         new Material(%toMaterial) 
-         {
-            diffuseMap[0] = "core/rendering/images/warnmat";
-            mapTo = "unmapped_mat";
-            parentGroup = RootGroup;
-         };    
-      }
-   
-      %action.toMaterial = %toMaterial.getId();
-      %action.fromMaterial = MaterialEditorGui.currentMaterial;
-   }
-   */
-   
+
    // Grab first material we see; if theres not one, create one
    %newMaterial = getUniqueName( "newMaterial" );
    new Material(%newMaterial) 
@@ -2396,18 +2311,13 @@ function MaterialEditorGui::clearMaterial(%this)
                      parentGroup = RootGroup;
                   };
    
-   MaterialEditorGui.copyMaterials( %tempMat, materialEd_previewMaterial );
-   MaterialEditorGui.guiSync( materialEd_previewMaterial );
-      
-   materialEd_previewMaterial.flush();
-   materialEd_previewMaterial.reload();
-   
    if (MaterialEditorGui.livePreview == true)
    {
       MaterialEditorGui.copyMaterials( %tempMat, MaterialEditorGui.currentMaterial );
-      MaterialEditorGui.currentMaterial.flush();
-      MaterialEditorGui.currentMaterial.reload();
    }
+
+   MaterialEditorGui.copyMaterials( %tempMat, materialEd_previewMaterial );
+   MaterialEditorGui.guiSync( materialEd_previewMaterial );
    
    MaterialEditorGui.setMaterialDirty();
    
@@ -2434,18 +2344,14 @@ function MaterialEditorGui::refreshMaterial(%this)
    MaterialEditorGui.submitUndo( %action );
    
    MaterialEditorGui.currentMaterial.setName( %this.originalName );
-   MaterialEditorGui.copyMaterials( notDirtyMaterial, materialEd_previewMaterial );
-   MaterialEditorGui.guiSync( materialEd_previewMaterial );
-      
-   materialEd_previewMaterial.flush();
-   materialEd_previewMaterial.reload();
-   
+
    if (MaterialEditorGui.livePreview == true)
    {
       MaterialEditorGui.copyMaterials( notDirtyMaterial, MaterialEditorGui.currentMaterial );
-      MaterialEditorGui.currentMaterial.flush();
-      MaterialEditorGui.currentMaterial.reload();
    }
+
+   MaterialEditorGui.copyMaterials( notDirtyMaterial, materialEd_previewMaterial );
+   MaterialEditorGui.guiSync( materialEd_previewMaterial );
    
    MaterialEditorGui.setMaterialNotDirty();
 }

--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -191,10 +191,7 @@ function MaterialEditorGui::quit(%this)
    }
 
    MaterialEditorGui.setMaterialNotDirty();
-   // First delete the model so that it releases
-   // material instances that use the preview materials.
-   matEd_previewObjectView.deleteModel();
-
+   
    // Now we can delete the preview materials and shaders
    // knowing that there are no matinstances using them.
    matEdCubeMapPreviewMat.delete();

--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -144,6 +144,15 @@ function MaterialEditorGui::open(%this)
    
    //Sift through the RootGroup and find all loaded material items.
    MaterialEditorGui.updateAllFields();
+
+   // this is a hacky piece of shit script, but it means that updates will continue.
+   matEd_previewObjectView.setModel("ToolsModule:cubepreview");
+   matEd_previewObjectView.setModel("ToolsModule:spherepreview");
+   matEd_previewObjectView.setModel("ToolsModule:pyramidpreview");
+   matEd_previewObjectView.setModel("ToolsModule:cylinderpreview");
+   matEd_previewObjectView.setModel("ToolsModule:toruspreview");
+   matEd_previewObjectView.setModel("ToolsModule:torusknotpreview");
+
    MaterialEditorGui.updatePreviewObject();
 
    // If no selected object; go to material mode. And edit the last selected material

--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -185,11 +185,11 @@ function MaterialEditorGui::quit(%this)
    // First delete the model so that it releases
    // material instances that use the preview materials.
    matEd_previewObjectView.deleteModel();
-   
+
    // Now we can delete the preview materials and shaders
    // knowing that there are no matinstances using them.
    matEdCubeMapPreviewMat.delete();
-   materialEd_previewMaterial.delete();
+   //materialEd_previewMaterial.delete();
    materialEd_justAlphaMaterial.delete();
    materialEd_justAlphaShader.delete();
 }
@@ -746,8 +746,8 @@ function MaterialEditorGui::setActiveMaterial( %this, %material )
    
    // we create or recreate a material to hold in a pristine state
    // or, this crashes the ap. fix properly - BJR
-//   if(isObject(notDirtyMaterial))
-//      notDirtyMaterial.delete();
+   if(isObject(notDirtyMaterial))
+      notDirtyMaterial.delete();
       
    singleton Material(notDirtyMaterial)
    {

--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -48,7 +48,7 @@ function MaterialEditorGui::establishMaterials(%this)
       };
    }
 
-   if(!isObject(materialEd_previewMaterial))
+   if(!isObject(materialEd_justAlphaMaterial))
    {
       singleton CustomMaterial( materialEd_justAlphaMaterial )
       {
@@ -57,7 +57,7 @@ function MaterialEditorGui::establishMaterials(%this)
       };
    }
 
-   if(!isObject(materialEd_previewMaterial))
+   if(!isObject(materialEd_justAlphaShader))
    {
       //Custom shader to allow the display of just the alpha channel. 
       singleton ShaderData( materialEd_justAlphaShader )
@@ -182,7 +182,6 @@ function MaterialEditorGui::quit(%this)
    }
 
    MaterialEditorGui.setMaterialNotDirty();
-   
    // First delete the model so that it releases
    // material instances that use the preview materials.
    matEd_previewObjectView.deleteModel();
@@ -190,7 +189,7 @@ function MaterialEditorGui::quit(%this)
    // Now we can delete the preview materials and shaders
    // knowing that there are no matinstances using them.
    matEdCubeMapPreviewMat.delete();
-   //materialEd_previewMaterial.delete();
+   materialEd_previewMaterial.delete();
    materialEd_justAlphaMaterial.delete();
    materialEd_justAlphaShader.delete();
 }
@@ -672,32 +671,32 @@ function MaterialEditorGui::updatePreviewObject(%this)
 	{
 		case "sphere":
          matEd_quickPreview_Popup.selected = %newModel;
-         matEd_previewObjectView.setModel("tools/materialEditor/gui/spherepreview.dts");
+         matEd_previewObjectView.setModel("ToolsModule:spherepreview");
          matEd_previewObjectView.setOrbitDistance(4);
 				
 		case "cube":
          matEd_quickPreview_Popup.selected = %newModel;
-         matEd_previewObjectView.setModel("tools/materialEditor/gui/cubepreview.dts");
+         matEd_previewObjectView.setModel("ToolsModule:cubepreview");
          matEd_previewObjectView.setOrbitDistance(5);
 				
 		case "pyramid":
          matEd_quickPreview_Popup.selected = %newModel;
-         matEd_previewObjectView.setModel("tools/materialEditor/gui/pyramidpreview.dts");
+         matEd_previewObjectView.setModel("ToolsModule:pyramidpreview");
          matEd_previewObjectView.setOrbitDistance(5);
 				
 		case "cylinder":
          matEd_quickPreview_Popup.selected = %newModel;
-         matEd_previewObjectView.setModel("tools/materialEditor/gui/cylinderpreview.dts");
+         matEd_previewObjectView.setModel("ToolsModule:cylinderpreview");
          matEd_previewObjectView.setOrbitDistance(4.2);
 				
 		case "torus":
          matEd_quickPreview_Popup.selected = %newModel;
-         matEd_previewObjectView.setModel("tools/materialEditor/gui/toruspreview.dts");
+         matEd_previewObjectView.setModel("ToolsModule:toruspreview");
          matEd_previewObjectView.setOrbitDistance(4.2);
 				
 		case "knot":
          matEd_quickPreview_Popup.selected = %newModel;
-         matEd_previewObjectView.setModel("tools/materialEditor/gui/torusknotpreview.dts");
+         matEd_previewObjectView.setModel("ToolsModule:torusknotpreview");
 	}
 }
 


### PR DESCRIPTION
Removed SceneManager direct references eg gActiveClientScene / gActiveServerScene replaced them with global functions getActive scenes.
Decoupled containers to do the same
Everywhere that referenced these now uses the functions instead
Added ScopedSceneManager, for temporarily setting objects to a different scene and rendering said scene. Once it goes out of scope the main scene becomes the new currently active client scene.
SceneObjects now get added to the client side of the server scene they are added to not just the current active scene.
SceneManagers keep a references to their clientSide and serverSide respectively. 