### PR TITLE
rigidshape pef tweaks

### DIFF
--- a/Engine/source/T3D/rigid.cpp
+++ b/Engine/source/T3D/rigid.cpp
@@ -363,4 +363,6 @@ void Rigid::setAtRest()
    linMomentum.set(0.0f,0.0f,0.0f);
    angVelocity.set(0.0f,0.0f,0.0f);
    angMomentum.set(0.0f,0.0f,0.0f);
+   force.set(0.0f, 0.0f, 0.0f);
+   torque.set(0.0f, 0.0f, 0.0f);
 }

--- a/Engine/source/T3D/rigidShape.cpp
+++ b/Engine/source/T3D/rigidShape.cpp
@@ -1117,7 +1117,7 @@ void RigidShape::updatePos(F32 dt)
       if (mCollisionList.getCount())
       {
          F32 k = mRigid.getKineticEnergy();
-         F32 G = mNetGravity* dt * mDataBlock->integration;
+         F32 G = mNetGravity* dt * TickMs / mDataBlock->integration;
          F32 Kg = 0.5 * mRigid.mass * G * G;
          if (k < sRestTol * Kg && ++restCount > sRestCount)
             mRigid.setAtRest();

--- a/Engine/source/T3D/rigidShape.cpp
+++ b/Engine/source/T3D/rigidShape.cpp
@@ -1648,6 +1648,7 @@ void RigidShape::unpackUpdate(NetConnection *con, BitStream *stream)
          mDelta.warpCount = mDelta.warpTicks = 0;
          setPosition(mRigid.linPosition, mRigid.angPosition);
       }
+      mRigid.updateCenterOfMass();
    }
    
    if(stream->readFlag())

--- a/Engine/source/T3D/vehicles/vehicle.cpp
+++ b/Engine/source/T3D/vehicles/vehicle.cpp
@@ -807,7 +807,7 @@ void Vehicle::updatePos(F32 dt)
       if (mCollisionList.getCount()) 
       {
          F32 k = mRigid.getKineticEnergy();
-         F32 G = mNetGravity* dt * mDataBlock->integration;
+         F32 G = mNetGravity* dt * TickMs / mDataBlock->integration;
          F32 Kg = 0.5 * mRigid.mass * G * G;
          if (k < sRestTol * Kg && ++restCount > sRestCount)
             mRigid.setAtRest();

--- a/Engine/source/T3D/vehicles/wheeledVehicle.h
+++ b/Engine/source/T3D/vehicles/wheeledVehicle.h
@@ -141,6 +141,7 @@ struct WheeledVehicleData: public VehicleData
    ClippedPolyList rigidBody;    // Extracted from shape
    S32 brakeLightSequence;       // Brakes
    S32 steeringSequence;         // Steering animation
+   F32 mDownForce;
 
    //
    WheeledVehicleData();


### PR DESCRIPTION
1) account for integration for atrest evaluation.
2) if we're atrest, *don't* network momentums. just send the bool
3) clean up a bunch of redundant networking that slipped in when compressing ridigshape and vehicle
4) while we're in here, add a modified variant of the old downforce resource to assist with driving