### PR TITLE
fix controller autoasignment script

### DIFF
--- a/Templates/BaseGame/game/tools/navEditor/navEditor.tscript
+++ b/Templates/BaseGame/game/tools/navEditor/navEditor.tscript
@@ -459,7 +459,7 @@ function NavEditorGui::onLinkSelected(%this, %flags)
 
 function NavEditorGui::onPlayerSelected(%this, %flags)
 {
-   if (!isObject(%this.getPlayer().aiController) && (!(%this.getPlayer().isMemberOfClass("AIPlayer"))))
+   if (!isObject(%this.getPlayer().aiController) || (isObject(%this.getPlayer().aiController) && !(%this.getPlayer().isMemberOfClass("AIPlayer"))))
    {
       %this.getPlayer().aiController = new AIController(){ ControllerData = %this.getPlayer().getDatablock().aiControllerData; };
       %this.getPlayer().setAIController(%this.getPlayer().aiController);


### PR DESCRIPTION
the navmesh editor will try and bolt on an aicontroller initially referencing a datablock.aiControllerData for any given thing clicked on. make sure if you saved a file with one still referenced, it wont try to use the old one