### PR TITLE
Update assetbrowser.tscript with patch

### DIFF
--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -2140,6 +2140,9 @@ function AssetBrowser::navigateTo(%this, %address, %historyNav)
    if(startsWith(%address, "/"))
       %address = strreplace(%address, "/", "");
       
+   // Safety
+   %address = strreplace(%address, "//", "/");
+      
    //Don't bother navigating if it's to the place we already are
    if(%this.dirHandler.currentAddress !$= %address)
    {


### PR DESCRIPTION
fix folder navigation in asset browser
fix found by Abbey

AssetBrowser was adding a // in the filepath and this was preventing our assets from appearing if we clicked on the folders instead of the tree on the left.