### PR TITLE
Parse Property Templated function

### DIFF
--- a/Engine/source/console/propertyParsing.h
+++ b/Engine/source/console/propertyParsing.h
@@ -168,12 +168,12 @@ namespace PropertyInfo
    {
       static const U32 bufSize = 256;
       char* buffer = Con::getReturnBuffer(bufSize);
-      FormatProperty<T,count>(dataPtr, buffer, bufSize);
+      FormatPropertyBuffer<T,count>(dataPtr, buffer, bufSize);
       return buffer;
    }
 
    template<typename T, size_t count>
-   char* FormatProperty(const void* dataPtr, char* buffer, U32 bufSize)
+   char* FormatPropertyBuffer(const void* dataPtr, char* buffer, U32 bufSize)
    {
       const T* values = reinterpret_cast<const T*>(dataPtr);
       char* ptr = buffer;

--- a/Engine/source/console/propertyParsing.h
+++ b/Engine/source/console/propertyParsing.h
@@ -164,15 +164,6 @@ namespace PropertyInfo
    bool default_print(String & result, SimObjectType * const & data);
 
    template<typename T, size_t count>
-   const char* FormatProperty(const void* dataPtr)
-   {
-      static const U32 bufSize = 256;
-      char* buffer = Con::getReturnBuffer(bufSize);
-      FormatPropertyBuffer<T,count>(dataPtr, buffer, bufSize);
-      return buffer;
-   }
-
-   template<typename T, size_t count>
    char* FormatPropertyBuffer(const void* dataPtr, char* buffer, U32 bufSize)
    {
       const T* values = reinterpret_cast<const T*>(dataPtr);
@@ -196,6 +187,15 @@ namespace PropertyInfo
 
       *ptr = '\0';
       return ptr; // return end of written string for chaining
+   }
+
+   template<typename T, size_t count>
+   const char* FormatProperty(const void* dataPtr)
+   {
+      static const U32 bufSize = 256;
+      char* buffer = Con::getReturnBuffer(bufSize);
+      FormatPropertyBuffer<T,count>(dataPtr, buffer, bufSize);
+      return buffer;
    }
 
    template<typename T, size_t count>

--- a/Engine/source/console/propertyParsing.h
+++ b/Engine/source/console/propertyParsing.h
@@ -164,6 +164,41 @@ namespace PropertyInfo
    bool default_print(String & result, SimObjectType * const & data);
 
    template<typename T, size_t count>
+   const char* FormatProperty(const void* dataPtr)
+   {
+      static const U32 bufSize = 256;
+      char* buffer = Con::getReturnBuffer(bufSize);
+      FormatProperty<T,count>(dataPtr, buffer, bufSize);
+      return buffer;
+   }
+
+   template<typename T, size_t count>
+   char* FormatProperty(const void* dataPtr, char* buffer, U32 bufSize)
+   {
+      const T* values = reinterpret_cast<const T*>(dataPtr);
+      char* ptr = buffer;
+
+      for (size_t i = 0; i < count; ++i)
+      {
+         S32 written = 0;
+
+         if constexpr (std::is_same_v<T, int> || std::is_same_v<T, S32>)
+            written = dSprintf(ptr, bufSize - (ptr - buffer), "%d", values[i]);
+         else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, F32>)
+            written = dSprintf(ptr, bufSize - (ptr - buffer), "%g", values[i]);
+         else
+            AssertFatal(sizeof(T) == 0, "Unsupported type in FormatProperty");
+
+         ptr += written;
+         if (i < count - 1)
+            *ptr++ = ' ';
+      }
+
+      *ptr = '\0';
+      return ptr; // return end of written string for chaining
+   }
+
+   template<typename T, size_t count>
    inline bool ParseProperty(char* str, T(&out)[count])
    {
 

--- a/Engine/source/console/propertyParsing.h
+++ b/Engine/source/console/propertyParsing.h
@@ -185,7 +185,6 @@ namespace PropertyInfo
             *ptr++ = ' ';
       }
 
-      *ptr = '\0';
       return ptr; // return end of written string for chaining
    }
 

--- a/Engine/source/console/propertyParsing.h
+++ b/Engine/source/console/propertyParsing.h
@@ -174,7 +174,7 @@ namespace PropertyInfo
       {
          if constexpr (std::is_same_v<T, int> || std::is_same_v<T, S32>)
          {
-            out[index++] = dAtoi(tok);
+            out[index++] = mRound(dAtof(tok));
          }
          else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, F32>)
          {

--- a/Engine/source/console/propertyParsing.h
+++ b/Engine/source/console/propertyParsing.h
@@ -162,6 +162,35 @@ namespace PropertyInfo
    bool hex_print(String & string, const S8 & hex);
 
    bool default_print(String & result, SimObjectType * const & data);
+
+   template<typename T, size_t count>
+   inline bool ParseProperty(char* str, T(&out)[count])
+   {
+
+      size_t index = 0;
+      char* tok = dStrtok(str, " \t");
+
+      while (tok && index < count)
+      {
+         if constexpr (std::is_same_v<T, int> || std::is_same_v<T, S32>)
+         {
+            out[index++] = dAtoi(tok);
+         }
+         else if constexpr (std::is_same_v<T, float> || std::is_same_v<T, F32>)
+         {
+            out[index++] = dAtof(tok);
+         }
+         else
+         {
+            AssertFatal(sizeof(T) == 0, "Unsupported type in PropertyInfo::ParseProperty");
+         }
+
+         tok = dStrtok(nullptr, " \t");
+      }
+
+      return index == count;
+   }
+
 }
 
 // Default Scan/print definition

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -399,12 +399,11 @@ ConsoleGetType( TypeMatrixF )
    static const U32 bufSize = 256;
    char* buffer = Con::getReturnBuffer(bufSize);
 
-   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(col0, buffer, bufSize);
+   PropertyInfo::FormatPropertyBuffer<F32, 3>(col0, buffer, bufSize);
    *buffer++ = ' ';
-   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(col1, buffer, bufSize);
+   PropertyInfo::FormatPropertyBuffer<F32, 3>(col1, buffer, bufSize);
    *buffer++ = ' ';
