### PR TITLE
NamedTexTargets as ImageAssets

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -377,12 +377,10 @@ GFXTexHandle ImageAsset::getTexture(GFXTextureProfile* requestedProfile)
          NamedTexTargetRef namedTarget = NamedTexTarget::find(mImageFileName + 1);
          if (namedTarget.isValid() && namedTarget->getTexture())
          {
-            if (mNamedTarget == NULL) {
-               mNamedTarget = namedTarget;
-               mResourceMap.insert(requestedProfile, mNamedTarget->getTexture());
-               mIsValidImage = true;
-               mChangeSignal.trigger();
-            }
+            mNamedTarget = namedTarget;
+            mIsValidImage = true;
+            mResourceMap.insert(requestedProfile, mNamedTarget->getTexture());
+            mChangeSignal.trigger();
          }
          if (mNamedTarget == NULL)
             return nullptr;

--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -381,12 +381,8 @@ GFXTexHandle ImageAsset::getTexture(GFXTextureProfile* requestedProfile)
             mIsValidImage = true;
             mResourceMap.insert(requestedProfile, mNamedTarget->getTexture());
             mChangeSignal.trigger();
-         }
-         if (mNamedTarget == NULL)
-            return nullptr;
-         else
             return mNamedTarget->getTexture();
-         
+         }
       }
       else
       {

--- a/Engine/source/T3D/assets/ImageAsset.h
+++ b/Engine/source/T3D/assets/ImageAsset.h
@@ -39,7 +39,11 @@
 #endif
 #ifndef _ASSET_PTR_H_
 #include "assets/assetPtr.h"
-#endif 
+#endif
+
+#ifndef _MATTEXTURETARGET_H_
+#include "materials/matTextureTarget.h"
+#endif
 
 #include "gfx/bitmap/gBitmap.h"
 #include "gfx/gfxTextureHandle.h"
@@ -71,7 +75,8 @@ public:
       Particle = 8,
       Decal = 9,
       Cubemap = 10,
-      ImageTypeCount = 11
+      Target = 11,
+      ImageTypeCount = 12
    };
 
    static StringTableEntry smNoImageAssetFallback;
@@ -205,8 +210,8 @@ public: \
          }\
          else if(_in[0] == '$' || _in[0] == '#')\
          {\
-            m##name##Name = _in;\
-            m##name##AssetId = StringTable->EmptyString();\
+            m##name##Name =  _in;\
+            m##name##AssetId = _in;\
             m##name##Asset = NULL;\
             m##name.free();\
             m##name = NULL;\
@@ -250,6 +255,16 @@ public: \
             m##name##Asset->getChangedSignal().notify(this, &className::changeFunc);\
          }\
          \
+         if (get##name()[0] == '$' || get##name()[0] == '#') {\
+            NamedTexTarget* namedTarget = NamedTexTarget::find(get##name() + 1);\
+            if (namedTarget)\
+            {\
+               m##name = namedTarget->getTexture(0);\
+               m##name##Name = get##name();\
+               m##name##AssetId = StringTable->EmptyString();\
+            }\
+         }\
+         else\
          m##name.set(get##name(), m##name##Profile, avar("%s() - mTextureObject (line %d)", __FUNCTION__, __LINE__));\
       }\
       else\
