### PR TITLE
Adjusts the test behavior for when the player class tries to ray-check against PathShapes

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -4762,14 +4762,16 @@ bool Player::step(Point3F *pos,F32 *maxStep,F32 time)
 // PATHSHAPE
 // This Function does a ray cast down to see if a pathshape object is below
 // If so, it will attempt to attach to it.
-void Player::updateAttachment(){
+void Player::updateAttachment()
+{
    Point3F rot, pos;
     RayInfo rInfo;
     MatrixF mat = getTransform();
     mat.getColumn(3, &pos);
+    disableCollision();
     if (gServerContainer.castRay(Point3F(pos.x, pos.y, pos.z + 0.1f),
         Point3F(pos.x, pos.y, pos.z - 1.0f ),
-        PathShapeObjectType, &rInfo))
+       sCollisionMoveMask, &rInfo))
     {
        if ((mJumpSurfaceLastContact < JumpSkipContactsMax) && !mSwimming)
           setPosition(rInfo.point, getRotation());
@@ -4793,12 +4795,13 @@ void Player::updateAttachment(){
     }
     else
     {	 
-       if (getParent() !=NULL)
+       if (getParent() != NULL)
        {
           clearProcessAfter();
           attachToParent(NULL);
        }
     }
+    enableCollision();
 }
 // PATHSHAPE END
 


### PR DESCRIPTION
Adjusts the test behavior for when the player class tries to ray-check against PathShapes to nudge the player to a safer position. Originally it ONLY checked pathshapes, so a static over a pathshape could cause erroneous behavior.