### PR TITLE
Fixes several reported issues with the updated Material Editor

### DIFF
--- a/Templates/BaseGame/game/tools/gui/compositeTextureEditor.tscript
+++ b/Templates/BaseGame/game/tools/gui/compositeTextureEditor.tscript
@@ -110,12 +110,11 @@ function CompositeEditorDoSaveComposite(%assetId)
       return;
    }
    
-    %targetFilePath = %assetDef.getImagePath();
+    %targetFilePath = filePath(%assetDef.getFilename()) @ "/" @ fileName(%assetDef.imageFile);
    
     %aoMapAsset = CompTextureEd_RedChan-->Bitmap.getBitmap();
     %roughMapAsset = CompTextureEd_GreenChan-->Bitmap.getBitmap();
     %metalMapAsset = CompTextureEd_BlueChan-->Bitmap.getBitmap();
-    
     
     if(%aoMapAsset $= "ToolsModule:unknownImage_image")
     {

--- a/Templates/BaseGame/game/tools/materialEditor/gui/MaterialEditorGui.gui
+++ b/Templates/BaseGame/game/tools/materialEditor/gui/MaterialEditorGui.gui
@@ -92,6 +92,7 @@ $guiContent = new GuiControl(MaterialEditorGui) {
          position = "3 24";
          extent = "387 1269";
          horizSizing = "width";
+         vertSizing = "height";
          profile = "ToolsGuiDefaultProfile";
          tooltipProfile = "GuiToolTipProfile";
 
@@ -433,6 +434,7 @@ $guiContent = new GuiControl(MaterialEditorGui) {
                extent = "382 793";
                minExtent = "64 64";
                horizSizing = "width";
+               vertSizing = "height";
                profile = "ToolsGuiDefaultProfile";
                tooltipProfile = "ToolsGuiToolTipProfile";
                isContainer = "0";

--- a/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/materialEditor/scripts/materialEditor.ed.tscript
@@ -526,7 +526,7 @@ function MaterialEditorGui::prepareActiveObject( %this, %override )
       {
          %fieldName = %obj.getField(%i);
          
-         if( %obj.getFieldType(%fieldName) !$= "TypeMaterialAssetId" /*&& %obj.getFieldType(%fieldName) !$= "TypeMaterialName"*/)
+         if( %obj.getFieldType(%fieldName) !$= "TypeMaterialAssetId" && %obj.getFieldType(%fieldName) !$= "TypeMaterialAssetPtr")
             continue;
       
          if( !%canSupportMaterial )
@@ -1022,6 +1022,7 @@ function MaterialEditorGui::guiSync( %this )
    }
    
    MaterialEditorPropInspector.loadCollapseState();
+   MaterialEditorPropInspector.loadScrollState();
    
    cancel(MaterialEditorGui.refreshSchedule);
    
@@ -1990,12 +1991,15 @@ function MaterialEditorGui::doSwapMaterial(%this, %materialAsset)
 
 function MaterialEditorPropInspector::onInspectorFieldModified(%this, %object, %fieldName, %arrayIndex, %oldValue, %newValue)
 {
+   MaterialEditorPropInspector.saveScrollState();
+   
    if(%arrayIndex !$= "" && %arrayIndex !$= "(null)")
       MaterialEditorGui.updateActiveMaterial(%fieldName @ "[" @ %arrayIndex @ "]", %newValue);
    else
       MaterialEditorGui.updateActiveMaterial(%fieldName, %newValue);
       
-   MaterialEditorGui.refreshSchedule = MaterialEditorGui.schedule(32, "guiSync");
+   cancel(MaterialEditorGui.refreshSchedule);
+   MaterialEditorGui.refreshSchedule = MaterialEditorGui.schedule(256, "guiSync");
 }
 
 function MaterialEditorPropInspector::getScrollbar(%this)
@@ -2026,7 +2030,7 @@ function MaterialEditorPropInspector::onPostInspectObject(%this, %obj)
 function MaterialEditorPropInspector::saveScrollState(%this)
 {
    %this.scrollPos = %this.getScrollbar().getScrollPosition();
-   //echo(%this.getName() @ "::saveScrollState" SPC %this.scrollPos);
+   echo(%this.getName() @ "::saveScrollState" SPC %this.scrollPos);
 }
 
 function MaterialEditorPropInspector::loadScrollState(%this)
@@ -2034,7 +2038,7 @@ function MaterialEditorPropInspector::loadScrollState(%this)
    if (%this.scrollPos $= "") 
       return;
    %this.getScrollbar().setScrollPosition(%this.scrollPos.x, %this.scrollPos.y);
-   //echo(%this.getName() @ "::loadScrollState" SPC %this.scrollPos);
+   echo(%this.getName() @ "::loadScrollState" SPC %this.scrollPos);
 }
 
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editors/worldEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editors/worldEditor.ed.tscript
@@ -43,7 +43,7 @@ function WorldEditor::onSelect( %this, %obj )
    
    // Used to help the Material Editor( the M.E doesn't utilize its own TS control )
    // so this dirty extension is used to fake it
-   if ( MaterialEditorGui.isVisible() )
+   if ( MaterialEditorGui.isAwake() )
       MaterialEditorGui.prepareActiveObject();
    
    // Update the Transform Selection window


### PR DESCRIPTION
- Fixes issue with resizing for the inspector panel of the updated MatEd where it would cut off
- Fixes refresh behavior where it'd refresh while you were doing a 'long action' like dragging a slider or range value
- Fixes issue where the scroll position would reset when modifying some fields
- Fixed issue where saving a composite texture could save it to the game root directory
- Fixed issue where opening the mat ed for the first time with an object selected could have the inspector not inspect the object