### PR TITLE
Fix UBO OpenGL

### DIFF
--- a/Engine/source/gfx/gl/gfxGLDevice.cpp
+++ b/Engine/source/gfx/gl/gfxGLDevice.cpp
@@ -323,8 +323,12 @@ GLuint GFXGLDevice::getDeviceBuffer(const GFXShaderConstDesc desc)
 
    GLuint uboHandle;
    glGenBuffers(1, &uboHandle);
+   glBindBuffer(GL_UNIFORM_BUFFER, uboHandle);
+   glBufferData(GL_UNIFORM_BUFFER, desc.size, NULL, GL_DYNAMIC_DRAW); // allocate once
 
    mDeviceBufferMap[name] = uboHandle;
+
+   glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
    return uboHandle;
 }

--- a/Engine/source/gfx/gl/gfxGLShader.cpp
+++ b/Engine/source/gfx/gl/gfxGLShader.cpp
@@ -713,7 +713,8 @@ void GFXGLShader::initConstantDescs()
 
       // fill out ubo desc.
       desc.name = String((char*)uboName);
-      desc.bindPoint = uboBinding;
+      desc.bindPoint = uboBinding == 0 ? glGetUniformBlockIndex(mProgram, uboName) : uboBinding;
+      glUniformBlockBinding(mProgram, glGetUniformBlockIndex(mProgram, uboName), desc.bindPoint);
       desc.size = uboSize;
       desc.constType = GFXSCT_ConstBuffer;
       desc.samplerReg = -1;
@@ -888,7 +889,7 @@ void GFXGLShader::initHandles()
       // Index element 1 of the name to skip the '$' we inserted earier.
       GLint loc = glGetUniformLocation(mProgram, &desc.name.c_str()[1]);
 
-      AssertFatal(loc != -1, avar("uniform %s in shader file Vert: (%s) Frag: (%s)", &desc.name.c_str()[1], mVertexFile.getFullPath().c_str(), mPixelFile.getFullPath().c_str()));
+      //AssertFatal(loc != -1, avar("uniform %s in shader file Vert: (%s) Frag: (%s)", &desc.name.c_str()[1], mVertexFile.getFullPath().c_str(), mPixelFile.getFullPath().c_str()));
 
       HandleMap::Iterator handle = mHandles.find(desc.name);
       S32 sampler = -1;

--- a/Engine/source/gfx/gl/gfxGLShader.cpp
+++ b/Engine/source/gfx/gl/gfxGLShader.cpp
@@ -889,7 +889,8 @@ void GFXGLShader::initHandles()
       // Index element 1 of the name to skip the '$' we inserted earier.
       GLint loc = glGetUniformLocation(mProgram, &desc.name.c_str()[1]);
 
-      //AssertFatal(loc != -1, avar("uniform %s in shader file Vert: (%s) Frag: (%s)", &desc.name.c_str()[1], mVertexFile.getFullPath().c_str(), mPixelFile.getFullPath().c_str()));
+      // The location for uniforms inside a UBO come back as -1.
+      // AssertFatal(loc != -1, avar("uniform %s in shader file Vert: (%s) Frag: (%s)", &desc.name.c_str()[1], mVertexFile.getFullPath().c_str(), mPixelFile.getFullPath().c_str()));
 
       HandleMap::Iterator handle = mHandles.find(desc.name);
       S32 sampler = -1;
@@ -908,6 +909,7 @@ void GFXGLShader::initHandles()
       {
          if (desc.bindPoint == -1)
          {
+            AssertFatal(loc != -1, avar("uniform %s in shader file Vert: (%s) Frag: (%s)", &desc.name.c_str()[1], mVertexFile.getFullPath().c_str(), mPixelFile.getFullPath().c_str()));
             desc.bindPoint = loc;
             mHandles[desc.name]->mUBOUniform = false;
          }
@@ -922,6 +924,7 @@ void GFXGLShader::initHandles()
       {
          if (desc.bindPoint == -1)
          {
+            AssertFatal(loc != -1, avar("uniform %s in shader file Vert: (%s) Frag: (%s)", &desc.name.c_str()[1], mVertexFile.getFullPath().c_str(), mPixelFile.getFullPath().c_str()));
             desc.bindPoint = loc;
             mHandles[desc.name] = new GFXGLShaderConstHandle(this, desc);
             mHandles[desc.name]->mUBOUniform = false;


### PR DESCRIPTION
This change fixes how ubo's are handled opengl side. 

Previously we were not initializing the ubos correctly, we were also asserting on a -1 location returned from the check in init handles, if this uniform belongs to a UBO it will return -1 as the location.