### PR TITLE
BUGFIX: Reported by Steve at 16052025

### DIFF
--- a/Engine/source/math/mathTypes.cpp
+++ b/Engine/source/math/mathTypes.cpp
@@ -573,7 +573,19 @@ ConsoleSetType( TypeTransformF )
       char buffer[256] = { 0 };
       dStrncpy(buffer, *argv, sizeof(buffer));
 
-      if (PropertyInfo::ParseProperty<F32, 7>(buffer, parsed))
+      if (!PropertyInfo::ParseProperty<F32, 7>(buffer, parsed))
+      {
+         TransformF* aa = (TransformF*)dptr;
+         aa->mPosition.x = parsed[0];
+         aa->mPosition.y = parsed[1];
+         aa->mPosition.z = parsed[2];
+         aa->mOrientation.axis.x = 1.000f;
+         aa->mOrientation.axis.y = 0.000f;
+         aa->mOrientation.axis.z = 0.000f;
+         aa->mOrientation.angle = 0.000f;
+         return;
+      }
+      else
       {
          TransformF* aa = (TransformF*)dptr;
          aa->mPosition.x = parsed[0];


### PR DESCRIPTION
https://discord.com/channels/358091480004558848/783127087820439582/1372966814954553347

TransformF can take 7 or 3 values so on false just set position for now. We may need to change ParseProperty to return a count for such cases as this and be able to tell whether its just position, rotation or both being set