### PR TITLE
Enables onMouseMove method for scripting on the GameTSCtrl class.

### DIFF
--- a/Engine/source/T3D/gameTSCtrl.cpp
+++ b/Engine/source/T3D/gameTSCtrl.cpp
@@ -158,6 +158,8 @@ void GameTSCtrl::onMouseMove(const GuiEvent &evt)
          lineTestEnd = pos + vec * 1000;
       }
    }
+   if (isMethod("onMouseMove"))
+      makeScriptCall("onMouseMove", evt);
 }
 
 void GameTSCtrl::onRender(Point2I offset, const RectI &updateRect)


### PR DESCRIPTION
Enables the onMouseMove method to be used in scripting for the GameTSCtrl class.