### PR TITLE
setFirstResonder Safeties

### DIFF
--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -2169,7 +2169,7 @@ void GuiCanvas::setFirstResponder( GuiControl* newResponder )
    if( oldResponder && ( oldResponder != newResponder ) )
       oldResponder->onLoseFirstResponder();
       
-   if( newResponder && ( newResponder != oldResponder ) )
+   if( newResponder && ( newResponder != oldResponder ) && newResponder->isProperlyAdded())
       newResponder->onGainFirstResponder();
 }
 

--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -2230,10 +2230,10 @@ void GuiControl::setFirstResponder( GuiControl* firstResponder )
 
 void GuiControl::setFirstResponder()
 {
-	if( mAwake && mVisible )
+	if( mAwake && mVisible && isProperlyAdded())
 	{
 	   GuiControl *parent = getParent();
-	   if ( mProfile->mCanKeyFocus == true && parent != NULL )
+	   if ( mProfile->mCanKeyFocus == true && parent && parent->isProperlyAdded())
          parent->setFirstResponder( this );
 	}
 }

--- a/Engine/source/gui/core/guiControl.h
+++ b/Engine/source/gui/core/guiControl.h
@@ -741,7 +741,7 @@ class GuiControl : public SimGroup
       GuiControl *getFirstResponder() { return mFirstResponder; }
       
       /// Occurs when the control gains first-responder status.
-      virtual void onGainFirstResponder();
+      void onGainFirstResponder();
       
       /// Occurs when the control loses first-responder status.
       virtual void onLoseFirstResponder();

--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -233,7 +233,7 @@ void GuiInspectorField::setFirstResponder( GuiControl *firstResponder )
 {
    Parent::setFirstResponder( firstResponder );
 
-   if ( firstResponder == this || firstResponder == mEdit )
+   if (( firstResponder == this || firstResponder == mEdit ) && firstResponder->isProperlyAdded())
    {
       mInspector->setHighlightField( this );      
    }   
@@ -851,7 +851,8 @@ void GuiInspectorField::setHLEnabled( bool enabled )
             edit->setCursorPos(0);
          }
       }
-      _executeSelectedCallback();
+      if (isProperlyAdded())
+         _executeSelectedCallback();
    }
 }
 


### PR DESCRIPTION
make sure we've properly added gui elements before trying to set the to be the responding one, or running callbacks against them