### PR TITLE
Fixed major memory leak in GFXDevice::createStateBlock()

### DIFF
--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -292,8 +292,9 @@ GFXStateBlockRef GFXDevice::createStateBlock(const GFXStateBlockDesc& desc)
    PROFILE_SCOPE( GFXDevice_CreateStateBlock );
 
    U32 hashValue = desc.getHashValue();
-   if (mCurrentStateBlocks[hashValue])
-      return mCurrentStateBlocks[hashValue];
+   auto it = mCurrentStateBlocks.find(hashValue);
+   if (it != mCurrentStateBlocks.end())
+      return it->value;
 
    GFXStateBlockRef result = createStateBlockInternal(desc);
    result->registerResourceWithDevice(this);   

--- a/Engine/source/gfx/gfxStateBlock.h
+++ b/Engine/source/gfx/gfxStateBlock.h
@@ -36,7 +36,7 @@
 #include "core/color.h"
 #endif
 
-
+#pragma pack(push, 1)
 struct GFXSamplerStateDesc
 {
    GFXTextureAddressMode addressModeU;
@@ -84,8 +84,10 @@ struct GFXSamplerStateDesc
       return !dMemcmp(this, &b, sizeof(GFXSamplerStateDesc));
    }
 };
+#pragma pack(pop)
 
 /// GFXStateBlockDesc defines a render state, which is then used to create a GFXStateBlock instance.  
+#pragma pack(push, 1)
 struct GFXStateBlockDesc
 {   
    // Blending   
@@ -189,6 +191,7 @@ struct GFXStateBlockDesc
    ///
    void setColorWrites( bool red, bool green, bool blue, bool alpha );
 };
+#pragma pack(pop)
 
 class GFXStateBlock : public StrongRefBase, public GFXResource
 {


### PR DESCRIPTION
**Problem 1**

Due to the way the hashing function for GFXStateBlockDesc is implemented:
```
U32 GFXStateBlockDesc::getHashValue() const
{   
    return CRC::calculateCRC(this, sizeof(GFXStateBlockDesc));
}
```
...two seemingly identical GFXStateBlockDesc objects can produce different hashes. The reason behind this is memory padding. Extra bytes, added to the structure size by the compiler, contain undefined garbage data for each GFXStateBlockDesc instance created. Over time, GFXDevice::createStateBlock fills its mCurrentStateBlocks with an infinite number of GFXStateBlockDesc instances, each containing an identical set of useful data.

**Solution**

GFXStateBlockDesc memory packaging with no padding.

**Problem 2**

There is a similar issue with GFXSamplerStateDesc due to the implementation of operator==. Memory comparison doesn't provide a consistent and adequate result for the same reason.

**Solution**

GFXSamplerStateDesc memory packaging with no padding.

**Problem 3**

In GFXDevice::createStateBlock(), the following check doesn't work as intended:
`if (mCurrentStateBlocks[hashValue])`
...since Map's operator[] performs insertion.

**Solution**

Use Map::find() for the check.

**History**

This was a major issue for us after the release of The Age of Decadence, affecting a significant number of players. It took me some sleepless nights and looping through several memory analysis tools to catch it. Unfortunately, I had very little experience with GitHub at the moment, since we were using SVN internally, so I posted about this on GarageGames forums. I don't remember getting any replies, and the problem seemingly persists in this repository.
I'm not sure if it wasn't remedied in some other way, though, since I haven't followed T3D development for some time, so please kindly take a look.