### PR TITLE
game mode filterfix

### DIFF
--- a/Engine/source/T3D/SubScene.cpp
+++ b/Engine/source/T3D/SubScene.cpp
@@ -348,7 +348,7 @@ void SubScene::load()
       return;
 
    GameMode::findGameModes(mGameModesNames, &mGameModesList);
-   if ((String(mGameModesNames).isNotEmpty() && mGameModesList.size() == 0) || !evaluateCondition())
+   if (!isSelected() && (String(mGameModesNames).isNotEmpty() && mGameModesList.size() == 0) || !evaluateCondition())
    {
       mLoaded = false;
       return;

--- a/Engine/source/T3D/gameMode.cpp
+++ b/Engine/source/T3D/gameMode.cpp
@@ -101,7 +101,8 @@ void GameMode::findGameModes(const char* gameModeList, Vector<GameMode*> *outGam
       GameMode* gm;
       if (Sim::findObject(gameModeNames[i].c_str(), gm))
       {
-         outGameModes->push_back(gm);
+         if (gm->isActive() || gm->isAlwaysActive())
+            outGameModes->push_back(gm);
       }
    }
 }


### PR DESCRIPTION
GameMode::findGameModes now only returns the *active* ones. 
SubScene::load() checks against either that, or if it's selected