### PR TITLE
Disables the behavior for building and exporting polyLists for SceneGroups

### DIFF
--- a/Engine/source/T3D/SceneGroup.cpp
+++ b/Engine/source/T3D/SceneGroup.cpp
@@ -364,51 +364,8 @@ void SceneGroup::unpackUpdate(NetConnection* conn, BitStream* stream)
    }
 }
 
-bool SceneGroup::buildPolyList(PolyListContext context, AbstractPolyList* polyList, const Box3F& box, const SphereF& sphere)
-{
-   Vector<SceneObject*> foundObjects;
-   if (empty())
-   {
-      Con::warnf("SceneGroup::buildPolyList() - SceneGroup %s is empty!", getName());
-      return false;
-   }
-   findObjectByType(foundObjects);
-
-   for (S32 i = 0; i < foundObjects.size(); i++)
-   {
-      foundObjects[i]->buildPolyList(context, polyList, box, sphere);
-   }
-
-   return true;
-}
-
-bool SceneGroup::buildExportPolyList(ColladaUtils::ExportData* exportData, const Box3F& box, const SphereF& sphere)
-{
-   Vector<SceneObject*> foundObjects;
-   findObjectByType(foundObjects);
-
-   for (S32 i = 0; i < foundObjects.size(); i++)
-   {
-      foundObjects[i]->buildExportPolyList(exportData, box, sphere);
-   }
-
-   return true;
-}
-
 void SceneGroup::getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList)
 {
-   //if (empty())
-      return;
-
-   Vector<SceneObject*> foundObjects;
-   findObjectByType(foundObjects);
-
-   for (S32 i = 0; i < foundObjects.size(); i++)
-   {
-      SceneObject* child = foundObjects[i];
-
-      child->getUtilizedAssets(usedAssetsList);
-   }
 }
 
 DefineEngineMethod(SceneGroup, recalculateBounds, void, (), ,

--- a/Engine/source/T3D/SceneGroup.h
+++ b/Engine/source/T3D/SceneGroup.h
@@ -49,8 +49,8 @@ public:
    void reparentOOBObjects();
 
    ///
-   bool buildPolyList(PolyListContext context, AbstractPolyList* polyList, const Box3F& box, const SphereF& sphere) override;
-   bool buildExportPolyList(ColladaUtils::ExportData* exportData, const Box3F& box, const SphereF&) override;
+   bool buildPolyList(PolyListContext context, AbstractPolyList* polyList, const Box3F& box, const SphereF& sphere) override { return false; };
+   bool buildExportPolyList(ColladaUtils::ExportData* exportData, const Box3F& box, const SphereF&) override { return false; };
    void getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList) override;
 };
 #endif


### PR DESCRIPTION
Disables the behavior for building and exporting polyLists for SceneGroups as you can just do so on the individual child items, and it can cause erroneous behavior like looping if triggered improperly.