-   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(col2, buffer, bufSize);
-   *buffer = '\0'; // null-terminate just in case
+   PropertyInfo::FormatPropertyBuffer<F32, 3>(col2, buffer, bufSize);
 
    return buffer;
 }
@@ -444,9 +443,9 @@ ConsoleGetType( TypeMatrixPosition )
    Point4F pos(col[0], col[4], col[8], col[12]);
 
    if (col[12] == 1.0f)
-      returnBuffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(&pos, returnBuffer, bufSize);
+      PropertyInfo::FormatPropertyBuffer<F32, 3>(&pos, returnBuffer, bufSize);
    else
-      returnBuffer = PropertyInfo::FormatPropertyBuffer<F32, 4>(&pos, returnBuffer, bufSize);
+      PropertyInfo::FormatPropertyBuffer<F32, 4>(&pos, returnBuffer, bufSize);
 
    return returnBuffer;
 }
@@ -644,9 +643,9 @@ ConsoleGetType( TypeEaseF )
    char* buffer = Con::getReturnBuffer(bufSize);
 
    EaseF* pEase = (EaseF*)dptr;
-   buffer = PropertyInfo::FormatPropertyBuffer<S32, 2>(pEase + 0, buffer, bufSize);
+   PropertyInfo::FormatPropertyBuffer<S32, 2>(pEase + 0, buffer, bufSize);
    *buffer++ = ' ';
-   buffer = PropertyInfo::FormatPropertyBuffer<F32, 2>(pEase + 2, buffer, bufSize);
+   PropertyInfo::FormatPropertyBuffer<F32, 2>(pEase + 2, buffer, bufSize);
    *buffer = '\0'; // null-terminate just in case
 
    return buffer;
@@ -691,12 +690,12 @@ ConsoleGetType(TypeRotationF)
    if (pt->mRotationType == RotationF::Euler)
    {
       EulerF out = pt->asEulerF(RotationF::Degrees);
-      returnBuffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(out, returnBuffer, bufSize);
+      PropertyInfo::FormatPropertyBuffer<F32, 3>(out, returnBuffer, bufSize);
    }
    else if (pt->mRotationType == RotationF::AxisAngle)
    {
       AngAxisF out = pt->asAxisAngle(RotationF::Degrees);
-      returnBuffer = PropertyInfo::FormatPropertyBuffer<F32, 4>(&out, returnBuffer, bufSize);
+      PropertyInfo::FormatPropertyBuffer<F32, 4>(&out, returnBuffer, bufSize);
    }
    *returnBuffer = '\0'; // null-terminate just in case
 

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -170,11 +170,8 @@ ImplementConsoleTypeCasters( TypePoint2I, Point2I )
 
 ConsoleGetType( TypePoint2I )
 {
-   Point2I *pt = (Point2I *) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%d %d", pt->x, pt->y);
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<S32, 2>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypePoint2I )
@@ -204,11 +201,8 @@ ImplementConsoleTypeCasters( TypePoint2F, Point2F )
 
 ConsoleGetType( TypePoint2F )
 {
-   Point2F *pt = (Point2F *) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%g %g", pt->x, pt->y);
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<F32, 2>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypePoint2F )
@@ -238,11 +232,8 @@ ImplementConsoleTypeCasters(TypePoint3I, Point3I)
 
 ConsoleGetType( TypePoint3I )
 {
-   Point3I *pt = (Point3I *) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%d %d %d", pt->x, pt->y, pt->z);
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<S32, 3>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypePoint3I )
@@ -272,11 +263,8 @@ ImplementConsoleTypeCasters(TypePoint3F, Point3F)
 
 ConsoleGetType( TypePoint3F )
 {
-   Point3F *pt = (Point3F *) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%g %g %g", pt->x, pt->y, pt->z);
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<F32, 3>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypePoint3F )
@@ -306,11 +294,8 @@ ImplementConsoleTypeCasters( TypePoint4F, Point4F )
 
 ConsoleGetType( TypePoint4F )
 {
-   Point4F *pt = (Point4F *) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%g %g %g %g", pt->x, pt->y, pt->z, pt->w);
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<F32, 4>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypePoint4F )
@@ -340,12 +325,8 @@ ImplementConsoleTypeCasters( TypeRectI, RectI )
 
 ConsoleGetType( TypeRectI )
 {
-   RectI *rect = (RectI *) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%d %d %d %d", rect->point.x, rect->point.y,
-            rect->extent.x, rect->extent.y);
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<S32, 4>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypeRectI )
@@ -375,12 +356,8 @@ ImplementConsoleTypeCasters( TypeRectF, RectF )
 
 ConsoleGetType( TypeRectF )
 {
-   RectF *rect = (RectF *) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%g %g %g %g", rect->point.x, rect->point.y,
-            rect->extent.x, rect->extent.y);
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<F32, 4>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypeRectF )
@@ -413,17 +390,18 @@ ImplementConsoleTypeCasters( TypeMatrixF, MatrixF )
 
 ConsoleGetType( TypeMatrixF )
 {
-   MatrixF* mat = ( MatrixF* ) dptr;
-
-   Point3F col0, col1, col2;
-   mat->getColumn(0, &col0);
-   mat->getColumn(1, &col1);
-   mat->getColumn(2, &col2);
    static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer,bufSize,"%g %g %g %g %g %g %g %g %g",
-            col0.x, col0.y, col0.z, col1.x, col1.y, col1.z, col2.x, col2.y, col2.z);
-   return returnBuffer;
+   char* buffer = Con::getReturnBuffer(bufSize);
+
+   F32* mat = (F32*)dptr;
+   buffer = PropertyInfo::FormatProperty<F32, 3>(mat + 0, buffer, bufSize);
+   *buffer++ = ' ';
+   buffer = PropertyInfo::FormatProperty<F32, 3>(mat + 4, buffer, bufSize);
+   *buffer++ = ' ';
+   buffer = PropertyInfo::FormatProperty<F32, 3>(mat + 8, buffer, bufSize);
+   *buffer = '\0'; // null-terminate just in case
+
+   return buffer;
 }
 
 ConsoleSetType( TypeMatrixF )
