### PR TITLE
suport augs for modules that include full libraries

### DIFF
--- a/Engine/source/CMakeLists.txt
+++ b/Engine/source/CMakeLists.txt
@@ -252,6 +252,29 @@ if (NOT "${TORQUE_MODULE_USER_PATH}" STREQUAL "")
 	list(APPEND TORQUE_MODULE_PATHS "${TORQUE_MODULE_USER_PATH}")
 endif()
 
+################# MODULE LIBRARIES ###################
+set(TORQUE_LIBRARY_BASE_PATH "${TORQUE_APP_GAME_DIRECTORY}/data")
+message(STATUS "Checking base path: ${TORQUE_LIBRARY_BASE_PATH}")
+set(MODULE_SUBDIRS_INCLUDED "")
+if (EXISTS "${TORQUE_LIBRARY_BASE_PATH}")
+    # List all immediate subdirectories of the base path for debugging
+    file(GLOB MODULE_SUBDIRS "${TORQUE_LIBRARY_BASE_PATH}/*")
+    foreach (MODULE_SUBDIR ${MODULE_SUBDIRS})
+        if (EXISTS "${MODULE_SUBDIR}/source/libs/libs.cmake")
+            message(STATUS "Adding subdirectory: ${MODULE_SUBDIR}/libs")
+            # Handle spaces in paths (if needed)
+            string(REPLACE " " "_" MODULE_BINARY_SUBDIR "${MODULE_SUBDIR}/libs")
+            
+            # Explicitly specify source and binary directories
+            include("${MODULE_SUBDIR}/source/libs/libs.cmake")
+            cmake_path(GET MODULE_SUBDIR STEM LAST_ONLY LAST_DIR_WORD)
+            set(MODULE_SUBDIRS_INCLUDED ${MODULE_SUBDIRS_INCLUDED} ${LAST_DIR_WORD})
+        endif()
+    endforeach()
+else()
+    message(WARNING "Base path ${TORQUE_LIBRARY_BASE_PATH} does not exist.")
+endif()
+
 # Before doing module scanning, store away the engine sources - we do this so that modules
 # can be placed into the proper filters
 set(TORQUE_SOURCE_FILES_TEMPORARY ${TORQUE_SOURCE_FILES} ${TORQUE_APP_GAME_SOURCES})
@@ -272,30 +295,49 @@ foreach (TORQUE_MODULE_PATH ${TORQUE_MODULE_PATHS})
 
 	# Next find sub projects, these can introduce new source files
 	SUBDIRLIST(POSSIBLE_PROJECTS "${TORQUE_MODULE_PATH}")
-	foreach (POSSIBLE_PROJECT ${POSSIBLE_PROJECTS})
+    set(FILTERED_PROJECTS ${POSSIBLE_PROJECTS})
+	foreach (MODULE_INCLUDED ${MODULE_SUBDIRS_INCLUDED})
+        list(FILTER FILTERED_PROJECTS EXCLUDE REGEX ${MODULE_INCLUDED})
+	endforeach()
+    
+	foreach (POSSIBLE_PROJECT ${FILTERED_PROJECTS})
 		# Retrieve the absolute path of this possible project
 		get_filename_component(POSSIBLE_PROJECT_ABSOLUTEPATH "${POSSIBLE_PROJECT}"
 							   REALPATH BASE_DIR "${TORQUE_MODULE_PATH}")
 
-		if (EXISTS "${POSSIBLE_PROJECT_ABSOLUTEPATH}/CMakeLists.txt")
+		if (EXISTS "${POSSIBLE_PROJECT_ABSOLUTEPATH}/source/CMakeLists.txt")
 			add_subdirectory("${POSSIBLE_PROJECT_ABSOLUTEPATH}" ${CMAKE_BINARY_DIR}/temp/${POSSIBLE_PROJECT} EXCLUDE_FROM_ALL)
             source_group(TREE "${POSSIBLE_PROJECT_ABSOLUTEPATH}" PREFIX "Modules/${POSSIBLE_PROJECT}" FILES ${TORQUE_SOURCE_FILES})
 
             set(TORQUE_SOURCE_FILES_TEMPORARY ${TORQUE_SOURCE_FILES_TEMPORARY} ${TORQUE_SOURCE_FILES})
             set(TORQUE_SOURCE_FILES "")
