### PR TITLE
clean up subscene load evaluators so that it doesn't require a client if it's set to global

### DIFF
--- a/Engine/source/T3D/Scene.cpp
+++ b/Engine/source/T3D/Scene.cpp
@@ -202,15 +202,12 @@ void Scene::processTick()
                controlObj = gc->getCameraObject();
             }
 
-            if (controlObj != nullptr)
-            {
-               if (mSubScenes[i]->testBox(controlObj->getWorldBox()))
+            if (mSubScenes[i]->testBox(controlObj != nullptr ? controlObj->getWorldBox() : Box3F::Zero))
                {
                   //we have a client controlling object in the bounds, so we ensure the contents are loaded
                   hasClients = true;
                   break;
                }
-            }
          }
       }
 


### PR DESCRIPTION
(allows spawnpoints to fill out prior to connections) also try and apply filtering prior to actual loading