### PR TITLE
don't trace setShaderConsts or onNewMessage callbacks

### DIFF
--- a/Engine/source/gui/controls/guiConsole.cpp
+++ b/Engine/source/gui/controls/guiConsole.cpp
@@ -27,6 +27,7 @@
 #include "gui/controls/guiConsole.h"
 #include "gui/containers/guiScrollCtrl.h"
 #include "console/engineAPI.h"
+#include <console/consoleInternal.h>
 
 IMPLEMENT_CONOBJECT(GuiConsole);
 
@@ -145,7 +146,10 @@ void GuiConsole::refreshLogText()
          }
       }
 
+      bool tracing = Con::gTraceOn;
+      Con::gTraceOn = false;
       onNewMessage_callback(errorCount, warnCount, normalCount);
+      Con::gTraceOn = tracing;
    }
 
    Con::unlockLog();

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -44,6 +44,7 @@
 #include "materials/shaderData.h"
 #include "postFx/postEffectManager.h"
 #include "postFx/postEffectVis.h"
+#include <console/consoleInternal.h>
 
 using namespace Torque;
 
@@ -1126,8 +1127,10 @@ void PostEffect::_setupConstants( const SceneRenderState *state )
             Con::setFloatVariable("$Param::NearDist", state->getNearPlane());
             Con::setFloatVariable("$Param::FarDist", state->getFarPlane());
          }
-
+         bool tracing = Con::gTraceOn;
+         Con::gTraceOn = false;
          setShaderConsts_callback();
+         Con::gTraceOn = tracing;
       }
 
       EffectConstTable::Iterator iter = mEffectConsts.begin();


### PR DESCRIPTION
they spam up the console to uselessness when using the trace(true/false) command