@@ -455,14 +433,9 @@ ConsoleMappedType(MatrixPosition, TypeMatrixPosition, Point3F, MatrixF, "")
 
 ConsoleGetType( TypeMatrixPosition )
 {
-   F32 *col = (F32 *) dptr + 3;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   if(col[12] == 1.f)
-      dSprintf(returnBuffer, bufSize, "%g %g %g", col[0], col[4], col[8]);
-   else
-      dSprintf(returnBuffer, bufSize, "%g %g %g %g", col[0], col[4], col[8], col[12]);
-   return returnBuffer;
+   F32* mat = (F32*)dptr;
+   const char* buff = PropertyInfo::FormatProperty<F32, 4>(mat + 8);
+   return buff;
 }
 
 ConsoleSetType( TypeMatrixPosition )
@@ -495,12 +468,11 @@ ConsoleMappedType(MatrixRotation, TypeMatrixRotation, AngAxisF, MatrixF, "")
 
 ConsoleGetType( TypeMatrixRotation )
 {
-   AngAxisF aa(*(MatrixF *) dptr);
+   AngAxisF aa(*(MatrixF*)dptr);
    aa.axis.normalize();
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer,bufSize,"%g %g %g %g",aa.axis.x,aa.axis.y,aa.axis.z,mRadToDeg(aa.angle));
-   return returnBuffer;
+   aa.angle = mRadToDeg(aa.angle);
+   const char* buff = PropertyInfo::FormatProperty<F32, 4>(&aa);
+   return buff;
 }
 
 ConsoleSetType( TypeMatrixRotation )
@@ -539,10 +511,9 @@ ImplementConsoleTypeCasters( TypeAngAxisF, AngAxisF )
 ConsoleGetType( TypeAngAxisF )
 {
    AngAxisF* aa = ( AngAxisF* ) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer,bufSize,"%g %g %g %g",aa->axis.x,aa->axis.y,aa->axis.z,mRadToDeg(aa->angle));
-   return returnBuffer;
+   aa->angle = mRadToDeg(aa->angle);
+   const char* buff = PropertyInfo::FormatProperty<F32, 4>(aa);
+   return buff;
 }
 
 ConsoleSetType( TypeAngAxisF )
@@ -577,13 +548,8 @@ ImplementConsoleTypeCasters( TypeTransformF, TransformF )
 
 ConsoleGetType( TypeTransformF )
 {
-   TransformF* aa = ( TransformF* ) dptr;
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf( returnBuffer, bufSize, "%g %g %g %g %g %g %g",
-             aa->mPosition.x, aa->mPosition.y, aa->mPosition.z,
-             aa->mOrientation.axis.x, aa->mOrientation.axis.y, aa->mOrientation.axis.z, aa->mOrientation.angle );
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<F32, 7>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypeTransformF )
@@ -623,15 +589,8 @@ ImplementConsoleTypeCasters( TypeBox3F, Box3F )
 
 ConsoleGetType( TypeBox3F )
 {
-   const Box3F* pBox = (const Box3F*)dptr;
-
-   static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%g %g %g %g %g %g",
-            pBox->minExtents.x, pBox->minExtents.y, pBox->minExtents.z,
-            pBox->maxExtents.x, pBox->maxExtents.y, pBox->maxExtents.z);
-
-   return returnBuffer;
+   const char* buff = PropertyInfo::FormatProperty<F32, 6>(dptr);
+   return buff;
 }
 
 ConsoleSetType( TypeBox3F )
@@ -668,14 +627,16 @@ ImplementConsoleTypeCasters( TypeEaseF, EaseF )
 
 ConsoleGetType( TypeEaseF )
 {
-   const EaseF* pEase = (const EaseF*)dptr;
-
    static const U32 bufSize = 256;
-   char* returnBuffer = Con::getReturnBuffer(bufSize);
-   dSprintf(returnBuffer, bufSize, "%d %d %g %g",
-            pEase->mDir, pEase->mType, pEase->mParam[0], pEase->mParam[1]);
+   char* buffer = Con::getReturnBuffer(bufSize);
 
-   return returnBuffer;
+   EaseF* pEase = (EaseF*)dptr;
+   buffer = PropertyInfo::FormatProperty<S32, 2>(pEase + 0, buffer, bufSize);
+   *buffer++ = ' ';
+   buffer = PropertyInfo::FormatProperty<F32, 2>(pEase + 2, buffer, bufSize);
+   *buffer = '\0'; // null-terminate just in case
+
+   return buffer;
 }
 
 ConsoleSetType( TypeEaseF )
@@ -717,13 +678,14 @@ ConsoleGetType(TypeRotationF)
    if (pt->mRotationType == RotationF::Euler)
    {
       EulerF out = pt->asEulerF(RotationF::Degrees);
-      dSprintf(returnBuffer, bufSize, "%g %g %g", out.x, out.y, out.z);
+      returnBuffer = PropertyInfo::FormatProperty<F32, 3>(out, returnBuffer, bufSize);
    }
    else if (pt->mRotationType == RotationF::AxisAngle)
    {
       AngAxisF out = pt->asAxisAngle(RotationF::Degrees);
-      dSprintf(returnBuffer, bufSize, "%g %g %g %g", out.axis.x, out.axis.y, out.axis.z, out.angle);
+      returnBuffer = PropertyInfo::FormatProperty<F32, 4>(&out, returnBuffer, bufSize);
    }
+   *returnBuffer = '\0'; // null-terminate just in case
 
    return returnBuffer;
 }

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -394,11 +394,11 @@ ConsoleGetType( TypeMatrixF )
    char* buffer = Con::getReturnBuffer(bufSize);
 
    F32* mat = (F32*)dptr;
-   buffer = PropertyInfo::FormatProperty<F32, 3>(mat + 0, buffer, bufSize);
+   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(mat + 0, buffer, bufSize);
    *buffer++ = ' ';
-   buffer = PropertyInfo::FormatProperty<F32, 3>(mat + 4, buffer, bufSize);
+   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(mat + 4, buffer, bufSize);
    *buffer++ = ' ';