-        elseif(NOT EXISTS "${POSSIBLE_PROJECT_ABSOLUTEPATH}/*.cmake")
+        elseif(NOT EXISTS "${POSSIBLE_PROJECT_ABSOLUTEPATH}/source/*.cmake" AND NOT EXISTS "${POSSIBLE_PROJECT_ABSOLUTEPATH}/source/libs/*.cmake")
             file(GLOB_RECURSE MODULE_SOURCE "${POSSIBLE_PROJECT_ABSOLUTEPATH}/source/*.h" "${POSSIBLE_PROJECT_ABSOLUTEPATH}/source/*.cpp")
             #message(STATUS "MODULE_SOURCE:${MODULE_SOURCE}")
             source_group(TREE "${POSSIBLE_PROJECT_ABSOLUTEPATH}" PREFIX "Modules/${POSSIBLE_PROJECT}/" FILES ${MODULE_SOURCE})
             set(TORQUE_SOURCE_FILES_TEMPORARY ${TORQUE_SOURCE_FILES_TEMPORARY} ${MODULE_SOURCE})
 		endif()
-	endforeach()
+	endforeach()    
+    
 endforeach()
 
-set(TORQUE_SOURCE_FILES ${TORQUE_SOURCE_FILES_TEMPORARY})
+foreach (MODULE_INCLUDED ${MODULE_SUBDIRS_INCLUDED})
+    set(WRAPPER_DIR ${TORQUE_LIBRARY_BASE_PATH}/${MODULE_INCLUDED}/source/wrappers)
+    if (EXISTS ${WRAPPER_DIR})
+        #message("including ${WRAPPER_DIR}")
+            file(GLOB_RECURSE WRAPPER_SOURCE "${WRAPPER_DIR}/*.h" "${WRAPPER_DIR}/*.cpp")
+            source_group(TREE "${WRAPPER_DIR}" PREFIX "Modules/${MODULE_INCLUDED}/" FILES ${WRAPPER_SOURCE})
+            set(WRAPPER_FILES ${WRAPPER_FILES} ${WRAPPER_SOURCE})
+        #message("including ${WRAPPER_FILES}")
+        set(TORQUE_INCLUDE_DIRECTORIES ${TORQUE_INCLUDE_DIRECTORIES} ${WRAPPER_DIR})
+    endif()
+endforeach()
+
+set(TORQUE_SOURCE_FILES ${TORQUE_SOURCE_FILES_TEMPORARY} ${WRAPPER_FILES})
+
 
 ################# Library Post-build Handling ###################
-set(TORQUE_LIBRARY_PATHS "${CMAKE_SOURCE_DIR}/Engine/lib" "${TORQUE_APP_GAME_DIRECTORY}/data")
+set(TORQUE_LIBRARY_PATHS "${CMAKE_SOURCE_DIR}/Engine/lib")
 if (NOT "${TORQUE_LIBRARY_USER_PATH}" STREQUAL "")
 	list(APPEND TORQUE_LIBRARY_PATHS "${TORQUE_LIBRARY_USER_PATH}")
 endif()
@@ -458,7 +500,7 @@ foreach (TORQUE_LIBRARY ${TORQUE_LINK_LIBRARIES})
   set_target_properties(${TORQUE_LIBRARY} PROPERTIES
   FOLDER "Libraries")
   # remove warnings from 3rd parties.
-  target_compile_options(${TORQUE_LIBRARY} PRIVATE "-w")
+  #target_compile_options(${TORQUE_LIBRARY} PRIVATE "-w")
 endforeach()
 
 target_compile_definitions(${TORQUE_APP_NAME} PUBLIC ${TORQUE_COMPILE_DEFINITIONS})

--- a/Tools/CMake/torque_macros.cmake
+++ b/Tools/CMake/torque_macros.cmake
@@ -33,7 +33,9 @@ endmacro()
 
 function(installTemplate templateName)
   message("Prepare Template(${templateName}) install...")
-
+  
+  file(COPY "${CMAKE_SOURCE_DIR}/Templates/${templateName}/" DESTINATION "${TORQUE_APP_ROOT_DIRECTORY}" FILES_MATCHING PATTERN "*.in")
+  file(COPY "${CMAKE_SOURCE_DIR}/Templates/${templateName}/" DESTINATION "${TORQUE_APP_ROOT_DIRECTORY}" FILES_MATCHING PATTERN "*.cmake")
   add_subdirectory("${CMAKE_SOURCE_DIR}/Templates/${templateName}")
 endfunction()
 


### PR DESCRIPTION
copies over .in and .cmake files for those cases when libraries themselves need to self-configure searches for a source/libs/libs.cmake file for any torque-specific confiugurations we need to make for a given library autoinclude any source/wrappers directory for unique to orque files, which will most commonly be data holder classes and script exposure, as well as adding those dirs to the #include listener list also ditches forcing warn levels to lowest for libraries since if folks are going to experiment, best tey know about anmy underlying things to avoid