### PR TITLE
Various Subscene Fixes

### DIFF
--- a/Engine/source/T3D/SubScene.h
+++ b/Engine/source/T3D/SubScene.h
@@ -40,6 +40,7 @@ private:
    S32 mStartUnloadTimerMS;
 
    bool mLoaded;
+   bool mSaving;
    bool mFreezeLoading;
 
    String mLoadIf;

--- a/Engine/source/T3D/assets/LevelAsset.cpp
+++ b/Engine/source/T3D/assets/LevelAsset.cpp
@@ -43,6 +43,7 @@
 // Debug Profiling.
 #include "platform/profiler.h"
 #include "gfx/gfxDrawUtil.h"
+#include "T3D/SubScene.h"
 
 
 //-----------------------------------------------------------------------------
@@ -479,8 +480,15 @@ GuiControl* GuiInspectorTypeLevelAssetPtr::constructEditControl()
    // Create "Open in Editor" button
    mEditButton = new GuiBitmapButtonCtrl();
 
-   dSprintf(szBuffer, sizeof(szBuffer), "$createAndAssignField = %s; AssetBrowser.setupCreateNewAsset(\"LevelAsset\", AssetBrowser.selectedModule, \"createAndAssignLevelAsset\");",
-      getIdString());
+   String setSubSceneValue = "$createLevelAssetIsSubScene = \"\";";
+   if(dynamic_cast<SubScene*>(mInspector->getInspectObject()) != NULL)
+   {
+      setSubSceneValue = "$createLevelAssetIsSubScene = true;";
+   }
+
+   dSprintf(szBuffer, sizeof(szBuffer), "$createAndAssignField = %s; %s AssetBrowser.setupCreateNewAsset(\"LevelAsset\", AssetBrowser.selectedModule, \"createAndAssignLevelAsset\");",
+      getIdString(),
+      setSubSceneValue.c_str());
    mEditButton->setField("Command", szBuffer);
 
    char bitmapName[512] = "ToolsModule:iconAdd_image";