-   buffer = PropertyInfo::FormatProperty<F32, 3>(mat + 8, buffer, bufSize);
+   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(mat + 8, buffer, bufSize);
    *buffer = '\0'; // null-terminate just in case
 
    return buffer;
@@ -631,9 +631,9 @@ ConsoleGetType( TypeEaseF )
    char* buffer = Con::getReturnBuffer(bufSize);
 
    EaseF* pEase = (EaseF*)dptr;
-   buffer = PropertyInfo::FormatProperty<S32, 2>(pEase + 0, buffer, bufSize);
+   buffer = PropertyInfo::FormatPropertyBuffer<S32, 2>(pEase + 0, buffer, bufSize);
    *buffer++ = ' ';
-   buffer = PropertyInfo::FormatProperty<F32, 2>(pEase + 2, buffer, bufSize);
+   buffer = PropertyInfo::FormatPropertyBuffer<F32, 2>(pEase + 2, buffer, bufSize);
    *buffer = '\0'; // null-terminate just in case
 
    return buffer;
@@ -678,12 +678,12 @@ ConsoleGetType(TypeRotationF)
    if (pt->mRotationType == RotationF::Euler)
    {
       EulerF out = pt->asEulerF(RotationF::Degrees);
-      returnBuffer = PropertyInfo::FormatProperty<F32, 3>(out, returnBuffer, bufSize);
+      returnBuffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(out, returnBuffer, bufSize);
    }
    else if (pt->mRotationType == RotationF::AxisAngle)
    {
       AngAxisF out = pt->asAxisAngle(RotationF::Degrees);
-      returnBuffer = PropertyInfo::FormatProperty<F32, 4>(&out, returnBuffer, bufSize);
+      returnBuffer = PropertyInfo::FormatPropertyBuffer<F32, 4>(&out, returnBuffer, bufSize);
    }
    *returnBuffer = '\0'; // null-terminate just in case
 

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -24,6 +24,7 @@
 #include "console/consoleTypes.h"
 #include "console/console.h"
 #include "console/engineAPI.h"
+#include "console/propertyParsing.h"
 #include "math/mPoint2.h"
 #include "math/mPoint3.h"
 #include "math/mMatrix.h"
