### PR TITLE
update max probecount

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Cubemap.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Cubemap.cpp
@@ -453,6 +453,12 @@ void GFXD3D11CubemapArray::init(const U32 cubemapCount, const U32 cubemapFaceSiz
    desc.MiscFlags = miscFlags;
    desc.CPUAccessFlags = 0;
 
+   if (desc.ArraySize > D3D11_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION)
+   {
+      AssertFatal(false, avar("CubemapArray size exceeds maximum array size of %d", D3D11_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION));
+      return;
+   }
+
    HRESULT hr = D3D11DEVICE->CreateTexture2D(&desc, NULL, &mTexture);
 
    if (FAILED(hr))

--- a/Engine/source/renderInstance/renderProbeMgr.h
+++ b/Engine/source/renderInstance/renderProbeMgr.h
@@ -171,11 +171,11 @@ class RenderProbeMgr : public RenderBinManager
 
 public:
    //maximum number of allowed probes
-   static const U32 PROBE_MAX_COUNT = 250;
+   static const U32 PROBE_MAX_COUNT = 340;
    //maximum number of rendered probes per frame adjust as needed
    static const U32 PROBE_MAX_FRAME = 8;
    //number of slots to allocate at once in the cubemap array
-   static const U32 PROBE_ARRAY_SLOT_BUFFER_SIZE = 10;
+   static const U32 PROBE_ARRAY_SLOT_BUFFER_SIZE = 5;
 
    //These dictate the default resolution size for the probe arrays
    static const GFXFormat PROBE_FORMAT = GFXFormatR16G16B16A16F;// GFXFormatR8G8B8A8;// when hdr fixed GFXFormatR16G16B16A16F; look into bc6h compression


### PR DESCRIPTION
dx11 has a 2048/6 cap on how many cubemaps can fit in a given array. bump the probe count up to just under that to buy folks head room while we work on revising a more robust solution