--- a/Engine/source/T3D/convexShape.cpp
+++ b/Engine/source/T3D/convexShape.cpp
@@ -526,7 +526,7 @@ const char* ConvexShape::getSpecialFieldOut(StringTableEntry fieldName, const U3
       char buffer[1024];
       dMemset(buffer, 0, 1024);
 
-      dSprintf(buffer, 1024, "%g %g %g %g %g %g %g %i %g %g %g %g %g %i %i",
+      dSprintf(buffer, 1024, "surface = \"%g %g %g %g %g %g %g %i %g %g %g %g %g %i %i\";",
          quat.x, quat.y, quat.z, quat.w, pos.x, pos.y, pos.z, mSurfaceUVs[index].matID,
          mSurfaceUVs[index].offset.x, mSurfaceUVs[index].offset.y, mSurfaceUVs[index].scale.x,
          mSurfaceUVs[index].scale.y, mSurfaceUVs[index].zRot, mSurfaceUVs[index].horzFlip, mSurfaceUVs[index].vertFlip);
@@ -541,7 +541,7 @@ const char* ConvexShape::getSpecialFieldOut(StringTableEntry fieldName, const U3
       char buffer[1024];
       dMemset(buffer, 0, 1024);
 
-      dSprintf(buffer, 1024, "%s", mSurfaceTextures[index].getMaterial());
+      dSprintf(buffer, 1024, "surfaceTexture = \"%s\";", mSurfaceTextures[index].getMaterial());
 
       return StringTable->insert(buffer);
    }

--- a/Engine/source/console/persistenceManager.h
+++ b/Engine/source/console/persistenceManager.h
@@ -278,9 +278,9 @@ protected:
 
    // Write out properties
    // Returns the number of new lines added
-   U32 writeProperties(const Vector<const char*>& properties, const U32 insertLine, const char* objectIndent);
+   U32 writeProperties(const Vector<String>& properties, const U32 insertLine, const char* objectIndent);
    // Write out a new object
-   ParsedObject* writeNewObject(SimObject* object, const Vector<const char*>& properties, const U32 insertLine, ParsedObject* parentObject = NULL);
+   ParsedObject* writeNewObject(SimObject* object, const Vector<String>& properties, const U32 insertLine, ParsedObject* parentObject = NULL);
 
 public:
    PersistenceManager();

--- a/Engine/source/environment/decalRoad.cpp
+++ b/Engine/source/environment/decalRoad.cpp
@@ -494,7 +494,7 @@ const char* DecalRoad::getSpecialFieldOut(StringTableEntry fieldName, const U32&
 
       char buffer[1024];
       dMemset(buffer, 0, 1024);
-      dSprintf(buffer, 1024, "%f %f %f %f", node.point.x, node.point.y, node.point.z, node.width);
+      dSprintf(buffer, 1024, "node = \"%f %f %f %f\";", node.point.x, node.point.y, node.point.z, node.width);
 
       return StringTable->insert(buffer);
    }

--- a/Engine/source/environment/meshRoad.cpp
+++ b/Engine/source/environment/meshRoad.cpp
@@ -1197,7 +1197,7 @@ const char* MeshRoad::getSpecialFieldOut(StringTableEntry fieldName, const U32& 
 
       return StringTable->insert(buffer);
    }
-   else if (fieldName == StringTable->insert("ProfileNode"))
+   else if (fieldName == StringTable->insert("ProfileNode") && mSideProfile.mNodes.size())
    {
       Point3F nodePos = mSideProfile.mNodes[index].getPosition();
       U8 smooth, mtrl;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/level.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/level.tscript
@@ -4,7 +4,13 @@ function AssetBrowser::setupCreateNewLevelAsset(%this)
    NewAssetPropertiesInspector.addField("LevelName", "Level Name", "String",  "Human-readable name of new level", "", "", %this.newAssetSettings);
    NewAssetPropertiesInspector.addField("levelPreviewImage", "Level Preview Image", "Image",  "Preview Image for the level", "", "", %this.newAssetSettings);
    
-   NewAssetPropertiesInspector.addField("isSubScene", "Is SubScene", "bool",  "Is this levelAsset intended as a subScene", "", "", %this.newAssetSettings);
+   //If we forcefully set it elsewhere, adhere
+   if($createLevelAssetIsSubScene == true)
+      %this.newAssetSettings.isSubScene = true;
+   else
+      %this.newAssetSettings.isSubScene = false;
+   
+   NewAssetPropertiesInspector.addField("isSubScene", "Is SubScene", "bool", "Is this levelAsset intended as a subScene", %this.newAssetSettings.isSubScene, "", %this.newAssetSettings);
 
    NewAssetPropertiesInspector.endGroup();
 }
@@ -27,6 +33,7 @@ function AssetBrowser::createLevelAsset(%this)
    %tamlpath = %assetPath @ %assetName @ ".asset.taml";
    %levelPath = %assetPath @ %assetName @ %misExtension;
    
+
    %asset = new LevelAsset()
    {
       AssetName = %assetName;
@@ -55,7 +62,24 @@ function AssetBrowser::createLevelAsset(%this)
       echo("Unable to copy template level file!");
    }
    
-   replaceInFile(%levelPath, "EditorTemplateLevel", %assetName);
+   if(%asset.isSubScene)
+   {
+      %fileObj = new FileObject();
+      if (!%fileObj.openForWrite(%levelPath)) 
+      {
+         echo("Unable to write subScene file!");
+      }
+      else
+      {
+         %fileObj.writeLine("");
+         %fileObj.close();
+         %fileObj.delete();  
+      }
+   }
+   else
+   {
+      replaceInFile(%levelPath, "EditorTemplateLevel", %assetName);
+   }
    
    //Generate the associated files
    DecalManagerSave( %assetPath @ %asset.DecalsFile );
@@ -87,6 +111,8 @@ function AssetBrowser::setupCreateNewSubScene(%this)
 
 function AssetBrowser::editLevelAsset(%this, %assetDef)
 {
+   echo("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+   echo(%assetDef @ ".isSubScene = " @ %assetDef.isSubScene);
    if(!%assetDef.isSubScene)
       schedule( 1, 0, "EditorOpenMission", %assetDef);
 }
@@ -157,7 +183,15 @@ function AssetBrowser::buildLevelAssetPreview(%this, %assetDef, %previewData)
 {
    %previewData.assetName = %assetDef.assetName;
    %previewData.assetPath = %assetDef.getLevelPath();
-   %previewData.doubleClickCommand = "schedule( 1, 0, \"EditorOpenMission\", "@%assetDef@");";
+
+   if(%this.selectMode || %assetDef.isSubScene)
+   {
+      %previewData.doubleClickCommand = "AssetBrowser.selectAsset( AssetBrowser.selectedAsset );";
+   }
+   else
+   {
+      %previewData.doubleClickCommand = "schedule( 1, 0, \"EditorOpenMission\", "@%assetDef@");";
+   }
    
    %levelPreviewImage = %assetDef.PreviewImage;
          
@@ -176,7 +210,10 @@ function AssetBrowser::buildLevelAssetPreview(%this, %assetDef, %previewData)
 
 function createAndAssignLevelAsset(%moduleName, %assetName)
 {
-   $createAndAssignField.apply(%moduleName @ ":" @ %assetName);
+   if(AssetDatabase.isDeclaredAsset(%moduleName))
+      $createAndAssignField.apply(%moduleName);
+   else
+      $createAndAssignField.apply(%moduleName @ ":" @ %assetName);
 }
 
 function EWorldEditor::createSelectedAsSubScene( %this, %object )

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/newAsset.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/newAsset.tscript
@@ -124,6 +124,8 @@ function AssetBrowser::setupCreateNewAsset(%this, %assetType, %moduleName, %call
       %command = %this @ ".setupCreateNew"@%assetType @"();";
       eval(%command);
    }
+   
+   NewAssetPropertiesInspector.refresh();
 }
 
 function NewAssetPropertiesInspector::updateNewAssetField(%this)


### PR DESCRIPTION
* Update levelAsset creation so it can be flagged to be creating a subScene preemptively, improving workflow when creating a SubScene level asset 'in place' via the inspector.
* Fixed issue of creating new SubScene using the full level template instead of a blank level file
* Fixed subScene inspector field handling so clicking the create new will mark the 'in place' created level asset as a subscene appropriately
* Changed up persistenceManager logic when parsing objects out - especially with specialty fields - to use Strings instead of const char* to simplify memory juggling and improve stability
* Rolled back specialty array field outputs for decal roads and convex shapes to have the field names in the output again
* Added sanity check for MeshRoad's when writing out via specialty array field to ensure there are profile nodes before trying to write any
* Added sanity check to avoid pointlessly writing out meshroad and river position field into subScene file as it could cause a transform double-up and cause them to move when loading from a subscene