### PR TITLE
fix crash with unclean exit

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -4604,10 +4604,12 @@ void Player::onUnmount( SceneObject *obj, S32 node )
 
 void Player::unmount()
 {
+
    // Reset back to root position during dismount.  This copies what is
    // done on the server and corrects the fact that the RootAnim change
    // is not sent across to the client using the standard ActionMask.
-   setActionThread(PlayerData::RootAnim,true,false,false);
+   if (!isRemoved())
+      setActionThread(PlayerData::RootAnim,true,false,false);
 
    Parent::unmount();
 }

--- a/Engine/source/ts/tsThread.cpp
+++ b/Engine/source/ts/tsThread.cpp
@@ -534,7 +534,6 @@ void TSShapeInstance::destroyThread(TSThread * thread)
    delete mThreadList[i];
    mThreadList.erase(i);
    setDirty(AllDirtyMask);
-   checkScaleCurrentlyAnimated();
 }
 
 U32 TSShapeInstance::threadCount()


### PR DESCRIPTION
for player, if we're unmounting because we're being deleted, don't bother animating.
for tsthreads in general, not much point in removing the threadlist, then checking if it's scaled