### PR TITLE
Double buffer rendering on DX and GL - (4.3?)

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -234,17 +234,17 @@ DXGI_SWAP_CHAIN_DESC GFXD3D11Device::setupPresentParams(const GFXVideoMode &mode
 
    mMultisampleDesc = sampleDesc;
 
-   d3dpp.BufferCount = smEnableVSync ? 2 : 1; // triple buffering when vsync is on.
+   d3dpp.BufferCount = smEnableVSync ? 3 : 2; // triple buffering in vsync, double buffered non vsync.
    d3dpp.BufferDesc.Width = mode.resolution.x;
    d3dpp.BufferDesc.Height = mode.resolution.y;
-   d3dpp.BufferDesc.Format = GFXD3D11TextureFormat[GFXFormatR8G8B8A8_SRGB];
+   d3dpp.BufferDesc.Format = GFXD3D11TextureFormat[GFXFormatR8G8B8A8];
    d3dpp.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
    d3dpp.OutputWindow = hwnd;
    d3dpp.SampleDesc = sampleDesc;
    d3dpp.Windowed = !mode.fullScreen;
    d3dpp.BufferDesc.RefreshRate.Numerator = mode.refreshRate;
    d3dpp.BufferDesc.RefreshRate.Denominator = 1;
-   d3dpp.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+   d3dpp.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 
    if (mode.fullScreen)
    {

--- a/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
@@ -332,7 +332,7 @@ GFXD3D11WindowTarget::GFXD3D11WindowTarget()
 GFXD3D11WindowTarget::~GFXD3D11WindowTarget()
 {
    SAFE_RELEASE(mDepthStencilView)
-      SAFE_RELEASE(mDepthStencil);
+   SAFE_RELEASE(mDepthStencil);
    SAFE_RELEASE(mBackBufferView);
    SAFE_RELEASE(mBackBuffer);
    SAFE_RELEASE(mSwapChain);
@@ -382,7 +382,8 @@ bool GFXD3D11WindowTarget::present()
       else if (result == DXGI_ERROR_INVALID_CALL)
          AssertFatal(false, "DXGI_ERROR_INVALID_CALL");
    }
-
+   // if swap chain flip this needs to be called right after present as it unbinds the backbuffer.
+   activate();
    return (hr == S_OK);
 }
 
@@ -553,8 +554,10 @@ void GFXD3D11WindowTarget::resurrect()
 
 void GFXD3D11WindowTarget::setBackBuffer()
 {
-   if (!mBackBuffer)
-      mSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)& mBackBuffer);
+   SAFE_RELEASE(mBackBuffer);
+   HRESULT hr = mSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&mBackBuffer);
+   if (FAILED(hr))
+      AssertFatal(false, "GFXD3D11WindowTarget::setBackBuffer - Failed to retrieve backbuffer.");
 }
 
 void GFXD3D11WindowTarget::activate()

--- a/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
@@ -324,6 +324,7 @@ GFXD3D11WindowTarget::GFXD3D11WindowTarget()
    mDepthStencilView = NULL;
    mDepthStencil = NULL;
    mBackBufferView = NULL;
+   mPrevBackBuffer = NULL;
    mSwapChain = NULL;
    dMemset(&mPresentationParams, 0, sizeof(mPresentationParams));
    mSecondaryWindow = false;
@@ -335,6 +336,7 @@ GFXD3D11WindowTarget::~GFXD3D11WindowTarget()
    SAFE_RELEASE(mDepthStencil);
    SAFE_RELEASE(mBackBufferView);
    SAFE_RELEASE(mBackBuffer);
+   SAFE_RELEASE(mPrevBackBuffer);
    SAFE_RELEASE(mSwapChain);
 }
 
@@ -383,6 +385,7 @@ bool GFXD3D11WindowTarget::present()
          AssertFatal(false, "DXGI_ERROR_INVALID_CALL");
    }
    // if swap chain flip this needs to be called right after present as it unbinds the backbuffer.
+   setBackBuffer();
    activate();
    return (hr == S_OK);
 }
