### PR TITLE
handle relfecting the health of the controlled object

### DIFF
--- a/Engine/source/T3D/fps/guiHealthBarHud.cpp
+++ b/Engine/source/T3D/fps/guiHealthBarHud.cpp
@@ -147,6 +147,11 @@ void GuiHealthBarHud::onRender(Point2I offset, const RectI &updateRect)
    if (!conn)
       return;
    ShapeBase* control = dynamic_cast<ShapeBase*>(conn->getControlObject());
+
+   //cover the case of a connection controling an object in turn controlling another
+   if (control && control->getControlObject())
+      control = control->getControlObject();
+
    if (!control || !(control->getTypeMask() & (PlayerObjectType | VehicleObjectType)))
       return;
 

--- a/Engine/source/T3D/fps/guiHealthTextHud.cpp
+++ b/Engine/source/T3D/fps/guiHealthTextHud.cpp
@@ -148,7 +148,12 @@ void GuiHealthTextHud::onRender(Point2I offset, const RectI &updateRect)
    GameConnection* conn = GameConnection::getConnectionToServer();  
    if (!conn)  
       return;  
-   ShapeBase* control = dynamic_cast<ShapeBase*>(conn->getControlObject());  
+   ShapeBase* control = dynamic_cast<ShapeBase*>(conn->getControlObject());
+
+   //cover the case of a connection controling an object in turn controlling another
+   if (control && control->getControlObject())
+      control = control->getControlObject();
+
    if (!control || !(control->getTypeMask() & (PlayerObjectType | VehicleObjectType)))
       return;  
   


### PR DESCRIPTION
players and vehicles can both be the controlobject, or you can control a vehicle *through* a player. set the health bar/text controls to reflect that state