### PR TITLE
fix forward cubemip

### DIFF
--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -1324,7 +1324,7 @@ void ProcessedShaderMaterial::setSceneInfo(SceneRenderState * state, const Scene
    if (sgData.cubemap)
       shaderConsts->setSafe(handles->mCubeMipsSC, (F32)sgData.cubemap->getMipMapLevels());
    else
-      shaderConsts->setSafe(handles->mCubeMipsSC, 1.0f);
+      shaderConsts->setSafe(handles->mCubeMipsSC, (F32)getBinLog2(PROBEMGR->getProbeTexSize()));
 
    shaderConsts->setSafe(handles->mVisiblitySC, sgData.visibility);
 


### PR DESCRIPTION
in case of temporary loss of the probe array, fall back to a (slightly) less arbitrary probemanager mip level as oposed to assuming 1 mip exists