@@ -554,10 +557,12 @@ void GFXD3D11WindowTarget::resurrect()
 
 void GFXD3D11WindowTarget::setBackBuffer()
 {
-   SAFE_RELEASE(mBackBuffer);
+   // dx automatically handles the backbuffer swaps, 0 is always the previous backbuffer.
    HRESULT hr = mSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&mBackBuffer);
    if (FAILED(hr))
       AssertFatal(false, "GFXD3D11WindowTarget::setBackBuffer - Failed to retrieve backbuffer.");
+
+   mPrevBackBuffer = mBackBuffer;
 }
 
 void GFXD3D11WindowTarget::activate()
@@ -589,7 +594,7 @@ void GFXD3D11WindowTarget::resolveTo(GFXTextureObject *tex)
    D3D11_TEXTURE2D_DESC desc;
    ID3D11Texture2D* surf = ((GFXD3D11TextureObject*)(tex))->get2DTex();
    surf->GetDesc(&desc);
-   D3D11DEVICECONTEXT->ResolveSubresource(surf, 0, mBackBuffer, 0, desc.Format);
+   D3D11DEVICECONTEXT->ResolveSubresource(surf, 0, mPrevBackBuffer, 0, desc.Format);
 }
 
 IDXGISwapChain* GFXD3D11WindowTarget::getSwapChain()
@@ -602,6 +607,12 @@ ID3D11Texture2D* GFXD3D11WindowTarget::getBackBuffer()
 {
    mBackBuffer->AddRef();
    return mBackBuffer;
+}
+
+ID3D11Texture2D* GFXD3D11WindowTarget::getPrevBackBuffer()
+{
+   mPrevBackBuffer->AddRef();
+   return mPrevBackBuffer;
 }
 
 ID3D11Texture2D* GFXD3D11WindowTarget::getDepthStencil()

--- a/Engine/source/gfx/D3D11/gfxD3D11Target.h
+++ b/Engine/source/gfx/D3D11/gfxD3D11Target.h
@@ -77,6 +77,7 @@ class GFXD3D11WindowTarget : public GFXWindowTarget
 
    /// Our backbuffer
    ID3D11Texture2D* mBackBuffer;
+   ID3D11Texture2D* mPrevBackBuffer;
    ID3D11Texture2D* mDepthStencil;
    ID3D11RenderTargetView* mBackBufferView;
    ID3D11DepthStencilView* mDepthStencilView;
@@ -116,6 +117,7 @@ public:
    // These are all reference counted and must be released by whomever uses the get* function
    IDXGISwapChain* getSwapChain();
    ID3D11Texture2D* getBackBuffer();
+   ID3D11Texture2D* getPrevBackBuffer();
    ID3D11Texture2D* getDepthStencil();
    ID3D11RenderTargetView* getBackBufferView();
    ID3D11DepthStencilView* getDepthStencilView();

--- a/Engine/source/gfx/gl/gfxGLWindowTarget.cpp
+++ b/Engine/source/gfx/gl/gfxGLWindowTarget.cpp
@@ -121,10 +121,10 @@ inline void GFXGLWindowTarget::_setupAttachments()
    glEnable(GL_FRAMEBUFFER_SRGB);
    GFXGL->getOpenglCache()->setCacheBinded(GL_FRAMEBUFFER, mBackBufferFBO);
    const Point2I dstSize = getSize();
-   mBackBufferColorTex.set(dstSize.x, dstSize.y, getFormat(), &GFXRenderTargetSRGBProfile, "backBuffer");
+   mBackBufferColorTex.set(dstSize.x, dstSize.y, getFormat(), &GFXRenderTargetSRGBProfile, "backBuffer_color");
    GFXGLTextureObject *color = static_cast<GFXGLTextureObject*>(mBackBufferColorTex.getPointer());
    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color->getHandle(), 0);
