### PR TITLE
add grace hieght for pathshape snapping eval

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -4763,8 +4763,11 @@ void Player::updateAttachment()
         Point3F(pos.x, pos.y, pos.z - 1.0f ),
        sCollisionMoveMask, &rInfo))
     {
+       Point3F setPos = rInfo.point;
+       setPos.z = mMax(setPos.z+sMinFaceDistance, pos.z);
+
        if ((mJumpSurfaceLastContact < JumpSkipContactsMax) && !mSwimming)
-          setPosition(rInfo.point, getRotation());
+          setPosition(setPos, getRotation());
 
        if( rInfo.object->getTypeMask() & PathShapeObjectType) //Ramen
        {


### PR DESCRIPTION
leverage minFaceDistance plus current hieght to try and ensure stepping down into a pathshape/tsstatic within the 0.1 ot -1.0 detection range range doesn't snap you through another one.