### PR TITLE
adds a built in detail map generator

### DIFF
--- a/Engine/source/gfx/gfxTextureManager.h
+++ b/Engine/source/gfx/gfxTextureManager.h
@@ -193,6 +193,7 @@ public:
    /// Used to remove a cubemap from the cache.
    void releaseCubemap( GFXCubemap *cubemap );
 
+   void splitTerrainMaps(const Torque::Path& path);
 public:
    /// The amount of texture mipmaps to skip when loading a
    /// texture that allows downscaling.

--- a/Templates/BaseGame/game/core/utility/scripts/helperFunctions.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/helperFunctions.tscript
@@ -783,3 +783,14 @@ function getNumCanCallOnObjectList(%functionName, %objectsList)
    
    return %numberWithFunction;
 }
+
+function getImageFileName(%id)
+{
+    %assetDef = AssetDatabase.acquireAsset(%id);
+    return %assetDef.getImagePath();
+}
+
+function makeTerrainMapsFrom(%id)
+{
+    splitTerrainMaps(getImageFileName(%id));
+}


### PR DESCRIPTION
use `splitTerrainMaps("data/some/file");` or `makeTerrainMapsFrom("module:anAsset");` to take a detailed albedo map and split it into a _bas(is) file that's an average of the input, and a _det(ail) file to raise and lower different channels from that average. 
special note: while used primarily for terrain authoring, these files could also be plugged into a normal material