### PR TITLE
Direct image file option

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -289,7 +289,7 @@ StringTableEntry ImageAsset::getAssetIdByFilename(StringTableEntry fileName)
                   Torque::Path temp1 = temp->getImageFile();
                   Torque::Path temp2 = fileName;
 
-                  if (temp1 == temp2)
+                  if (temp1.getPath() == temp2.getPath() && temp1.getFileName() == temp2.getFileName())
                   {
                      return imgAsset;
                   }

--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -289,7 +289,7 @@ StringTableEntry ImageAsset::getAssetIdByFilename(StringTableEntry fileName)
                   Torque::Path temp1 = temp->getImageFile();
                   Torque::Path temp2 = fileName;
 
-                  if (temp1.getFileName() == temp2.getFileName())
+                  if (temp1 == temp2)
                   {
                      return imgAsset;
                   }

--- a/Engine/source/T3D/assets/ImageAsset.h
+++ b/Engine/source/T3D/assets/ImageAsset.h
@@ -244,7 +244,8 @@ DefineEnumType(ImageAssetType);
 
 #define DECLARE_IMAGEASSET(className, name, profile)                                                                                                                 \
 private:                                                                                                                                                                      \
-   AssetPtr<ImageAsset> m##name##Asset;                                                                                                                                       \
+   AssetPtr<ImageAsset> m##name##Asset;\
+   String               m##name##File;\
 public:                                                                                                                                                                       \
    void _set##name(StringTableEntry _in){                                                                                                                                     \
       if(m##name##Asset.getAssetId() == _in)                                                                                                                                  \
@@ -263,7 +264,7 @@ public:                                                                         
          {                                                                                                                                                                    \
             imageAssetId = query.mAssetList[0];                                                                                                                               \
          }                                                                                                                                                                    \
-         else if(Torque::FS::IsFile(_in) || (_in[0] == '$' || _in[0] == '#'))                                                                                                 \
+         else if(Torque::FS::IsFile(_in))                                                                                                                                     \
          {                                                                                                                                                                    \
             imageAssetId = ImageAsset::getAssetIdByFilename(_in);                                                                                                             \
             if (imageAssetId == ImageAsset::smNoImageAssetFallback)                                                                                                           \
@@ -296,6 +297,7 @@ public:                                                                         
 #define DECLARE_IMAGEASSET_NET(className, name, profile, mask)                                                                                                       \
 private:                                                                                                                                                                      \
    AssetPtr<ImageAsset> m##name##Asset;                                                                                                                                       \
+   String               m##name##File;\
 public:                                                                                                                                                                       \
    void _set##name(StringTableEntry _in){                                                                                                                                     \
       if(m##name##Asset.getAssetId() == _in)                                                                                                                                  \
@@ -347,12 +349,14 @@ public:                                                                         
 
 
 #define INITPERSISTFIELD_IMAGEASSET(name, consoleClass, docs)                                                                                                        \
-   addProtectedField(assetText(name, Asset), TypeImageAssetPtr, Offset(m##name##Asset, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, asset docs.));
+   addProtectedField(assetText(name, Asset), TypeImageAssetPtr, Offset(m##name##Asset, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, asset docs.)); \
+   addProtectedField(assetText(name, File), TypeFilename, Offset(m##name##File, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, file docs.));
 
 
 #define DECLARE_IMAGEASSET_ARRAY(className, name, profile, max)                                                                                                      \
 private:                                                                                                                                                                      \
    AssetPtr<ImageAsset> m##name##Asset[max];                                                                                                                                  \
+   String               m##name##File[max];\
 public:                                                                                                                                                                       \
    void _set##name(StringTableEntry _in, const U32& index){                                                                                                                   \
       if(m##name##Asset[index].getAssetId() == _in)                                                                                                                           \
@@ -405,6 +409,7 @@ public:                                                                         
 #define DECLARE_IMAGEASSET_ARRAY_NET(className, name, profile, max, mask)                                                                                            \
 private:                                                                                                                                                                      \
    AssetPtr<ImageAsset> m##name##Asset[max];                                                                                                                                  \
+   String               m##name##File[max];\
 public:                                                                                                                                                                       \
    void _set##name(StringTableEntry _in, const U32& index){                                                                                                                   \
       if(m##name##Asset[index].getAssetId() == _in)                                                                                                                           \

--- a/Engine/source/T3D/assets/ImageAsset.h
+++ b/Engine/source/T3D/assets/ImageAsset.h
@@ -264,7 +264,7 @@ public:                                                                         
          {                                                                                                                                                                    \
             imageAssetId = query.mAssetList[0];                                                                                                                               \
          }                                                                                                                                                                    \
-         else if(Torque::FS::IsFile(_in) || (_in[0] == '$' || _in[0] == '#'))                                                                                                                                     \
+         else if(Torque::FS::IsFile(_in) || (_in[0] == '$' || _in[0] == '#'))                                                                                                 \
          {                                                                                                                                                                    \
             imageAssetId = ImageAsset::getAssetIdByFilename(_in);                                                                                                             \
             if (imageAssetId == ImageAsset::smNoImageAssetFallback)                                                                                                           \

--- a/Engine/source/T3D/assets/ImageAsset.h
+++ b/Engine/source/T3D/assets/ImageAsset.h
@@ -264,7 +264,7 @@ public:                                                                         
          {                                                                                                                                                                    \
             imageAssetId = query.mAssetList[0];                                                                                                                               \
          }                                                                                                                                                                    \
-         else if(Torque::FS::IsFile(_in))                                                                                                                                     \
+         else if(Torque::FS::IsFile(_in) || (_in[0] == '$' || _in[0] == '#'))                                                                                                                                     \
          {                                                                                                                                                                    \
             imageAssetId = ImageAsset::getAssetIdByFilename(_in);                                                                                                             \
             if (imageAssetId == ImageAsset::smNoImageAssetFallback)                                                                                                           \

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -626,28 +626,13 @@ const char* ShapeAsset::generateCachedPreviewImage(S32 resolution, String overri
    delete imposterCap;
    delete shape;
 
-   String dumpPath = String(mFilePath) + "_Preview.dds";
+   String dumpPath = String(mFilePath) + ".png";
 
    char* returnBuffer = Con::getReturnBuffer(128);
    dSprintf(returnBuffer, 128, "%s", dumpPath.c_str());
 
-   /*FileStream stream;
-   if (stream.open(dumpPath, Torque::FS::File::Write))
-      destBmp.writeBitmap("png", stream);
-   stream.close();*/
+   imposter->writeBitmap("png", dumpPath);
    
-   DDSFile* ddsDest = DDSFile::createDDSFileFromGBitmap(imposter);
-   ImageUtil::ddsCompress(ddsDest, GFXFormatBC2);
-
-   // Finally save the imposters to disk.
-   FileStream fs;
-   if (fs.open(returnBuffer, Torque::FS::File::Write))
-   {
-      ddsDest->write(fs);
-      fs.close();
-   }
-
-   delete ddsDest;
    delete imposter;
    delete imposterNrml;
 

--- a/Engine/source/T3D/fx/groundCover.cpp
+++ b/Engine/source/T3D/fx/groundCover.cpp
@@ -974,8 +974,6 @@ void GroundCover::_initialize( U32 cellCount, U32 cellPlacementCount )
          GFXTexHandle tex;
          if (mat->getDiffuseMap(0))
             tex = mat->getDiffuseMap(0);
-         else if (mat->getDiffuseMapAsset(0).notNull())
-            tex = mat->getDiffuseMap(0);
 
          if(tex.isValid())
          {

--- a/Engine/source/T3D/levelInfo.cpp
+++ b/Engine/source/T3D/levelInfo.cpp
@@ -367,7 +367,7 @@ void LevelInfo::_onLMActivate(const char *lm, bool enable)
 
 void LevelInfo::setLevelAccuTexture()
 {
-   if (isClientObject() && mAccuTextureAsset.notNull())
+   if (isClientObject() && getAccuTexture())
    {
       gLevelAccuMap = getAccuTexture();
    }

--- a/Engine/source/afx/ce/afxZodiac.cpp
+++ b/Engine/source/afx/ce/afxZodiac.cpp
@@ -324,10 +324,7 @@ bool afxZodiacData::preload(bool server, String &errorStr)
   if (vert_range.x == 0.0f && vert_range.y == 0.0f)
     vert_range.x = vert_range.y = radius_xy;
 
-  if (mTextureAsset.notNull())
-  {
-     getTexture();
-  }
+  getTexture();
 
   return true;
 }
@@ -345,10 +342,7 @@ void afxZodiacData::onStaticModified(const char* slot, const char* newValue)
 
 void afxZodiacData::onPerformSubstitutions() 
 {
-   if (mTextureAsset.notNull())
-   {
-      getTexture();
-   }
+   getTexture();
 }
 
 F32 afxZodiacData::calcRotationAngle(F32 elapsed, F32 rate_factor)

--- a/Engine/source/environment/basicClouds.cpp
+++ b/Engine/source/environment/basicClouds.cpp
@@ -332,7 +332,7 @@ void BasicClouds::_initTexture()
 {
    for ( U32 i = 0; i < TEX_COUNT; i++ )
    {
-      if ( mLayerEnabled[i] && mTextureAsset[i].notNull())
+      if ( mLayerEnabled[i])
       {
          // load the resource.
          getTexture(i);

--- a/Engine/source/environment/cloudLayer.cpp
+++ b/Engine/source/environment/cloudLayer.cpp
@@ -239,7 +239,7 @@ U32 CloudLayer::packUpdate( NetConnection *conn, U32 mask, BitStream *stream )
 {
    U32 retMask = Parent::packUpdate( conn, mask, stream );
 
-   if (stream->writeFlag(mTextureAsset.notNull())) {
+   if (stream->writeFlag(getTexture())) {
       NetStringHandle assetIdStr = mTextureAsset.getAssetId(); conn->packNetStringHandleU(stream, assetIdStr);
    }
    

--- a/Engine/source/gfx/bitmap/loaders/bitmapSTB.cpp
+++ b/Engine/source/gfx/bitmap/loaders/bitmapSTB.cpp
@@ -100,8 +100,6 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
    S32 x, y, n, channels;
    String ext = path.getExtension();
 
-   U32 prevWaterMark = FrameAllocator::getWaterMark();
-
    // if this is an ies profile we need to create a texture for it.
    if (ext.equal("ies"))
    {
@@ -130,8 +128,6 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
          dMemcpy(pBase, data, rowBytes);
 
          stbi_image_free(data);
-
-         FrameAllocator::setWaterMark(prevWaterMark);
 
          return true;
       }
@@ -190,8 +186,6 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
 
          stbi_image_free(dataChar);
 
-         FrameAllocator::setWaterMark(prevWaterMark);
-
          sWriteSTB(textureName, bitmap, 10);
 
          return true;
@@ -201,7 +195,6 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
 
    if (!stbi_info(path.getFullPath().c_str(), &x, &y, &channels))
    {
-      FrameAllocator::setWaterMark(prevWaterMark);
       const char* stbErr = stbi_failure_reason();
 
       if (!stbErr)
@@ -243,8 +236,6 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
 
             stbi_image_free(data);
 
-            FrameAllocator::setWaterMark(prevWaterMark);
-
             return true;
          }
       }
@@ -271,8 +262,6 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
       //stbi_image_free(data);
       stbi_image_free(dataChar);
 
-      FrameAllocator::setWaterMark(prevWaterMark);
-
       return true;
    }
 
@@ -296,7 +285,6 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
       format = GFXFormatR8G8B8A8;
       break;
    default:
-      FrameAllocator::setWaterMark(prevWaterMark);
       return false;
    }
 
@@ -315,8 +303,6 @@ bool sReadSTB(const Torque::Path& path, GBitmap* bitmap)
    // Check this bitmap for transparency
    if (channels == 4)
       bitmap->checkForTransparency();
-
-   FrameAllocator::setWaterMark(prevWaterMark);
 
    return true;
 }

--- a/Engine/source/gui/buttons/guiBitmapButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiBitmapButtonCtrl.cpp
@@ -132,6 +132,7 @@ GuiBitmapButtonCtrl::GuiBitmapButtonCtrl()
    mBitmapName = StringTable->EmptyString();
    mBitmap = NULL;
    mBitmapAsset.registerRefreshNotify(this);
+   mBitmapFile = String::EmptyString;
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/gui/buttons/guiBitmapButtonCtrl.h
+++ b/Engine/source/gui/buttons/guiBitmapButtonCtrl.h
@@ -118,7 +118,11 @@ class GuiBitmapButtonCtrl : public GuiButtonCtrl, protected AssetPtrCallback
       ///
       BitmapMode mBitmapMode;
 
-private: AssetPtr<ImageAsset> mBitmapAsset; public: void _setBitmap(StringTableEntry _in) {
+private:
+   AssetPtr<ImageAsset> mBitmapAsset;
+   String               mBitmapFile; 
+public:
+   void _setBitmap(StringTableEntry _in) {
    if (mBitmapAsset.getAssetId() == _in) return; if (!AssetDatabase.isDeclaredAsset(_in)) {
       StringTableEntry imageAssetId = ImageAsset::smNoImageAssetFallback; AssetQuery query; S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in); if (foundAssetcount != 0) {
          imageAssetId = query.mAssetList[0];

--- a/Engine/source/gui/buttons/guiIconButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiIconButtonCtrl.cpp
@@ -380,7 +380,7 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
       if ( mTextLocation == TextLocRight )
       {
          Point2I start( mTextMargin, ( getHeight() - mProfile->mFont->getHeight() ) / 2 );
-         if (mBitmapAsset.notNull() && mIconLocation != IconLocNone)
+         if (getBitmap() && mIconLocation != IconLocNone)
          {
             start.x = getWidth() - (iconRect.extent.x + mButtonMargin.x + textWidth);
          }
@@ -400,7 +400,7 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
       if ( mTextLocation == TextLocCenter )
       {
          Point2I start;
-         if (mBitmapAsset.notNull() && mIconLocation == IconLocLeft )
+         if (getBitmap() && mIconLocation == IconLocLeft )
          {
             start.set( ( getWidth() - textWidth - iconRect.extent.x ) / 2 + iconRect.extent.x, 
                        ( getHeight() - mProfile->mFont->getHeight() ) / 2 );

--- a/Engine/source/gui/buttons/guiIconButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiIconButtonCtrl.cpp
@@ -296,7 +296,7 @@ void GuiIconButtonCtrl::renderButton( Point2I &offset, const RectI& updateRect )
    RectI iconRect( 0, 0, 0, 0 );
 
    // Render the icon
-   if ( mBitmapAsset.notNull() && mIconLocation != GuiIconButtonCtrl::IconLocNone)
+   if ( getBitmap() && mIconLocation != GuiIconButtonCtrl::IconLocNone)
    {
       // Render the normal bitmap
       drawer->clearBitmapModulation();

--- a/Engine/source/gui/buttons/guiToolboxButtonCtrl.cpp
+++ b/Engine/source/gui/buttons/guiToolboxButtonCtrl.cpp
@@ -88,7 +88,7 @@ void GuiToolboxButtonCtrl::inspectPostApply()
    // set it's extent to be exactly the size of the normal bitmap (if present)
    Parent::inspectPostApply();
 
-   if ((getWidth() == 0) && (getHeight() == 0) && mNormalBitmapAsset.notNull())
+   if ((getWidth() == 0) && (getHeight() == 0) && getNormalBitmap())
    {
       setExtent(getNormalBitmap()->getWidth(), getNormalBitmap()->getHeight());
    }
@@ -142,7 +142,7 @@ void GuiToolboxButtonCtrl::onRender(Point2I offset, const RectI& updateRect)
    }
 
    // Now render the image
-   if( mNormalBitmapAsset.notNull() )
+   if(getNormalBitmap())
    {
       renderButton(getNormalBitmap(), offset, updateRect );
       return;

--- a/Engine/source/gui/controls/guiBitmapCtrl.cpp
+++ b/Engine/source/gui/controls/guiBitmapCtrl.cpp
@@ -101,7 +101,7 @@ void GuiBitmapCtrl::inspectPostApply()
    // set it's extent to be exactly the size of the bitmap (if present)
    Parent::inspectPostApply();
 
-   if (!mWrap && (getExtent().x == 0) && (getExtent().y == 0) && mBitmapAsset.notNull())
+   if (!mWrap && (getExtent().x == 0) && (getExtent().y == 0) && getBitmap())
    {
       setExtent(mBitmap->getWidth(), mBitmap->getHeight());
    }
@@ -126,7 +126,7 @@ void GuiBitmapCtrl::setBitmap(const char* name, bool resize)
 
    mBitmap = mBitmapAsset->getTexture(&GFXDefaultGUIProfile);
 
-   if (mBitmapAsset.notNull() && resize)
+   if (getBitmap() && resize)
    {
      
       setExtent(mBitmap->getWidth(), mBitmap->getHeight());
@@ -212,7 +212,7 @@ void GuiBitmapCtrl::onRender(Point2I offset, const RectI& updateRect)
 
 void GuiBitmapCtrl::setValue(S32 x, S32 y)
 {
-   if (mBitmapAsset.notNull())
+   if (getBitmap())
    {
       x += mBitmapAsset->getTextureBitmapWidth() / 2;
       y += mBitmapAsset->getTextureBitmapHeight() / 2;

--- a/Engine/source/gui/controls/guiBitmapCtrl.cpp
+++ b/Engine/source/gui/controls/guiBitmapCtrl.cpp
@@ -121,7 +121,7 @@ void GuiBitmapCtrl::setBitmap(const char* name, bool resize)
       if (assetId != StringTable->EmptyString())
          _setBitmap(assetId);
       else
-         return;
+         _setBitmap(name);
    }
 
    mBitmap = mBitmapAsset->getTexture(&GFXDefaultGUIProfile);

--- a/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
@@ -184,7 +184,7 @@ void GuiGameSettingsCtrl::onRenderListOption(Point2I currentOffset)
       bool arrowOnR = (isSelected() || isHighlighted()) && (mWrapOptions || (mSelectedOption < mOptions.size() - 1));
       if (arrowOnL)
       {
-         if (mPreviousBitmapAsset.notNull())
+         if (getPreviousBitmap())
          {
             arrowOffset.x = currentOffset.x + mColumnSplit;
             arrowOffset.y = currentOffset.y + arrowOffsetY;
@@ -205,7 +205,7 @@ void GuiGameSettingsCtrl::onRenderListOption(Point2I currentOffset)
       }
       if (arrowOnR)
       {
-         if (mNextBitmapAsset.notNull())
+         if (getNextBitmap())
          {
             arrowOffset.x = currentOffset.x + getWidth() - mRightPad - mArrowSize;
             arrowOffset.y = currentOffset.y + arrowOffsetY;
@@ -369,7 +369,7 @@ void GuiGameSettingsCtrl::onRenderKeybindOption(Point2I currentOffset)
    buttonSize.x = height;
    buttonSize.y = height;
 
-   if (mKeybindBitmapAsset.notNull())
+   if (getKeybindBitmap())
    {
       RectI rect(button, buttonSize);
       drawer->clearBitmapModulation();

--- a/Engine/source/gui/controls/guiPopUpCtrl.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrl.cpp
@@ -891,13 +891,13 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
       }
 
       //  Draw a bitmap over the background?
-      if ( mBitmapAsset[Depressed].notNull() )
+      if (getBitmap(Depressed))
       {
          RectI rect(offset, mBitmapBounds);
          drawUtil->clearBitmapModulation();
          drawUtil->drawBitmapStretch( getBitmap(Depressed), rect );
       } 
-      else if ( mBitmapAsset[Normal].notNull() )
+      else if (getBitmap(Normal))
       {
          RectI rect(offset, mBitmapBounds);
          drawUtil->clearBitmapModulation();
@@ -941,7 +941,7 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
          }
 
          //  Draw a bitmap over the background?
-         if ( mBitmapAsset[Normal].notNull() )
+         if (getBitmap(Normal))
          {
             RectI rect( offset, mBitmapBounds );
             drawUtil->clearBitmapModulation();
@@ -977,7 +977,7 @@ void GuiPopUpMenuCtrl::onRender( Point2I offset, const RectI &updateRect )
          }
 
          //  Draw a bitmap over the background?
-         if (mBitmapAsset[Normal].notNull())
+         if (getBitmap(Normal))
          {
             RectI rect(offset, mBitmapBounds);
             drawUtil->clearBitmapModulation();

--- a/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
@@ -1090,13 +1090,13 @@ void GuiPopUpMenuCtrlEx::onRender(Point2I offset, const RectI &updateRect)
       }
 
       //  Draw a bitmap over the background?
-      if ( mBitmapAsset[Depressed].notNull() )
+      if (getBitmap(Depressed))
       {
          RectI rect(offset, mBitmapBounds);
          drawUtil->clearBitmapModulation();
          drawUtil->drawBitmapStretch(getBitmap(Depressed), rect );
       } 
-      else if (mBitmapAsset[Normal].notNull())
+      else if (getBitmap(Normal))
       {
          RectI rect(offset, mBitmapBounds);
          drawUtil->clearBitmapModulation();
@@ -1134,7 +1134,7 @@ void GuiPopUpMenuCtrlEx::onRender(Point2I offset, const RectI &updateRect)
          }
 
          //  Draw a bitmap over the background?
-         if (mBitmapAsset[Normal].notNull())
+         if (getBitmap(Normal))
          {
             RectI rect( offset, mBitmapBounds );
             drawUtil->clearBitmapModulation();
@@ -1164,7 +1164,7 @@ void GuiPopUpMenuCtrlEx::onRender(Point2I offset, const RectI &updateRect)
          }
 
          //  Draw a bitmap over the background?
-         if (mBitmapAsset[Normal].notNull())
+         if (getBitmap(Normal))
          {
             RectI rect(offset, mBitmapBounds);
             drawUtil->clearBitmapModulation();

--- a/Engine/source/gui/core/guiTypes.cpp
+++ b/Engine/source/gui/core/guiTypes.cpp
@@ -112,7 +112,7 @@ void GuiCursor::onRemove()
 
 void GuiCursor::render(const Point2I &pos)
 {
-   if (mBitmapAsset.notNull())
+   if (getBitmap())
    {
       mExtent.set(getBitmap()->getWidth(), getBitmap()->getHeight());
    }

--- a/Engine/source/gui/game/guiChunkedBitmapCtrl.cpp
+++ b/Engine/source/gui/game/guiChunkedBitmapCtrl.cpp
@@ -155,7 +155,7 @@ void GuiChunkedBitmapCtrl::renderRegion(const Point2I &offset, const Point2I &ex
 void GuiChunkedBitmapCtrl::onRender(Point2I offset, const RectI &updateRect)
 {
 
-   if( mBitmapAsset.notNull() )
+   if(getBitmap())
    {
       RectI boundsRect( offset, getExtent());
       GFX->getDrawUtil()->drawBitmapStretch(getBitmap(), boundsRect, GFXBitmapFlip_None, GFXTextureFilterLinear);

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -393,7 +393,7 @@ void ProcessedMaterial::_setStageData()
    for (i = 0; i < Material::MAX_STAGES; i++)
    {
       // DiffuseMap
-      if (mMaterial->getDiffuseMapAsset(i).notNull())
+      if (mMaterial->getDiffuseMap(i))
       {
          mStages[i].setTex(MFT_DiffuseMap, mMaterial->getDiffuseMap(i));
          if (!mStages[i].getTex(MFT_DiffuseMap))
@@ -406,7 +406,7 @@ void ProcessedMaterial::_setStageData()
          }
       }
       // OverlayMap
-      if (mMaterial->getOverlayMapAsset(i).notNull())
+      if (mMaterial->getOverlayMap(i))
       {
          mStages[i].setTex(MFT_OverlayMap, mMaterial->getOverlayMap(i));
          if (!mStages[i].getTex(MFT_OverlayMap))
@@ -414,7 +414,7 @@ void ProcessedMaterial::_setStageData()
       }
 
       // LightMap
-      if (mMaterial->getLightMapAsset(i).notNull())
+      if (mMaterial->getLightMap(i))
       {
          mStages[i].setTex(MFT_LightMap, mMaterial->getLightMap(i));
          if (!mStages[i].getTex(MFT_LightMap))
@@ -422,7 +422,7 @@ void ProcessedMaterial::_setStageData()
       }
 
       // ToneMap
-      if (mMaterial->getToneMapAsset(i).notNull())
+      if (mMaterial->getToneMap(i))
       {
          mStages[i].setTex(MFT_ToneMap, mMaterial->getToneMap(i));
          if (!mStages[i].getTex(MFT_ToneMap))
@@ -430,7 +430,7 @@ void ProcessedMaterial::_setStageData()
       }
 
       // DetailMap
-      if (mMaterial->getDetailMapAsset(i).notNull())
+      if (mMaterial->getDetailMap(i))
       {
          mStages[i].setTex(MFT_DetailMap, mMaterial->getDetailMap(i));
          if (!mStages[i].getTex(MFT_DetailMap))
@@ -438,7 +438,7 @@ void ProcessedMaterial::_setStageData()
       }
 
       // NormalMap
-      if (mMaterial->getNormalMapAsset(i).notNull())
+      if (mMaterial->getNormalMap(i))
       {
          mStages[i].setTex(MFT_NormalMap, mMaterial->getNormalMap(i));
          if (!mStages[i].getTex(MFT_NormalMap))
@@ -450,7 +450,7 @@ void ProcessedMaterial::_setStageData()
       }
 
       // Detail Normal Map
-      if (mMaterial->getDetailNormalMapAsset(i).notNull())
+      if (mMaterial->getDetailNormalMap(i))
       {
          mStages[i].setTex(MFT_DetailNormalMap, mMaterial->getDetailNormalMap(i));
          if (!mStages[i].getTex(MFT_DetailNormalMap))
@@ -463,7 +463,7 @@ void ProcessedMaterial::_setStageData()
          profile = &GFXStaticTextureSRGBProfile;
 
       // ORMConfig
-      if (mMaterial->getORMConfigMapAsset(i).notNull())
+      if (mMaterial->getORMConfigMap(i))
       {
          mStages[i].setTex(MFT_OrmMap, mMaterial->getORMConfigMap(profile, i));
          if (!mStages[i].getTex(MFT_OrmMap))
@@ -471,7 +471,7 @@ void ProcessedMaterial::_setStageData()
       }
       else
       {
-         if ((mMaterial->getAOMapAsset(i).notNull()) || (mMaterial->getRoughMapAsset(i).notNull()) || (mMaterial->getMetalMapAsset(i).notNull()))
+         if ((mMaterial->getAOMap(i)) || (mMaterial->getRoughMap(i)) || (mMaterial->getMetalMap(i)))
          {
             U32 inputKey[4];
             inputKey[0] = mMaterial->mAOChan[i];
@@ -485,7 +485,7 @@ void ProcessedMaterial::_setStageData()
                mMaterial->logError("Failed to dynamically create ORM Config map for stage %i", i);
          }
       }
-      if (mMaterial->getGlowMapAsset(i).notNull())
+      if (mMaterial->getGlowMap(i))
       {
          mStages[i].setTex(MFT_GlowMap, mMaterial->getGlowMap(i));
          if (!mStages[i].getTex(MFT_GlowMap))

--- a/Engine/source/materials/processedShaderMaterial.cpp
+++ b/Engine/source/materials/processedShaderMaterial.cpp
@@ -875,7 +875,7 @@ void ProcessedShaderMaterial::setTextureStages( SceneRenderState *state, const S
          case Material::TexTarget:
             {
                texTarget = rpd->mTexSlot[i].texTarget;
-               if (!mMaterial->getDiffuseMapAsset(0).notNull())
+               if (!mMaterial->getDiffuseMap(0))
                {
                   GFX->setTexture(i, NULL);
                   break;

--- a/Engine/source/terrain/terrRender.cpp
+++ b/Engine/source/terrain/terrRender.cpp
@@ -96,7 +96,7 @@ void TerrainBlock::_updateMaterials()
    {
       TerrainMaterial *mat = mFile->mMaterials[i];
 
-      if (mat->getDiffuseMapAsset().notNull())
+      if (mat->getDiffuseMap())
       {
          mBaseTextures[i] = mat->getDiffuseMap();
       }
@@ -104,11 +104,11 @@ void TerrainBlock::_updateMaterials()
          mBaseTextures[ i ] = GFXTexHandle();
 
       // Find the maximum detail distance.
-      if (  mat->getDetailMapAsset().notNull() &&
+      if (  mat->getDetailMap() &&
             mat->getDetailDistance() > mMaxDetailDistance )
          mMaxDetailDistance = mat->getDetailDistance();
 
-      if (  mat->getMacroMapAsset().notNull() &&
+      if (  mat->getMacroMap() &&
             mat->getMacroDistance() > mMaxDetailDistance )
          mMaxDetailDistance = mat->getMacroDistance();
    }
@@ -126,18 +126,18 @@ void TerrainBlock::_updateMaterials()
    {
       TerrainMaterial* mat = mFile->mMaterials[i];
 
-      if (mat->getDetailMapAsset().notNull())
+      if (mat->getDetailMap())
          detailTexArray[i] = mat->getDetailMap();
-      if (mat->getMacroMapAsset().notNull())
+      if (mat->getMacroMap())
          macroTexArray[i] = mat->getMacroMap();
-      if (mat->getNormalMapAsset().notNull())
+      if (mat->getNormalMap())
          normalTexArray[i] = mat->getNormalMap();
 
       //depending on creation method this may or may not have been shoved into srgb space eroneously
       GFXTextureProfile* profile = &GFXStaticTextureProfile;
       if (mat->getIsSRGB())
          profile = &GFXStaticTextureSRGBProfile;
-      if (mat->getORMConfigMapAsset().notNull())
+      if (mat->getORMConfigMap())
          ormTexArray[i] = mat->getORMConfigMapAsset()->getTexture(profile);
    }
 

--- a/Engine/source/ts/collada/colladaUtils.cpp
+++ b/Engine/source/ts/collada/colladaUtils.cpp
@@ -1030,7 +1030,7 @@ void ColladaUtils::exportColladaMaterials(tinyxml2::XMLElement* rootNode, const 
       {
          Torque::Path diffusePath;
 
-         if (mat->getDiffuseMapAsset(0).notNull())
+         if (mat->getDiffuseMap(0))
             diffusePath = Torque::Path(mat->getDiffuseMapAsset(0)->getImageFile());
          else
             diffusePath = String("warningMat");
@@ -1040,7 +1040,7 @@ void ColladaUtils::exportColladaMaterials(tinyxml2::XMLElement* rootNode, const 
       }
       else
       {
-         if (mat->getDiffuseMapAsset(0).notNull())
+         if (mat->getDiffuseMap(0))
             diffuseMap += Torque::Path(mat->getDiffuseMapAsset(0)->getImageFile());
          else
             diffuseMap += "warningMat";
@@ -1316,7 +1316,7 @@ void ColladaUtils::exportColladaMaterials(tinyxml2::XMLElement* rootNode, const 
       {
          Torque::Path diffusePath;
 
-         if (mat->getDiffuseMapAsset(0).notNull())
+         if (mat->getDiffuseMap(0))
             diffusePath = Torque::Path(mat->getDiffuseMapAsset(0)->getImageFile());
          else
             diffusePath = String("warningMat");
@@ -1326,7 +1326,7 @@ void ColladaUtils::exportColladaMaterials(tinyxml2::XMLElement* rootNode, const 
       }
       else
       {
-         if (mat->getDiffuseMapAsset(0).notNull())
+         if (mat->getDiffuseMap(0))
             diffuseMap += Torque::Path(mat->getDiffuseMapAsset(0)->getImageFile());
          else
             diffuseMap += "warningMat";

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -2778,7 +2778,7 @@ function getAssetPreviewImage(%asset)
    
    if(%previewPath $= "")
       %previewPath = "ToolsModule:unknownImage_image";
-   
+
    return %previewPath;
 }
 

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -2515,7 +2515,7 @@ function GuiEditor::onControlDropped(%this, %payload, %position)
       %assetId = %payload.moduleName @ ":" @ %payload.assetName;
       %assetType = AssetDatabase.getAssetType(%assetId);
       
-      AssetBrowser.callAssetTypeFunc(%assetType, "GUIEditorDropped", %payload.moduleName, %payload.assetName, %pos);
+      %ctrl = AssetBrowser.callAssetTypeFunc(%assetType, "onGUIEditorDropped", %payload.moduleName, %payload.assetName, %pos);
    }
    else
    {

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -740,7 +740,7 @@ function AssetBrowser::buildAssetPreview( %this, %asset, %moduleName )
    %previewButton.assetType = %assetType;
    %previewButton.assetBrowser = %this;
    
-   %previewButton.bitmapAsset = %this.previewData.previewImage;
+   %previewButton.setBitmap(%this.previewData.previewImage);
    
    %previewButton.profile = "AssetBrowserPreview" @ %previewButton.assetType;
    %previewButton.tooltip = %this.previewData.tooltip;
@@ -789,21 +789,15 @@ function AssetBrowser::doRefresh(%this)
 
 function AssetBrowser::populatePreviewImages(%this)
 {
-   if (AssetPreviewArray.count()>0)
-      echo("AssetBrowser::populatePreviewImages() - Previews to generate: " @ AssetPreviewArray.count());
-      
    for(%i=0; %i < AssetPreviewArray.count(); %i++)
    {
       %previewButton = AssetPreviewArray.getKey(%i);
       %assetType = %previewButton.assetType;
       
-      echo("   - Generating preview for asset: " @ %previewButton.moduleName @ ":" @ %previewButton.assetName);
-      
       %this.callAssetTypeFunc(%assetType, "generatePreviewImage", %previewButton.moduleName, %previewButton.assetName, %previewButton);
       
       AssetPreviewArray.erase(%i);
-      
-      echo("   - done, scheduling another pass");
+
       %this.schedule(32, "populatePreviewImages");
       return;
    }
@@ -2764,12 +2758,13 @@ function getAssetPreviewImage(%asset)
    {
       %moduleName = AssetDatabase.getAssetModule(%asset).ModuleId;
       %assetName = AssetDatabase.getAssetName(%asset);
-      %previewAssetName = "ToolsModule:" @ %moduleName @ "_" @ %assetName @ "_PreviewImage";
-      if(AssetDatabase.isDeclaredAsset(%previewAssetName))
+      
+      %previewPath = "tools/resources/previewCache/" @ %moduleName @ "/";
+      %previewFilePath = %previewPath @ %assetName @ ".png";
+
+      if(isFile(%previewFilePath))
       {
-         %previewDef = AssetDatabase.acquireAsset(%previewAssetName);  
-         %previewPath = %previewDef.getImagePath();
-         AssetDatabase.releaseAsset(%previewAssetName);
+         %previewPath = %previewFilePath;
       }
       else
       {

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/genericAsset.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/genericAsset.tscript
@@ -319,18 +319,18 @@ function GenericAsset::onSaveProperties(%this)
 //Called when the asset's Preview has been dragged and dropped into the world editor
 //This would usually spawn an associated instance, or a scene object that can utilize the
 //asset in question(ie, Dropping a SoundAsset spawns a SoundEmitter)
-function GenericAsset::onWorldEditorDropped(%this, %position)
+/*function GenericAsset::onWorldEditorDropped(%this, %position)
 {
    echo("GenericAsset::onWorldEditorDropped() - " @ %this @ ", " @ %position);
-}
+}*/
 
 //Called when the asset's Preview has been dragged and dropped into the GUI editor
 //This would usually spawn an associated instance, or a gui object that can utilize the
 //asset in question(ie, Dropping a SoundAsset spawns a guiAudioCtrl)
-function GenericAsset::onGuiEditorDropped(%this, %position)
+/*function GenericAsset::onGuiEditorDropped(%this, %position)
 {
    echo("GenericAsset::onGuiEditorDropped() - " @ %this @ ", " @ %position);
-}
+}*/
 
 //An example case of handling other specialized editors, such as dropping a Datablock
 //Preview into the DatablockEditor. This would be very case-by-case

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
@@ -4,7 +4,17 @@ function ImageAsset::buildBrowserElement(%this, %previewData)
 {
    //%module = %this.dirHandler.getModuleFromAddress(makeRelativePath(filePath(%assetDef.getImagePath())));
       
-   %previewData.previewImage = %this.isNamedTarget() ? "Core_Rendering:namedTarget_image" : "ToolsModule:genericAssetIcon_image";
+   if( %this.isNamedTarget())
+      %previewImage = "Core_Rendering:namedTarget_image";
+   else
+   {
+      %previewImage = getAssetPreviewImage(%this.getAssetId());    
+      if(!isFile(%previewImage))
+         %previewImage = "ToolsModule:genericAssetIcon_image";
+   }
+      
+   %previewData.previewImage = %previewImage;
+
    %previewData.previewLoaded = %this.isNamedTarget() ? true : false;//this marks it for loading progressively later
    
    %previewData.assetName = %this.assetName;
@@ -39,55 +49,20 @@ function ImageAsset::generatePreviewImage(%this, %previewButton, %forceRegenerat
       $CurrentAssetBrowser.dirHandler.createFolder(%previewPath);
    }
    
-   %previewFilePath = %previewPath @ %this.assetName @ "_Preview.png";
+   %previewFilePath = %previewPath @ %this.assetName @ ".png";
    if(!isFile(%previewFilePath) || (compareFileTimes(%this.getImagePath(), %previewFilePath) == 1))
    {
       %generatePreview = true;
    }
-   
-   %previewAssetName = %previewButton.moduleName @ "_" @ %this.assetName @ "_PreviewImage";
-   
+
    if(%generatePreview || %forceRegenerate)
    {
       %success = saveScaledImage(%this.getImagePath(), %previewFilePath, EditorSettings.value("Assets/Browser/PreviewImageSize"));
       
       if(%success)
-      {
-         if(!AssetDatabase.isDeclaredAsset("ToolsModule:" @ %previewAssetName))
-         {
-            %previewAsset = new ImageAsset()
-            {
-               assetName = %previewAssetName;
-               versionId = 1;
-               imageFile = makeFullPath(%previewFilePath);
-            };
-         
-            %previewAssetName = "ToolsModule:" @ %previewAssetName;
-            %previewImgAssetPath = %previewPath @ %previewAsset.assetName @ ".asset.taml";
-            %assetImportSuccessful = TAMLWrite(%previewAsset, %previewImgAssetPath); 
-         
-            %toolsModuleDef = ModuleDatabase.findModule("ToolsModule",1);
-            
-            %success = AssetDatabase.addDeclaredAsset(%toolsModuleDef, %previewImgAssetPath);
-            
-            if(!%success)
-            {
-               return false; //failed to register the preview image for some reason?
-            }
-         }
-            
-            %previewButton.bitmapAsset = %previewAssetName;
-            return true;
-         }
-      }
-      else
-      {
-         //just map the existing one then
-         if(AssetDatabase.isDeclaredAsset("ToolsModule:" @ %previewAssetName))
-      {
-            %previewButton.bitmapAsset = "ToolsModule:" @ %previewAssetName;
-            return true;
-      }
+         %previewButton.setBitmap(%previewFilePath);
+      
+      return %success;
    }
    
    return false;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
@@ -50,6 +50,7 @@ function ImageAsset::generatePreviewImage(%this, %previewButton, %forceRegenerat
    }
    
    %previewFilePath = %previewPath @ %this.assetName @ ".png";
+   
    if(!isFile(%previewFilePath) || (compareFileTimes(%this.getImagePath(), %previewFilePath) == 1))
    {
       %generatePreview = true;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/image.tscript
@@ -84,6 +84,18 @@ function ImageAsset::onSaveProperties(%this)
 {
    GenericAsset::onSaveProperties(%this);
 }
+
+function ImageAsset::onGuiEditorDropped(%this, %position)
+{
+   %assetId = %this.getAssetId();
+   %cmd = "new GuiBitmapCtrl(){";
+   %cmd = %cmd @ "BitmapAsset =\""@ %assetId @"\";";
+   %cmd = %cmd @ "position =\""@ %position @"\";";
+   %cmd = %cmd @ "};";
+   %ctrl = GuiEditCanvas.createObject(%cmd);
+   
+   return %ctrl;
+}
    
 function GuiInspectorTypeImageAssetPtr::onControlDropped( %this, %payload, %position )
 {

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
@@ -67,6 +67,7 @@ function MaterialAsset::buildBrowserElement(%this, %previewData)
    %previewImage = getAssetPreviewImage(%this.getAssetId());
    
    %previewData.previewImage = isFile(%previewImage) ? %previewImage : "ToolsModule:genericAssetIcon_image";
+
    %previewData.previewLoaded = false; //this marks it for loading progressively later
       
    %previewData.assetName = %this.assetName;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/material.tscript
@@ -64,7 +64,9 @@ function AssetBrowser::renameMaterialAsset(%this, %assetDef, %newAssetName)
 
 function MaterialAsset::buildBrowserElement(%this, %previewData)
 {   
-   %previewData.previewImage = "ToolsModule:genericAssetIcon_image";
+   %previewImage = getAssetPreviewImage(%this.getAssetId());
+   
+   %previewData.previewImage = isFile(%previewImage) ? %previewImage : "ToolsModule:genericAssetIcon_image";
    %previewData.previewLoaded = false; //this marks it for loading progressively later
       
    %previewData.assetName = %this.assetName;
@@ -108,7 +110,7 @@ function MaterialAsset::generatePreviewImage(%this, %previewButton, %forceRegene
 
    %generatePreview = false;
 
-   %previewFilePath = %previewPath @ %this.assetName @ "_Preview.dds";
+   %previewFilePath = %previewPath @ %this.assetName @ ".png";
    if(!isFile(%previewFilePath))
    {
       %generatePreview = true;
@@ -123,8 +125,6 @@ function MaterialAsset::generatePreviewImage(%this, %previewButton, %forceRegene
       }
    }
 
-   %previewAssetName = %module.moduleId @ "_" @ %this.assetName @ "_PreviewImage";
-                                   
    if(%generatePreview || %forceRegenerate)
    {
       if(isObject(%this.materialDefinitionName))
@@ -142,39 +142,13 @@ function MaterialAsset::generatePreviewImage(%this, %previewButton, %forceRegene
          pathCopy(%generatedFilePath, %previewFilePath, false);
          fileDelete(%generatedFilePath);
 
-         if(!AssetDatabase.isDeclaredAsset("ToolsModule:" @ %previewAssetName))
+         if(isFile(%previewFilePath))
          {
-            %previewAsset = new ImageAsset()
-            {
-               assetName = %previewAssetName;
-               versionId = 1;
-               imageFile = makeFullPath(%previewFilePath);
-            };
-            
-            %previewImgAssetPath = %previewPath @ %previewAsset.assetName @ ".asset.taml";
-            
-            %assetImportSuccessful = TAMLWrite(%previewAsset, %previewImgAssetPath); 
-            %toolsModuleDef = ModuleDatabase.findModule("ToolsModule",1);
-            
-            %success = AssetDatabase.addDeclaredAsset(%toolsModuleDef, %previewImgAssetPath);
-            
-            if(!%success)
-            {
-               return false; //failed to register the preview image for some reason?
-            }
+            %previewButton.setBitmap(%previewFilePath);
+            return true;
          }
-      
-         %previewButton.bitmapAsset = "ToolsModule:" @ %previewAssetName;
-         return true;
-      }
-   }
-   else
-   {
-      //just map the existing one then
-      if(AssetDatabase.isDeclaredAsset("ToolsModule:" @ %previewAssetName))
-      {
-         %previewButton.bitmapAsset = "ToolsModule:" @ %previewAssetName;
-         return true;
+
+         return false;
       }
    }
       

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
@@ -148,9 +148,16 @@ function ShapeAsset::onWorldEditorDropped(%assetDef, %position)
    MECreateUndoAction::submit(%newStatic );
 }
 
-function ShapeAsset::onGUIEditorDropped(%assetDef, %position)
+function ShapeAsset::onGUIEditorDropped(%this, %position)
 {
+   %assetId = %this.getAssetId();
+   %cmd = "new GuiObjectView(){";
+   %cmd = %cmd @ "ModelAsset =\""@ %assetId @"\";";
+   %cmd = %cmd @ "position =\""@ %position @"\";";
+   %cmd = %cmd @ "};";
+   %ctrl = GuiEditCanvas.createObject(%cmd);
    
+   return %ctrl;
 }
 
 function GuiInspectorTypeShapeAssetPtr::onControlDropped( %this, %payload, %position )

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
@@ -28,7 +28,7 @@ function ShapeAsset::onDelete(%this)
 {
    //Special handle the cache preview image
    %module = $CurrentAssetBrowser.dirHandler.getModuleFromAddress(makeRelativePath(filePath(%this.getShapePath())));
-   %previewPath = "tools/resources/previewCache/" @ %module.moduleId @ "/" @ %this.assetName @ "_Preview.dds";
+   %previewPath = "tools/resources/previewCache/" @ %module.moduleId @ "/" @ %this.assetName @ ".png";
 
    if(isFile(%previewPath))
    {
@@ -41,7 +41,9 @@ function ShapeAsset::onDelete(%this)
 
 function ShapeAsset::buildBrowserElement(%this, %previewData)
 {
-   %previewData.previewImage = "ToolsModule:genericAssetIcon_image";
+   %previewImage = getAssetPreviewImage(%this.getAssetId());
+   
+   %previewData.previewImage = isFile(%previewImage) ? %previewImage : "ToolsModule:genericAssetIcon_image";
    %previewData.previewLoaded = false; //this marks it for loading progressively later
    
    %previewData.assetName = %this.assetName;
@@ -88,18 +90,15 @@ function ShapeAsset::generatePreviewImage(%this, %previewButton, %forceRegenerat
    
    %generatePreview = false;
    
-   %previewFilePath = %previewPath @ %this.assetName @ "_Preview.dds";
+   %previewFilePath = %previewPath @ %this.assetName @ ".png";
    if(!isFile(%previewFilePath) || (compareFileTimes(%this.getShapePath(), %previewFilePath) == 1))
    {
       %generatePreview = true;
    }
    
-   %previewAssetName = %module.moduleId @ "_" @ %this.assetName @ "_PreviewImage";
-   
    if(%generatePreview || %forceRegenerate)
    {
       //real fast, we'll be 100% sure that the image resource we need is loaded
-      
       %matSlot0AssetId = %this.materialSlot0;
       if(AssetDatabase.isDeclaredAsset(%matSlot0AssetId))
       {
@@ -115,39 +114,13 @@ function ShapeAsset::generatePreviewImage(%this, %previewButton, %forceRegenerat
       pathCopy(%filePath, %previewFilePath, false);
       fileDelete(%filePath); //cleanup
       
-      if(!AssetDatabase.isDeclaredAsset("ToolsModule:" @ %previewAssetName))
+      if(isFile(%previewFilePath))
       {
-         %previewAsset = new ImageAsset()
-         {
-            assetName = %previewAssetName;
-            versionId = 1;
-            imageFile = makeFullPath(%previewFilePath);
-         };
-         
-         %previewImgAssetPath = %previewPath @ %previewAsset.assetName @ ".asset.taml";
-         
-         %assetImportSuccessful = TAMLWrite(%previewAsset, %previewImgAssetPath); 
-         %toolsModuleDef = ModuleDatabase.findModule("ToolsModule",1);
-         
-         %success = AssetDatabase.addDeclaredAsset(%toolsModuleDef, %previewImgAssetPath);
-         
-         if(!%success)
-         {
-            return false; //failed to register the preview image for some reason?
-         }
-   }
-   
-      %previewButton.bitmapAsset = "ToolsModule:" @ %previewAssetName;
-      return true;
-   }
-   else
-   {
-      //just map the existing one then
-      if(AssetDatabase.isDeclaredAsset("ToolsModule:" @ %previewAssetName))
-      {
-         %previewButton.bitmapAsset = "ToolsModule:" @ %previewAssetName;
+         %previewButton.setBitmap(%previewFilePath);
          return true;
       }
+
+      return false;
    }
    
    return false;

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
@@ -28,7 +28,7 @@ function ShapeAsset::onDelete(%this)
 {
    //Special handle the cache preview image
    %module = $CurrentAssetBrowser.dirHandler.getModuleFromAddress(makeRelativePath(filePath(%this.getShapePath())));
-   %previewPath = "tools/resources/previewCache/" @ %module.moduleId @ "/" @ %this.assetName @ ".png";
+   %previewPath = "tools/resources/previewCache/" @ %module.moduleId @ "/" @ %this.assetName @ ".dds";
 
    if(isFile(%previewPath))
    {

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/sound.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/sound.tscript
@@ -87,6 +87,8 @@ function SoundAsset::onGUIEditorDropped(%this, %position)
    %cmd = %cmd @ "};";
    %ctrl = GuiEditCanvas.createObject(%cmd);
    //echo(%ctrl SPC "created");
+   
+   return %ctrl;
 }
 
 function GuiInspectorTypeSoundAssetPtr::onControlDropped( %this, %payload, %position )

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/directoryHandling.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/directoryHandling.tscript
@@ -40,6 +40,9 @@ function directoryHandler::loadFolders(%this, %path, %parentId)
          if(%parentName $= "Data" && (%folderName $= "shaderCache" || %folderName $= "cache"))
             continue;
             
+         if(%folderName $= "previewCache")
+            continue;
+            
          if(%folderName $= ".git")
             continue;
          


### PR DESCRIPTION
Implements handling for classes that utilize image assets(such as GUIs) can be given a direct filename and process/use it appropriately.
Primarily intended for tooling, such as the fixed up handling of preview images in the asset browser that this also implements