### PR TITLE
conform and correct gridsize

### DIFF
--- a/Engine/source/environment/waterBlock.cpp
+++ b/Engine/source/environment/waterBlock.cpp
@@ -531,10 +531,10 @@ void WaterBlock::initPersistFields()
    docsURL;
    addGroup( "WaterBlock" );
 
-   addProtectedFieldV("gridSize", TypeRangedF32, Offset(mGridElementSize, WaterBlock), &setGridSizeProperty, &defaultProtectedGetFn, &CommonValidators::PositiveNonZeroFloat,
+   addProtectedFieldV("gridSize", TypeRangedS32, Offset(mGridElementSize, WaterBlock), &setGridSizeProperty, &defaultProtectedGetFn, &CommonValidators::NaturalNumber,
       "Spacing between vertices in the WaterBlock mesh");
 
-   addProtectedFieldV("gridElementSize", TypeRangedF32, Offset(mGridElementSize, WaterBlock), &setGridSizeProperty, &defaultProtectedGetFn, &CommonValidators::PositiveNonZeroFloat,
+   addProtectedFieldV("gridElementSize", TypeRangedS32, Offset(mGridElementSize, WaterBlock), &setGridSizeProperty, &defaultProtectedGetFn, &CommonValidators::NaturalNumber,
       "Duplicate of gridElementSize for backwards compatility");
 
    Parent::initPersistFields();

--- a/Engine/source/environment/waterBlock.h
+++ b/Engine/source/environment/waterBlock.h
@@ -82,7 +82,7 @@ private:
    GFXPrimitiveBufferHandle mRadialPrimBuff;
 
    // misc
-   F32            mGridElementSize;
+   U32            mGridElementSize;
    U32            mWidth;
    U32            mHeight;
    F32            mElapsedTime;   

--- a/Engine/source/environment/waterPlane.cpp
+++ b/Engine/source/environment/waterPlane.cpp
@@ -122,10 +122,10 @@ void WaterPlane::initPersistFields()
    docsURL;
    addGroup( "WaterPlane" );     
 
-      addProtectedFieldV( "gridSize", TypeRangedF32, Offset( mGridSize, WaterPlane ), &protectedSetGridSize, &defaultProtectedGetFn, &CommonValidators::PositiveNonZeroFloat,
+      addProtectedFieldV( "gridSize", TypeRangedS32, Offset( mGridSize, WaterPlane ), &protectedSetGridSize, &defaultProtectedGetFn, &CommonValidators::NaturalNumber,
 		  "Spacing between vertices in the WaterBlock mesh" );
 
-      addProtectedFieldV( "gridElementSize", TypeRangedF32, Offset( mGridElementSize, WaterPlane ), &protectedSetGridElementSize, &defaultProtectedGetFn, &CommonValidators::PositiveNonZeroFloat,
+      addProtectedFieldV( "gridElementSize", TypeRangedS32, Offset( mGridElementSize, WaterPlane ), &protectedSetGridElementSize, &defaultProtectedGetFn, &CommonValidators::NaturalNumber,
 		  "Duplicate of gridElementSize for backwards compatility");
 
    endGroup( "WaterPlane" );


### PR DESCRIPTION
waterblock and waterplane were using two entirely different var types. by usage, those should be natural numbers