### PR TITLE
Path class augs

### DIFF
--- a/Engine/source/scene/simPath.h
+++ b/Engine/source/scene/simPath.h
@@ -76,12 +76,14 @@ class Path : public GameBase
    ~Path();
 
    void addObject(SimObject*) override;
+   void onPostAdd() override;
    void removeObject(SimObject*) override;
 
    void sortMarkers();
    void updatePath();
    bool isLooping() { return mIsLooping; }
    U32 getPathIndex() const;
+   void setTransform(const MatrixF& mat) override;
 
    DECLARE_CONOBJECT(Path);
    DECLARE_CATEGORY("Cinematic");


### PR DESCRIPTION
adds the following behaviours: onPostAdd, send an updatePath event so that paths created post-pathOnMissionLoadDone command can register with clients (like say when they are loaded from a submis) for editing tool purposes, allow Path::SetTransform to impact child objects so that pre-existing ones can be copy/pasted without the markers ending up in the same spot, or so that you can shift the entire path around and have those move in a relative manner