-   mBackBufferDepthTex.set(dstSize.x, dstSize.y, GFXFormatD24S8, &BackBufferDepthProfile, "backBuffer");
+   mBackBufferDepthTex.set(dstSize.x, dstSize.y, GFXFormatD24S8, &BackBufferDepthProfile, "backBuffer_depth");
    GFXGLTextureObject *depth = static_cast<GFXGLTextureObject*>(mBackBufferDepthTex.getPointer());
    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depth->getHandle(), 0);
 }

--- a/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
+++ b/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
@@ -103,8 +103,6 @@ void GFXGLDevice::enumerateAdapters( Vector<GFXAdapter*> &adapterList )
    }
 
    SDL_ClearError();
-   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
    SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1);
 
@@ -140,6 +138,9 @@ void GFXGLDevice::enumerateAdapters( Vector<GFXAdapter*> &adapterList )
       return;
    }
 
+   // Set our sdl attribute to use this version.
+   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, major);
+   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minor);
    //check for required extensions
    if (!gglHasExtension(ARB_texture_cube_map_array))
    {

--- a/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
+++ b/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
@@ -137,6 +137,7 @@ void GFXGLDevice::enumerateAdapters( Vector<GFXAdapter*> &adapterList )
    {
       return;
    }
+   Con::printf("OpenGL Version: %d.%d", major, minor);
 
    // Set our sdl attribute to use this version.
    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, major);
@@ -169,7 +170,26 @@ void GFXGLDevice::enumerateAdapters( Vector<GFXAdapter*> &adapterList )
       dStrcpy(toAdd->mName, "OpenGL", GFXAdapter::MaxAdapterNameLen);
 
    toAdd->mType = OpenGL;
-   toAdd->mShaderModel = 0.f;
+   F32 shaderModel = 3.3;
+   if (major == 4)
+   {
+      if (minor == 0)
+         shaderModel = 4.00f;  // GLSL 4.00
+      else if (minor == 1)
+         shaderModel = 4.10f;  // GLSL 4.10
+      else if (minor == 2)
+         shaderModel = 4.20f;  // GLSL 4.20
+      else if (minor == 3)
+         shaderModel = 4.30f;  // GLSL 4.30
+      else if (minor == 4)
+         shaderModel = 4.40f;  // GLSL 4.40
+      else if (minor == 5)
+         shaderModel = 4.50f;  // GLSL 4.50
+      else if (minor == 6)
+         shaderModel = 4.60f;  // GLSL 4.60
+   }
+
+   toAdd->mShaderModel = shaderModel;
    toAdd->mCreateDeviceInstanceDelegate = mCreateDeviceInstance;
 
    // Enumerate all available resolutions:

--- a/Engine/source/platformSDL/sdlPlatformGL.cpp
+++ b/Engine/source/platformSDL/sdlPlatformGL.cpp
@@ -13,18 +13,16 @@ namespace PlatformGL
 
    void init()
    {
-       const U32 majorOGL = 3;
-       const U32 minorOGL = 3;
        U32 debugFlag = 0;
 #ifdef TORQUE_DEBUG
        debugFlag |= SDL_GL_CONTEXT_DEBUG_FLAG;
 #endif
-
-       SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, majorOGL);
-       SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minorOGL);
        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
        SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, debugFlag);
        SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1);
+       SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1); // Enable double buffering
+       // Make sure the visual is accelerated
+       SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 #ifdef TORQUE_GL_SOFTWARE
        SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 0);
 #endif
@@ -50,6 +48,10 @@ namespace PlatformGL
            Con::printf( err );
            AssertFatal(0, err );
        }
+       int majorOGL = 0;
+       int minorOGL = 0;
+       SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &majorOGL);
+       SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minorOGL);
 
        return ctx;
    }


### PR DESCRIPTION
### DX Changes
use DXGI_SWAP_EFFECT_FLIP_DISCARD for the swapeffect 
buffer count to 2, 3 when vsync is on (recommended setup but can tune this)
prevBackBuffer added to gfxd3d11windowTarget to swap to for postfx or targets etc.

### GL Changes
use SDL window in double buffered mode
dynamic version picking (minimum of 3.3) 
TODO: pointer to previous buffer render.