@@ -278,7 +293,10 @@ public: \
    const StringTableEntry get##name() const\
    {\
       if (m##name##Asset && (m##name##Asset->getImageFileName() != StringTable->EmptyString()))\
-         return  Platform::makeRelativePathName(m##name##Asset->getImagePath(), Platform::getMainDotCsDir());\
+         if (m##name##Asset->getImageFileName()[0] == '#' || m##name##Asset->getImageFileName()[0] == '$')\
+            return m##name##Asset->getImageFileName();\
+         else\
+            return  Platform::makeRelativePathName(m##name##Asset->getImagePath(), Platform::getMainDotCsDir());\
       else if (m##name##AssetId != StringTable->EmptyString())\
          return m##name##AssetId;\
       else if (m##name##Name != StringTable->EmptyString())\
@@ -353,8 +371,8 @@ public: \
          }\
          else if(_in[0] == '$' || _in[0] == '#')\
          {\
-            m##name##Name[index] = _in;\
-            m##name##AssetId[index] = StringTable->EmptyString();\
+            m##name##Name[index] =  _in;\
+            m##name##AssetId[index] = _in;\
             m##name##Asset[index] = NULL;\
             m##name[index].free();\
             m##name[index] = NULL;\
@@ -393,6 +411,16 @@ public: \
       }\
       if (get##name(index) != StringTable->EmptyString() && m##name##Name[index] != StringTable->insert("texhandle"))\
       {\
+         if (get##name(index)[0] == '$' || get##name(index)[0] == '#') {\
+            NamedTexTarget* namedTarget = NamedTexTarget::find(get##name(index) + 1);\
+            if (namedTarget)\
+            {\
+               m##name[index] = namedTarget->getTexture(0);\
+               m##name##Name[index] = get##name(index);\
+               m##name##AssetId[index] = StringTable->EmptyString();\
+            }\
+         }\
+         else\
          m##name[index].set(get##name(index), m##name##Profile[index], avar("%s() - mTextureObject (line %d)", __FUNCTION__, __LINE__));\
       }\
       else\
@@ -421,7 +449,10 @@ public: \
    const StringTableEntry get##name(const U32& index) const\
    {\
       if (m##name##Asset[index] && (m##name##Asset[index]->getImageFileName() != StringTable->EmptyString()))\
-         return  Platform::makeRelativePathName(m##name##Asset[index]->getImagePath(), Platform::getMainDotCsDir());\
+         if (m##name##Asset[index]->getImageFileName()[0] == '#' || m##name##Asset[index]->getImageFileName()[0] == '$')\
+            return m##name##Asset[index]->getImageFileName();\
+         else\
+            return  Platform::makeRelativePathName(m##name##Asset[index]->getImagePath(), Platform::getMainDotCsDir());\
       else if (m##name##AssetId[index] != StringTable->EmptyString())\
          return m##name##AssetId[index];\
       else if (m##name##Name[index] != StringTable->EmptyString())\

--- a/Engine/source/T3D/assets/ImageAsset.h
+++ b/Engine/source/T3D/assets/ImageAsset.h
@@ -406,11 +406,9 @@ public: \
       }\
       if (get##name(index) != StringTable->EmptyString() && m##name##Name[index] != StringTable->insert("texhandle"))\
       {\
-         if (get##name(index)[0] == '$' || get##name(index)[0] == '#') {\
-             m##name##Asset[index]->getChangedSignal().notify(this, &className::changeFunc);\
-         }\
-         else\
-         m##name[index].set(get##name(index), m##name##Profile[index], avar("%s() - mTextureObject (line %d)", __FUNCTION__, __LINE__));\
+         m##name##Asset[index]->getChangedSignal().notify(this, &className::changeFunc);\
+         if (get##name(index)[0] != '$' && get##name(index)[0] != '#')\
+            m##name[index].set(get##name(index), m##name##Profile[index], avar("%s() - mTextureObject (line %d)", __FUNCTION__, __LINE__));\
       }\
       else\
       {\

--- a/Engine/source/T3D/assets/ImageAsset.h
+++ b/Engine/source/T3D/assets/ImageAsset.h
@@ -212,7 +212,7 @@ public: \
          else if(_in[0] == '$' || _in[0] == '#')\
          {\
             m##name##Name =  _in;\
-            m##name##AssetId = _in;\
+            m##name##AssetId = StringTable->EmptyString();\
             m##name##Asset = NULL;\
             m##name.free();\
             m##name = NULL;\
@@ -256,15 +256,9 @@ public: \
             m##name##Asset->getChangedSignal().notify(this, &className::changeFunc);\
          }\
          \
-         if (get##name()[0] == '$' || get##name()[0] == '#') {\
-            NamedTexTargetRef namedTarget = NamedTexTarget::find(get##name() + 1);\
-            if (namedTarget.isValid())\
-            {\
-               m##name = namedTarget->getTexture(0);\
-            }\
+         if (get##name()[0] != '$' && get##name()[0] != '#') {\
+            m##name.set(get##name(), m##name##Profile, avar("%s() - mTextureObject (line %d)", __FUNCTION__, __LINE__));\
          }\
-         else\
-         m##name.set(get##name(), m##name##Profile, avar("%s() - mTextureObject (line %d)", __FUNCTION__, __LINE__));\
       }\
       else\
       {\
@@ -373,7 +367,7 @@ public: \
          else if(_in[0] == '$' || _in[0] == '#')\
          {\
             m##name##Name[index] =  _in;\
-            m##name##AssetId[index] = _in;\
+            m##name##AssetId[index] = StringTable->EmptyString();\
             m##name##Asset[index] = NULL;\
             m##name[index].free();\
             m##name[index] = NULL;\

--- a/Engine/source/T3D/fx/splash.h
+++ b/Engine/source/T3D/fx/splash.h
@@ -122,8 +122,9 @@ public:
    F32               times[ NUM_TIME_KEYS ];
    LinearColorF            colors[ NUM_TIME_KEYS ];
 
-   DECLARE_IMAGEASSET_ARRAY(SplashData, Texture, NUM_TEX);
+   DECLARE_IMAGEASSET_ARRAY(SplashData, Texture, NUM_TEX, onTextureChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(SplashData, Texture)
+   void onTextureChanged() {}
 
    ExplosionData*    explosion;
    S32               explosionId;

--- a/Engine/source/environment/basicClouds.h
+++ b/Engine/source/environment/basicClouds.h
@@ -94,9 +94,9 @@ protected:
    static U32 smVertCount;
    static U32 smTriangleCount;
 
-   DECLARE_IMAGEASSET_ARRAY(BasicClouds, Texture, TEX_COUNT);
+   DECLARE_IMAGEASSET_ARRAY(BasicClouds, Texture, TEX_COUNT, onTextureChanged);
    DECLARE_IMAGEASSET_ARRAY_NET_SETGET(BasicClouds, Texture, -1);
-
+   void onTextureChanged() {}
    GFXStateBlockRef mStateblock;
 
    GFXShaderRef mShader;

--- a/Engine/source/gfx/sim/cubemapData.h
+++ b/Engine/source/gfx/sim/cubemapData.h
@@ -76,9 +76,10 @@ protected:
    DECLARE_IMAGEASSET(CubemapData, CubeMap, onCubemapChanged, GFXStaticTextureSRGBProfile);
    DECLARE_ASSET_SETGET(CubemapData, CubeMap);
 
-   DECLARE_IMAGEASSET_ARRAY(CubemapData, CubeMapFace, 6);
+   DECLARE_IMAGEASSET_ARRAY(CubemapData, CubeMapFace, 6, onCubeMapFaceChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(CubemapData, CubeMapFace);
 
+   void onCubeMapFaceChanged() {}
    GFXTexHandle mDepthBuff;
    GFXTextureTargetRef mRenderTarget;
 

--- a/Engine/source/gui/controls/guiPopUpCtrl.h
+++ b/Engine/source/gui/controls/guiPopUpCtrl.h
@@ -126,9 +126,9 @@ protected:
       NumBitmapModes = 2
    };
 
-   DECLARE_IMAGEASSET_ARRAY(GuiPopUpMenuCtrl, Bitmap, NumBitmapModes);
+   DECLARE_IMAGEASSET_ARRAY(GuiPopUpMenuCtrl, Bitmap, NumBitmapModes, onBitmapChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(GuiPopUpMenuCtrl, Bitmap);
-
+   void onBitmapChanged() {}
    Point2I mBitmapBounds; //  Added
 	S32 mIdMax;
 

--- a/Engine/source/gui/controls/guiPopUpCtrlEx.h
+++ b/Engine/source/gui/controls/guiPopUpCtrlEx.h
@@ -131,9 +131,9 @@ class GuiPopUpMenuCtrlEx : public GuiTextCtrl
       NumBitmapModes = 2
    };
 
-   DECLARE_IMAGEASSET_ARRAY(GuiPopUpMenuCtrlEx, Bitmap, NumBitmapModes);
+   DECLARE_IMAGEASSET_ARRAY(GuiPopUpMenuCtrlEx, Bitmap, NumBitmapModes, onBitmapChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(GuiPopUpMenuCtrlEx, Bitmap);
-
+   void onBitmapChanged() {}
    Point2I mBitmapBounds; //  Added
 
 	S32 mIdMax;

--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -245,6 +245,7 @@ Material::Material()
 
 void Material::onImageAssetChanged()
 {
+   flush();
    reload();
 }
 

--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -243,6 +243,10 @@ Material::Material()
    mReverbSoundOcclusion = 1.0;
 }
 
+void Material::onImageAssetChanged()
+{
+   reload();
+}
 
 void Material::initPersistFields()
 {
@@ -857,3 +861,4 @@ DEF_IMAGEASSET_ARRAY_BINDS(Material, AOMap);
 DEF_IMAGEASSET_ARRAY_BINDS(Material, MetalMap);
 DEF_IMAGEASSET_ARRAY_BINDS(Material, GlowMap);
 DEF_IMAGEASSET_ARRAY_BINDS(Material, DetailNormalMap);
+

--- a/Engine/source/materials/materialDefinition.h
+++ b/Engine/source/materials/materialDefinition.h
@@ -208,49 +208,53 @@ public:
    //-----------------------------------------------------------------------
    // Data
    //-----------------------------------------------------------------------
-   DECLARE_IMAGEASSET_ARRAY(Material, DiffuseMap, MAX_STAGES);
+   void onImageAssetChanged() {
+      reload();
+   }
+
+   DECLARE_IMAGEASSET_ARRAY(Material, DiffuseMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, DiffuseMap);
 
    bool     mDiffuseMapSRGB[MAX_STAGES];   // SRGB diffuse
-   DECLARE_IMAGEASSET_ARRAY(Material, OverlayMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, OverlayMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, OverlayMap);
 
-   DECLARE_IMAGEASSET_ARRAY(Material, LightMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, LightMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, LightMap);
 
-   DECLARE_IMAGEASSET_ARRAY(Material, ToneMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, ToneMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, ToneMap);
 
-   DECLARE_IMAGEASSET_ARRAY(Material, DetailMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, DetailMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, DetailMap);
 
-   DECLARE_IMAGEASSET_ARRAY(Material, NormalMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, NormalMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, NormalMap);
 
-   DECLARE_IMAGEASSET_ARRAY(Material, ORMConfigMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, ORMConfigMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, ORMConfigMap);
 
    bool     mIsSRGb[MAX_STAGES];
-   DECLARE_IMAGEASSET_ARRAY(Material, AOMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, AOMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, AOMap);
    F32      mAOChan[MAX_STAGES];
 
-   DECLARE_IMAGEASSET_ARRAY(Material, RoughMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, RoughMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, RoughMap);
    bool     mInvertRoughness[MAX_STAGES];
    F32      mRoughnessChan[MAX_STAGES];
 
-   DECLARE_IMAGEASSET_ARRAY(Material, MetalMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, MetalMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, MetalMap);
 
    F32      mMetalChan[MAX_STAGES];
-   DECLARE_IMAGEASSET_ARRAY(Material, GlowMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, GlowMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, GlowMap);
 
    F32      mGlowMul[MAX_STAGES];
    /// A second normal map which repeats at the detail map
    /// scale and blended with the base normal map.
-   DECLARE_IMAGEASSET_ARRAY(Material, DetailNormalMap, MAX_STAGES);
+   DECLARE_IMAGEASSET_ARRAY(Material, DetailNormalMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, DetailNormalMap);
 
    /// The strength scalar for the detail normal map.

--- a/Engine/source/materials/materialDefinition.h
+++ b/Engine/source/materials/materialDefinition.h
@@ -208,9 +208,7 @@ public:
    //-----------------------------------------------------------------------
    // Data
    //-----------------------------------------------------------------------
-   void onImageAssetChanged() {
-      reload();
-   }
+   void onImageAssetChanged();
 
    DECLARE_IMAGEASSET_ARRAY(Material, DiffuseMap, MAX_STAGES, onImageAssetChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(Material, DiffuseMap);

--- a/Engine/source/materials/materialManager.h
+++ b/Engine/source/materials/materialManager.h
@@ -116,11 +116,7 @@ public:
    /// Returns the signal used to notify systems that the 
    /// procedural shaders have been flushed.
    FlushSignal& getFlushSignal() { return mFlushSignal; }
-
-   /// Flushes all the procedural shaders and re-initializes all
-   /// the active materials instances immediately.
    void flushAndReInitInstances();
-
    // Flush the instance
    void flushInstance( BaseMaterialDefinition *target );
 
@@ -133,7 +129,14 @@ protected:
    friend class MatInstance;
    void _track(MatInstance*);
    void _untrack(MatInstance*);
+   /// Flushes all the procedural shaders and re-initializes all
+   /// the active materials instances immediately.
+   void _flushAndReInitInstances();
+   // Flush the instance
+   void _flushInstance(BaseMaterialDefinition* target);
 
+   /// Re-initializes the material instances for a specific target material.   
+   void _reInitInstance(BaseMaterialDefinition* target);
    /// @see LightManager::smActivateSignal
    void _onLMActivate( const char *lm, bool activate );
 
@@ -155,6 +158,8 @@ protected:
    /// If set we flush and reinitialize all materials at the
    /// start of the next rendered frame.
    bool mFlushAndReInit;
+   bool mMatDefShouldReload;
+   bool mMatDefShouldFlush;
 
    // material map
    typedef Map<String, String> MaterialMap;
@@ -169,6 +174,8 @@ protected:
    F32 mDampness;
 
    BaseMatInstance* mWarningInst;
+   BaseMaterialDefinition* mMatDefToFlush;
+   BaseMaterialDefinition* mMatDefToReload;
 
    /// The default max anisotropy used in texture filtering.
    S32 mDefaultAnisotropy;

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -401,14 +401,8 @@ void ProcessedMaterial::_setStageData()
             if (String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("#") || String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("$"))
             {
                mMaterial->logError("Named Target not ready %s for stage %i", mMaterial->mDiffuseMapAsset[i]->getImageFileName(), i);
-               mHasSetStageData = false;
             }
-            else
-            {
-               // Load a debug texture to make it clear to the user 
-               // that the texture for this stage was missing.
-               mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
-            }
+            mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
          }
       }
       else if (mMaterial->mDiffuseMapName[i] != StringTable->EmptyString())
@@ -421,14 +415,10 @@ void ProcessedMaterial::_setStageData()
             if (String(mMaterial->mDiffuseMapName[i]).startsWith("#") || String(mMaterial->mDiffuseMapName[i]).startsWith("$"))
             {
                mMaterial->logError("Named Target not ready %s for stage %i", mMaterial->mDiffuseMapName[i], i);
-               mHasSetStageData = false;
             }
-            else
-            {
-               // Load a debug texture to make it clear to the user 
-               // that the texture for this stage was missing.
-               mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
-            }
+            // Load a debug texture to make it clear to the user 
+            // that the texture for this stage was missing.
+            mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
          }
       }
       // OverlayMap

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -395,30 +395,42 @@ void ProcessedMaterial::_setStageData()
       if (mMaterial->mDiffuseMapAsset[i] && !mMaterial->mDiffuseMapAsset[i].isNull())
       {
          mStages[i].setTex(MFT_DiffuseMap, mMaterial->getDiffuseMapResource(i));
-         //mStages[i].setTex(MFT_DiffuseMap, _createTexture(mMaterial->getDiffuseMap(i), &GFXStaticTextureSRGBProfile));
          if (!mStages[i].getTex(MFT_DiffuseMap))
          {
+            // If we start with a #, we're probably actually attempting to hit a named target and it may not get a hit on the first pass.
             if (String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("#") || String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("$"))
             {
-               NamedTexTarget* namedTarget = NamedTexTarget::find(mMaterial->mDiffuseMapAsset[i]->getImageFileName() + 1);
-               if (namedTarget)
-                  mStages[i].setTex(MFT_DiffuseMap, namedTarget->getTexture(0));
-               if (mStages[i].getTex(MFT_DiffuseMap))
-               {
-                  mMaterial->mDiffuseMap[i] = namedTarget->getTexture(0);
-               }
-
-               if (!mStages[i].getTex(MFT_DiffuseMap))
-                  mHasSetStageData = false;
+               mMaterial->logError("Named Target not ready %s for stage %i", mMaterial->mDiffuseMapAsset[i]->getImageFileName(), i);
+               mHasSetStageData = false;
             }
-            else {
+            else
+            {
                // Load a debug texture to make it clear to the user 
                // that the texture for this stage was missing.
                mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
             }
          }
       }
-
+      else if (mMaterial->mDiffuseMapName[i] != StringTable->EmptyString())
+      {
+         mStages[i].setTex(MFT_DiffuseMap, _createTexture(mMaterial->mDiffuseMapName[i], &GFXStaticTextureSRGBProfile));
+         if (!mStages[i].getTex(MFT_DiffuseMap))
+         {
+            //If we start with a #, we're probably actually attempting to hit a named target and it may not get a hit on the first pass. So we'll
+            //pass on the error rather than spamming the console
+            if (String(mMaterial->mDiffuseMapName[i]).startsWith("#") || String(mMaterial->mDiffuseMapName[i]).startsWith("$"))
+            {
+               mMaterial->logError("Named Target not ready %s for stage %i", mMaterial->mDiffuseMapName[i], i);
+               mHasSetStageData = false;
+            }
+            else
+            {
+               // Load a debug texture to make it clear to the user 
+               // that the texture for this stage was missing.
+               mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
+            }
+         }
+      }
       // OverlayMap
       if (mMaterial->getOverlayMap(i) != StringTable->EmptyString())
       {

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -398,29 +398,20 @@ void ProcessedMaterial::_setStageData()
          //mStages[i].setTex(MFT_DiffuseMap, _createTexture(mMaterial->getDiffuseMap(i), &GFXStaticTextureSRGBProfile));
          if (!mStages[i].getTex(MFT_DiffuseMap))
          {
-            // Load a debug texture to make it clear to the user 
-            // that the texture for this stage was missing.
-            mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
-         }
-      }
-      else if (mMaterial->mDiffuseMapName[i] != StringTable->EmptyString())
-      {
-         mStages[i].setTex(MFT_DiffuseMap, _createTexture(mMaterial->mDiffuseMapName[i], &GFXStaticTextureSRGBProfile));
-         if (!mStages[i].getTex(MFT_DiffuseMap))
-         {
-            //If we start with a #, we're probably actually attempting to hit a named target and it may not get a hit on the first pass. So we'll
-            //pass on the error rather than spamming the console
-            if (String(mMaterial->mDiffuseMapName[i]).startsWith("#") || String(mMaterial->mDiffuseMapName[i]).startsWith("$"))
+            if (String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("#") || String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("$"))
             {
-               NamedTexTarget* namedTarget = NamedTexTarget::find(mMaterial->mDiffuseMapName[i] + 1);
-               if(namedTarget)
+               NamedTexTarget* namedTarget = NamedTexTarget::find(mMaterial->mDiffuseMapAsset[i]->getImageFileName() + 1);
+               if (namedTarget)
                   mStages[i].setTex(MFT_DiffuseMap, namedTarget->getTexture(0));
-            }
-            else
-            {
-               if (!String(mMaterial->mDiffuseMapName[i]).startsWith("#"))
-                  mMaterial->logError("Failed to load diffuse map %s for stage %i", mMaterial->mDiffuseMapName[i], i);
+               if (mStages[i].getTex(MFT_DiffuseMap))
+               {
+                  mMaterial->mDiffuseMap[i] = namedTarget->getTexture(0);
+               }
 
+               if (!mStages[i].getTex(MFT_DiffuseMap))
+                  mHasSetStageData = false;
+            }
+            else {
                // Load a debug texture to make it clear to the user 
                // that the texture for this stage was missing.
                mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -398,10 +398,9 @@ void ProcessedMaterial::_setStageData()
          if (!mStages[i].getTex(MFT_DiffuseMap))
          {
             // If we start with a #, we're probably actually attempting to hit a named target and it may not get a hit on the first pass.
-            if (String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("#") || String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("$"))
-            {
-               mMaterial->logError("Named Target not ready %s for stage %i", mMaterial->mDiffuseMapAsset[i]->getImageFileName(), i);
-            }
+            if (!String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("#") && !String(mMaterial->mDiffuseMapAsset[i]->getImageFileName()).startsWith("$"))
+               mMaterial->logError("Failed to load diffuse map %s for stage %i", mMaterial->mDiffuseMapAsset[i]->getImageFileName(), i);
+
             mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
          }
       }
@@ -410,12 +409,10 @@ void ProcessedMaterial::_setStageData()
          mStages[i].setTex(MFT_DiffuseMap, _createTexture(mMaterial->mDiffuseMapName[i], &GFXStaticTextureSRGBProfile));
          if (!mStages[i].getTex(MFT_DiffuseMap))
          {
-            //If we start with a #, we're probably actually attempting to hit a named target and it may not get a hit on the first pass. So we'll
-            //pass on the error rather than spamming the console
-            if (String(mMaterial->mDiffuseMapName[i]).startsWith("#") || String(mMaterial->mDiffuseMapName[i]).startsWith("$"))
-            {
-               mMaterial->logError("Named Target not ready %s for stage %i", mMaterial->mDiffuseMapName[i], i);
-            }
+            //If we start with a #, we're probably actually attempting to hit a named target and it may not get a hit on the first pass.
+            if (!String(mMaterial->mDiffuseMapName[i]).startsWith("#") && !String(mMaterial->mDiffuseMapName[i]).startsWith("$"))
+               mMaterial->logError("Failed to load diffuse map %s for stage %i", mMaterial->mDiffuseMapName[i], i);
+
             // Load a debug texture to make it clear to the user 
             // that the texture for this stage was missing.
             mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -410,12 +410,21 @@ void ProcessedMaterial::_setStageData()
          {
             //If we start with a #, we're probably actually attempting to hit a named target and it may not get a hit on the first pass. So we'll
             //pass on the error rather than spamming the console
-            if (!String(mMaterial->mDiffuseMapName[i]).startsWith("#"))
-               mMaterial->logError("Failed to load diffuse map %s for stage %i", mMaterial->mDiffuseMapName[i], i);
+            if (String(mMaterial->mDiffuseMapName[i]).startsWith("#") || String(mMaterial->mDiffuseMapName[i]).startsWith("$"))
+            {
+               NamedTexTarget* namedTarget = NamedTexTarget::find(mMaterial->mDiffuseMapName[i] + 1);
+               if(namedTarget)
+                  mStages[i].setTex(MFT_DiffuseMap, namedTarget->getTexture(0));
+            }
+            else
+            {
+               if (!String(mMaterial->mDiffuseMapName[i]).startsWith("#"))
+                  mMaterial->logError("Failed to load diffuse map %s for stage %i", mMaterial->mDiffuseMapName[i], i);
 
-            // Load a debug texture to make it clear to the user 
-            // that the texture for this stage was missing.
-            mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
+               // Load a debug texture to make it clear to the user 
+               // that the texture for this stage was missing.
+               mStages[i].setTex(MFT_DiffuseMap, _createTexture(GFXTextureManager::getMissingTexturePath().c_str(), &GFXStaticTextureSRGBProfile));
+            }
          }
       }
 

--- a/Engine/source/postFx/postEffect.h
+++ b/Engine/source/postFx/postEffect.h
@@ -90,8 +90,9 @@ public:
 
 protected:
 
-   DECLARE_IMAGEASSET_ARRAY(PostEffect, Texture, NumTextures);
+   DECLARE_IMAGEASSET_ARRAY(PostEffect, Texture, NumTextures, onTextureChanged);
    DECLARE_IMAGEASSET_ARRAY_SETGET(PostEffect, Texture);
+   void onTextureChanged() {}
 
    bool mTexSRGB[NumTextures];
 


### PR DESCRIPTION
image assets can now be bound to a named texture target if used in a material the target needs to exist before the material is initialized