@@ -178,12 +179,20 @@ ConsoleGetType( TypePoint2I )
 
 ConsoleSetType( TypePoint2I )
 {
-   if(argc == 1)
-      dSscanf(argv[0], "%d %d", &((Point2I *) dptr)->x, &((Point2I *) dptr)->y);
-   else if(argc == 2)
-      *((Point2I *) dptr) = Point2I(dAtoi(argv[0]), dAtoi(argv[1]));
-   else
-      Con::printf("Point2I must be set as { x, y } or \"x y\"");
+   if (argc >= 1) {
+      S32 parsed[2];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      if (PropertyInfo::ParseProperty<S32, 2>(buffer, parsed)) {
+         *((Point2I*)dptr) = Point2I(parsed[0], parsed[1]);
+         return;
+      }
+   }
+
+   Con::printf("Point2I must be set as { x, y } or \"x y\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -203,12 +212,20 @@ ConsoleGetType( TypePoint2F )
 
 ConsoleSetType( TypePoint2F )
 {
-   if(argc == 1)
-      dSscanf(argv[0], "%g %g", &((Point2F *) dptr)->x, &((Point2F *) dptr)->y);
-   else if(argc == 2)
-      *((Point2F *) dptr) = Point2F(dAtof(argv[0]), dAtof(argv[1]));
-   else
-      Con::printf("Point2F must be set as { x, y } or \"x y\"");
+   if (argc >= 1) {
+      F32 parsed[2];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      if (PropertyInfo::ParseProperty<F32, 2>(buffer, parsed)) {
+         *((Point2F*)dptr) = Point2F(parsed[0], parsed[1]);
+         return;
+      }
+   }
+
+   Con::printf("Point2F must be set as { x, y } or \"x y\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -228,12 +245,20 @@ ConsoleGetType( TypePoint3I )
 
 ConsoleSetType( TypePoint3I )
 {
-   if(argc == 1)
-      dSscanf(argv[0], "%d %d %d", &((Point3I *) dptr)->x, &((Point3I *) dptr)->y, &((Point3I *) dptr)->z);
-   else if(argc == 3)
-      *((Point3I *) dptr) = Point3I(dAtoi(argv[0]), dAtoi(argv[1]), dAtoi(argv[2]));
-   else
-      Con::printf("Point3I must be set as { x, y, z } or \"x y z\"");
+   if (argc >= 1) {
+      S32 parsed[3];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      if (PropertyInfo::ParseProperty<S32, 3>(buffer, parsed)) {
+         *((Point3I*)dptr) = Point3I(parsed[0], parsed[1], parsed[2]);
+         return;
+      }
+   }
+
+   Con::printf("Point3I must be set as { x, y, z } or \"x y z\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -253,12 +278,20 @@ ConsoleGetType( TypePoint3F )
 
 ConsoleSetType( TypePoint3F )
 {
-   if(argc == 1)
-      dSscanf(argv[0], "%g %g %g", &((Point3F *) dptr)->x, &((Point3F *) dptr)->y, &((Point3F *) dptr)->z);
-   else if(argc == 3)
-      *((Point3F *) dptr) = Point3F(dAtof(argv[0]), dAtof(argv[1]), dAtof(argv[2]));
-   else
-      Con::printf("Point3F must be set as { x, y, z } or \"x y z\"");
+   if (argc >= 1) {
+      F32 parsed[3];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      if (PropertyInfo::ParseProperty<F32, 3>(buffer, parsed)) {
+         *((Point3F*)dptr) = Point3F(parsed[0], parsed[1], parsed[2]);
+         return;
+      }
+   }
+
+   Con::printf("Point3F must be set as { x, y, z } or \"x y z\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -278,12 +311,20 @@ ConsoleGetType( TypePoint4F )
 
 ConsoleSetType( TypePoint4F )
 {
-   if(argc == 1)
-      dSscanf(argv[0], "%g %g %g %g", &((Point4F *) dptr)->x, &((Point4F *) dptr)->y, &((Point4F *) dptr)->z, &((Point4F *) dptr)->w);
-   else if(argc == 4)
-      *((Point4F *) dptr) = Point4F(dAtof(argv[0]), dAtof(argv[1]), dAtof(argv[2]), dAtof(argv[3]));
-   else
-      Con::printf("Point4F must be set as { x, y, z, w } or \"x y z w\"");
+   if (argc >= 1) {
+      F32 parsed[4];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      if (PropertyInfo::ParseProperty<F32, 4>(buffer, parsed)) {
+         *((Point4F*)dptr) = Point4F(parsed[0], parsed[1], parsed[2], parsed[3]);
+         return;
+      }
+   }
+
+   Con::printf("Point4F must be set as { x, y, z, w } or \"x y z w\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -304,13 +345,20 @@ ConsoleGetType( TypeRectI )
 
 ConsoleSetType( TypeRectI )
 {
-   if(argc == 1)
-      dSscanf(argv[0], "%d %d %d %d", &((RectI *) dptr)->point.x, &((RectI *) dptr)->point.y,
-              &((RectI *) dptr)->extent.x, &((RectI *) dptr)->extent.y);
-   else if(argc == 4)
-      *((RectI *) dptr) = RectI(dAtoi(argv[0]), dAtoi(argv[1]), dAtoi(argv[2]), dAtoi(argv[3]));
-   else
-      Con::printf("RectI must be set as { x, y, w, h } or \"x y w h\"");
+   if (argc >= 1) {
+      S32 parsed[4];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      if (PropertyInfo::ParseProperty<S32, 4>(buffer, parsed)) {
+         *((RectI*)dptr) = RectI(parsed[0], parsed[1], parsed[2], parsed[3]);
+         return;
+      }
+   }
+
+   Con::printf("RectI must be set as { x, y, w, h } or \"x y w h\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -331,13 +379,20 @@ ConsoleGetType( TypeRectF )
 
 ConsoleSetType( TypeRectF )
 {
-   if(argc == 1)
-      dSscanf(argv[0], "%g %g %g %g", &((RectF *) dptr)->point.x, &((RectF *) dptr)->point.y,
-              &((RectF *) dptr)->extent.x, &((RectF *) dptr)->extent.y);
-   else if(argc == 4)
-      *((RectF *) dptr) = RectF(dAtof(argv[0]), dAtof(argv[1]), dAtof(argv[2]), dAtof(argv[3]));
-   else
-      Con::printf("RectF must be set as { x, y, w, h } or \"x y w h\"");
+   if (argc >= 1) {
+      F32 parsed[4];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      if (PropertyInfo::ParseProperty<F32, 4>(buffer, parsed)) {
+         *((RectF*)dptr) = RectF(parsed[0], parsed[1], parsed[2], parsed[3]);
+         return;
+      }
+   }
+
+   Con::printf("RectF must be set as { x, y, w, h } or \"x y w h\"");
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -390,15 +390,20 @@ ImplementConsoleTypeCasters( TypeMatrixF, MatrixF )
 
 ConsoleGetType( TypeMatrixF )
 {
+   MatrixF* mat = (MatrixF*)dptr;
+
+   Point3F col0, col1, col2;
+   mat->getColumn(0, &col0);
+   mat->getColumn(1, &col1);
+   mat->getColumn(2, &col2);
    static const U32 bufSize = 256;
    char* buffer = Con::getReturnBuffer(bufSize);
 
-   F32* mat = (F32*)dptr;
-   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(mat + 0, buffer, bufSize);
+   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(col0, buffer, bufSize);
    *buffer++ = ' ';
-   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(mat + 4, buffer, bufSize);
+   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(col1, buffer, bufSize);
    *buffer++ = ' ';
-   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(mat + 8, buffer, bufSize);
+   buffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(col2, buffer, bufSize);
    *buffer = '\0'; // null-terminate just in case
 
    return buffer;
@@ -433,16 +438,24 @@ ConsoleMappedType(MatrixPosition, TypeMatrixPosition, Point3F, MatrixF, "")
 
 ConsoleGetType( TypeMatrixPosition )
 {
-   F32* mat = (F32*)dptr;
-   const char* buff = PropertyInfo::FormatProperty<F32, 4>(mat + 8);
-   return buff;
+   F32* col = (F32*)dptr + 3;
+   static const U32 bufSize = 256;
+   char* returnBuffer = Con::getReturnBuffer(bufSize);
+   Point4F pos(col[0], col[4], col[8], col[12]);
+
+   if (col[12] == 1.0f)
+      returnBuffer = PropertyInfo::FormatPropertyBuffer<F32, 3>(&pos, returnBuffer, bufSize);
+   else
+      returnBuffer = PropertyInfo::FormatPropertyBuffer<F32, 4>(&pos, returnBuffer, bufSize);
+
+   return returnBuffer;
 }
 
 ConsoleSetType( TypeMatrixPosition )
 {
    if (argc >= 1)
    {
-      F32 parsed[4] = { 1.0f }; // default all to 1.0f
+      F32 parsed[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
       // Combine argv into a single space-separated string if argc > 1
       char buffer[256] = { 0 };
       dStrncpy(buffer, *argv, sizeof(buffer));

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -646,7 +646,6 @@ ConsoleGetType( TypeEaseF )
    PropertyInfo::FormatPropertyBuffer<S32, 2>(pEase + 0, buffer, bufSize);
    *buffer++ = ' ';
    PropertyInfo::FormatPropertyBuffer<F32, 2>(pEase + 2, buffer, bufSize);
-   *buffer = '\0'; // null-terminate just in case
 
    return buffer;
 }

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -179,7 +179,8 @@ ConsoleGetType( TypePoint2I )
 
 ConsoleSetType( TypePoint2I )
 {
-   if (argc >= 1) {
+   if (argc >= 1)
+   {
       S32 parsed[2];
       // Combine argv into a single space-separated string if argc > 1
       char buffer[256] = { 0 };
@@ -192,7 +193,7 @@ ConsoleSetType( TypePoint2I )
       }
    }
 
-   Con::printf("Point2I must be set as { x, y } or \"x y\"");
+   Con::warnf("Point2I must be set as { x, y } or \"x y\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -212,7 +213,8 @@ ConsoleGetType( TypePoint2F )
 
 ConsoleSetType( TypePoint2F )
 {
-   if (argc >= 1) {
+   if (argc >= 1)
+   {
       F32 parsed[2];
       // Combine argv into a single space-separated string if argc > 1
       char buffer[256] = { 0 };
@@ -225,7 +227,7 @@ ConsoleSetType( TypePoint2F )
       }
    }
 
-   Con::printf("Point2F must be set as { x, y } or \"x y\"");
+   Con::warnf("Point2F must be set as { x, y } or \"x y\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -245,7 +247,8 @@ ConsoleGetType( TypePoint3I )
 
 ConsoleSetType( TypePoint3I )
 {
-   if (argc >= 1) {
+   if (argc >= 1)
+   {
       S32 parsed[3];
       // Combine argv into a single space-separated string if argc > 1
       char buffer[256] = { 0 };
@@ -258,7 +261,7 @@ ConsoleSetType( TypePoint3I )
       }
    }
 
-   Con::printf("Point3I must be set as { x, y, z } or \"x y z\"");
+   Con::warnf("Point3I must be set as { x, y, z } or \"x y z\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -278,7 +281,8 @@ ConsoleGetType( TypePoint3F )
 
 ConsoleSetType( TypePoint3F )
 {
-   if (argc >= 1) {
+   if (argc >= 1)
+   {
       F32 parsed[3];
       // Combine argv into a single space-separated string if argc > 1
       char buffer[256] = { 0 };
@@ -291,7 +295,7 @@ ConsoleSetType( TypePoint3F )
       }
    }
 
-   Con::printf("Point3F must be set as { x, y, z } or \"x y z\"");
+   Con::warnf("Point3F must be set as { x, y, z } or \"x y z\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -311,7 +315,8 @@ ConsoleGetType( TypePoint4F )
 
 ConsoleSetType( TypePoint4F )
 {
-   if (argc >= 1) {
+   if (argc >= 1)
+   {
       F32 parsed[4];
       // Combine argv into a single space-separated string if argc > 1
       char buffer[256] = { 0 };
@@ -324,7 +329,7 @@ ConsoleSetType( TypePoint4F )
       }
    }
 
-   Con::printf("Point4F must be set as { x, y, z, w } or \"x y z w\"");
+   Con::warnf("Point4F must be set as { x, y, z, w } or \"x y z w\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -345,7 +350,8 @@ ConsoleGetType( TypeRectI )
 
 ConsoleSetType( TypeRectI )
 {
-   if (argc >= 1) {
+   if (argc >= 1)
+   {
       S32 parsed[4];
       // Combine argv into a single space-separated string if argc > 1
       char buffer[256] = { 0 };
@@ -358,7 +364,7 @@ ConsoleSetType( TypeRectI )
       }
    }
 
-   Con::printf("RectI must be set as { x, y, w, h } or \"x y w h\"");
+   Con::warnf("RectI must be set as { x, y, w, h } or \"x y w h\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -379,7 +385,8 @@ ConsoleGetType( TypeRectF )
 
 ConsoleSetType( TypeRectF )
 {
-   if (argc >= 1) {
+   if (argc >= 1)
+   {
       F32 parsed[4];
       // Combine argv into a single space-separated string if argc > 1
       char buffer[256] = { 0 };
@@ -392,7 +399,7 @@ ConsoleSetType( TypeRectF )
       }
    }
 
-   Con::printf("RectF must be set as { x, y, w, h } or \"x y w h\"");
+   Con::warnf("RectF must be set as { x, y, w, h } or \"x y w h\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -421,21 +428,24 @@ ConsoleGetType( TypeMatrixF )
 
 ConsoleSetType( TypeMatrixF )
 {
-   if( argc != 1 )
+   if (argc == 1)
    {
-      Con::errorf( "MatrixF must be set as \"c0x c0y c0z c1x c1y c1z c2x c2y c2z\"" );
-      return;
-   }
-   
-   Point3F col0, col1, col2;
-   dSscanf( argv[ 0 ], "%g %g %g %g %g %g %g %g %g",
-            &col0.x, &col0.y, &col0.z, &col1.x, &col1.y, &col1.z, &col2.x, &col2.y, &col2.z );
+      F32 parsed[9];
 
-   MatrixF* mat = ( MatrixF* ) dptr;
-   
-   mat->setColumn( 0, col0 );
-   mat->setColumn( 1, col1 );
-   mat->setColumn( 2, col2 );
+      char* buffer = new char[dStrlen(argv[0])];
+      dStrcpy(buffer, argv[0], sizeof(buffer));
+
+      if (PropertyInfo::ParseProperty<F32, 9>(buffer, parsed)) {
+         MatrixF* mat = (MatrixF*)dptr;
+
+         mat->setColumn(0, Point3F(parsed[0], parsed[1], parsed[2]));
+         mat->setColumn(1, Point3F(parsed[3], parsed[4], parsed[5]));
+         mat->setColumn(2, Point3F(parsed[6], parsed[7], parsed[8]));
+         return;
+      }
+   }
+
+   Con::warnf("MatrixF must be set as \"c0x c0y c0z c1x c1y c1z c2x c2y c2z\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -457,20 +467,25 @@ ConsoleGetType( TypeMatrixPosition )
 
 ConsoleSetType( TypeMatrixPosition )
 {
-   F32 *col = ((F32 *) dptr) + 3;
-   if (argc == 1)
+   if (argc >= 1)
    {
-      col[0] = col[4] = col[8] = 0.f;
-      col[12] = 1.f;
-      dSscanf(argv[0], "%g %g %g %g", &col[0], &col[4], &col[8], &col[12]);
+      F32 parsed[4] = { 1.0f }; // default all to 1.0f
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+      dStrncpy(buffer, *argv, sizeof(buffer));
+      // we dont want to hard fail based on the count.
+      // this will allow any number of properties to be set.
+      PropertyInfo::ParseProperty<F32, 4>(buffer, parsed);
+      {
+         Point4F temp(parsed[0], parsed[1], parsed[2], parsed[3]);
+         MatrixF* mat = (MatrixF*)dptr;
+         mat->setColumn(3, temp);
+         return;
+      }
    }
-   else if (argc <= 4) 
-   {
-      for (S32 i = 0; i < argc; i++)
-         col[i << 2] = dAtof(argv[i]);
-   }
-   else
-      Con::printf("Matrix position must be set as { x, y, z, w } or \"x y z w\"");
+
+   Con::warnf("Matrix position must be set as { x, y, z, w } or \"x y z w\"");
+
 }
 
 //-----------------------------------------------------------------------------
@@ -490,32 +505,29 @@ ConsoleGetType( TypeMatrixRotation )
 
 ConsoleSetType( TypeMatrixRotation )
 {
-   // DMM: Note that this will ONLY SET the ULeft 3x3 submatrix.
-   //
-   AngAxisF aa(Point3F(0,0,0),0);
-   if (argc == 1)
+   if (argc >= 1)
    {
-      dSscanf(argv[0], "%g %g %g %g", &aa.axis.x, &aa.axis.y, &aa.axis.z, &aa.angle);
-      aa.angle = mDegToRad(aa.angle);
-   }
-   else if (argc == 4) 
-   {
-         for (S32 i = 0; i < argc; i++)
-            ((F32*)&aa)[i] = dAtof(argv[i]);
-         aa.angle = mDegToRad(aa.angle);
-   }
-   else
-      Con::printf("Matrix rotation must be set as { x, y, z, angle } or \"x y z angle\"");
+      F32 parsed[4];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+      dStrncpy(buffer, *argv, sizeof(buffer));
 
-   //
-   MatrixF temp;
-   aa.setMatrix(&temp);
+      if (PropertyInfo::ParseProperty<F32, 4>(buffer, parsed))
+      {
+         AngAxisF aa(Point3F(parsed[0], parsed[1], parsed[2]), mDegToRad(parsed[3]));
+         MatrixF temp;
+         aa.setMatrix(&temp);
 
-   F32* pDst = *(MatrixF *)dptr;
-   const F32* pSrc = temp;
-   for (U32 i = 0; i < 3; i++)
-      for (U32 j = 0; j < 3; j++)
-         pDst[i*4 + j] = pSrc[i*4 + j];
+         F32* pDst = *(MatrixF*)dptr;
+         const F32* pSrc = temp;
+         for (U32 i = 0; i < 3; i++)
+            for (U32 j = 0; j < 3; j++)
+               pDst[i * 4 + j] = pSrc[i * 4 + j];
+         return;
+      }
+   }
+
+   Con::warnf("Matrix rotation must be set as { x, y, z, angle } or \"x y z angle\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -535,22 +547,22 @@ ConsoleGetType( TypeAngAxisF )
 
 ConsoleSetType( TypeAngAxisF )
 {
-   // DMM: Note that this will ONLY SET the ULeft 3x3 submatrix.
-   //
-   AngAxisF* aa = ( AngAxisF* ) dptr;
-   if (argc == 1)
+   if (argc >= 1)
    {
-      dSscanf(argv[0], "%g %g %g %g", &aa->axis.x, &aa->axis.y, &aa->axis.z, &aa->angle);
-      aa->angle = mDegToRad(aa->angle);
+      F32 parsed[4];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      if(PropertyInfo::ParseProperty<F32, 4>(buffer, parsed))
+      {
+         AngAxisF* aa = (AngAxisF*)dptr;
+         aa->set(Point3F(parsed[0], parsed[1], parsed[2]), mDegToRad(parsed[3]));
+         return;
+      }
    }
-   else if (argc == 4) 
-   {
-      for (S32 i = 0; i < argc; i++)
-         ((F32*)&aa)[i] = dAtof(argv[i]);
-      aa->angle = mDegToRad(aa->angle);
-   }
-   else
-      Con::printf("AngAxisF must be set as { x, y, z, angle } or \"x y z angle\"");
+
+   Con::warnf("AngAxisF must be set as { x, y, z, angle } or \"x y z angle\"");
 }
 
 
@@ -576,27 +588,29 @@ ConsoleGetType( TypeTransformF )
 
 ConsoleSetType( TypeTransformF )
 {
-   TransformF* aa = ( TransformF* ) dptr;
-   if( argc == 1 )
+   if(argc >= 1)
    {
-      U32 count = dSscanf( argv[ 0 ], "%g %g %g %g %g %g %g",
-               &aa->mPosition.x, &aa->mPosition.y, &aa->mPosition.z,
-               &aa->mOrientation.axis.x, &aa->mOrientation.axis.y, &aa->mOrientation.axis.z, &aa->mOrientation.angle );
+      F32 parsed[7];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+      dStrncpy(buffer, *argv, sizeof(buffer));
 
-      aa->mHasRotation = ( count == 7 );
+      if (PropertyInfo::ParseProperty<F32, 7>(buffer, parsed))
+      {
+         TransformF* aa = (TransformF*)dptr;
+         aa->mPosition.x = parsed[0];
+         aa->mPosition.y = parsed[1];
+         aa->mPosition.z = parsed[2];
+         aa->mOrientation.axis.x = parsed[3];
+         aa->mOrientation.axis.y = parsed[4];
+         aa->mOrientation.axis.z = parsed[5];
+         aa->mOrientation.angle = parsed[6];
+         aa->mHasRotation = true;
+         return;
+      }
    }
-   else if( argc == 7 )
-   {
-      aa->mPosition.x = dAtof( argv[ 0 ] );
-      aa->mPosition.y = dAtof( argv[ 1 ] );
-      aa->mPosition.z = dAtof( argv[ 2 ] );
-      aa->mOrientation.axis.x = dAtof( argv[ 3 ] );
-      aa->mOrientation.axis.y = dAtof( argv[ 4 ] );
-      aa->mOrientation.axis.z = dAtof( argv[ 5 ] );
-      aa->mOrientation.angle = dAtof( argv[ 6 ] );
-   }
-   else
-      Con::errorf( "TransformF must be set as { px, py, pz, x, y, z, angle } or \"px py pz x y z angle\"");
+
+   Con::warnf("TransformF must be set as { px, py, pz, x, y, z, angle } or \"px py pz x y z angle\"");
 }
 
 

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -696,7 +696,6 @@ ConsoleGetType(TypeRotationF)
       AngAxisF out = pt->asAxisAngle(RotationF::Degrees);
       PropertyInfo::FormatPropertyBuffer<F32, 4>(&out, returnBuffer, bufSize);
    }
-   *returnBuffer = '\0'; // null-terminate just in case
 
    return returnBuffer;
 }

--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -636,19 +636,27 @@ ConsoleGetType( TypeBox3F )
 
 ConsoleSetType( TypeBox3F )
 {
-   Box3F* pDst = (Box3F*)dptr;
+   if (argc >= 1)
+   {
+      F32 parsed[6];
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+      dStrncpy(buffer, *argv, sizeof(buffer));
 
-   if (argc == 1) 
-   {
-      U32 args = dSscanf(argv[0], "%g %g %g %g %g %g",
-                         &pDst->minExtents.x, &pDst->minExtents.y, &pDst->minExtents.z,
-                         &pDst->maxExtents.x, &pDst->maxExtents.y, &pDst->maxExtents.z);
-      AssertWarn(args == 6, "Warning, box probably not read properly");
-   } 
-   else 
-   {
-      Con::printf("Box3F must be set as \"xMin yMin zMin xMax yMax zMax\"");
+      if (PropertyInfo::ParseProperty<F32, 6>(buffer, parsed))
+      {
+         Box3F* pDst = (Box3F*)dptr;
+         pDst->minExtents.x = parsed[0];
+         pDst->minExtents.y = parsed[1];
+         pDst->minExtents.z = parsed[2];
+         pDst->maxExtents.x = parsed[3];
+         pDst->maxExtents.y = parsed[4];
+         pDst->maxExtents.z = parsed[5];
+         return;
+      }
    }
+
+   Con::warnf("Box3F must be set as \"xMin yMin zMin xMax yMax zMax\"");
 }
 
 
@@ -672,19 +680,26 @@ ConsoleGetType( TypeEaseF )
 
 ConsoleSetType( TypeEaseF )
 {
-   EaseF* pDst = (EaseF*)dptr;
+   if (argc >= 1)
+   {
+      F32 parsed[4];
+      parsed[2] = -1.0f;
+      parsed[3] = -1.0f;
 
-   // defaults...
-   pDst->mParam[0] = -1.0f;
-   pDst->mParam[1] = -1.0f;
-   if (argc == 1) {
-      U32 args = dSscanf(argv[0], "%d %d %f %f", // the two params are optional and assumed -1 if not present...
-                         &pDst->mDir, &pDst->mType, &pDst->mParam[0],&pDst->mParam[1]);
-      if( args < 2 )
-         Con::warnf( "Warning, EaseF probably not read properly" );
-   } else {
-      Con::printf("EaseF must be set as \"dir type [param0 param1]\"");
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      // same as matrix do not hard fail based on count!
+      PropertyInfo::ParseProperty<F32, 4>(buffer, parsed);
+      {
+         ((EaseF*)dptr)->set(mRound(parsed[0]), mRound(parsed[1]), parsed[2], parsed[3]);
+         return;
+      }
    }
+
+   Con::warnf("EaseF must be set as \"dir type [param0 param1]\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -715,34 +730,36 @@ ConsoleGetType(TypeRotationF)
 
 ConsoleSetType(TypeRotationF)
 {
-   if (argc == 1)
+   if (argc >= 1)
    {
-      U32 elements = StringUnit::getUnitCount(argv[0], " \t\n");
+      // Combine argv into a single space-separated string if argc > 1
+      char buffer[256] = { 0 };
+      dStrncpy(buffer, *argv, sizeof(buffer));
+
+      U32 elements = StringUnit::getUnitCount(buffer, " \t\n");
       if (elements == 3)
       {
-         EulerF in;
-         dSscanf(argv[0], "%g %g %g", &in.x, &in.y, &in.z);
-         ((RotationF *)dptr)->set(in, RotationF::Degrees);
+         F32 parsed[3];
+         if(PropertyInfo::ParseProperty<F32, 3>(buffer, parsed))
+         {
+            EulerF in(parsed[0], parsed[1], parsed[2]);
+            ((RotationF*)dptr)->set(in, RotationF::Degrees);
+            return;
+         }
       }
-      else
+      else if (elements == 4)
       {
-         AngAxisF in;
-         dSscanf(argv[0], "%g %g %g %g", &in.axis.x, &in.axis.y, &in.axis.z, &in.angle);
-         ((RotationF *)dptr)->set(in, RotationF::Degrees);
+         F32 parsed[4];
+         if (PropertyInfo::ParseProperty<F32, 4>(buffer, parsed))
+         {
+            AngAxisF in(Point3F(parsed[0], parsed[1], parsed[2]), parsed[3]);
+            ((RotationF*)dptr)->set(in, RotationF::Degrees);
+            return;
+         }
       }
    }
-   else if (argc == 3)
-   {
-      EulerF in(dAtof(argv[0]), dAtof(argv[1]), dAtof(argv[2]));
-      ((RotationF *)dptr)->set(in, RotationF::Degrees);
-   }
-   else if (argc == 4)
-   {
-      AngAxisF in(Point3F(dAtof(argv[0]), dAtof(argv[1]), dAtof(argv[2])), dAtof(argv[3]));
-      ((RotationF *)dptr)->set(in, RotationF::Degrees);
-   }
-   else
-      Con::printf("RotationF must be set as { x, y, z, w } or \"x y z w\"");
+
+   Con::warnf("RotationF must be set as { x, y, z, w } or \"x y z w\"");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Add a parseProperty function to the PropertyInfo namespace

Use this function throughout the ConsoleSet macros. 

This PR accomplishes proper rounding of integer types, and puts all our parsing code for types into 1 place for easier debugging and refactoring in future if needed.

TODO:
Possible: create a function to do the inverse to push all the Get calls into one place also.