### PR TITLE
Linux Depenencies for OpenAL and SDL2

### DIFF
--- a/.github/workflows/build-linux-gcc.yml
+++ b/.github/workflows/build-linux-gcc.yml
@@ -61,6 +61,13 @@ jobs:
                     libx11-dev \
                     libxxf86vm-dev \
                     libopenal-dev \
+                    libasound2-dev \
+                    libpipewire-0.3-dev \
+                    portaudio19-dev \
+                    oss4-dev \
+                    libjack-dev \
+                    libpulse-dev \
+                    libdbus-1-dev \
                     libfreetype6-dev \
                     libxcursor-dev \
                     libxinerama-dev \


### PR DESCRIPTION
updates the list of depenencies, these are required by both sdl2 and openal in order to properly compile and produce audio.