### PR TITLE
fix directx rendertarget crash

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Target.cpp
@@ -106,9 +106,9 @@ void GFXD3D11TextureTarget::attachTexture( RenderSlot slot, GFXTextureObject *te
    else
    {
       // Cast the texture object to D3D...
-      AssertFatal(static_cast<GFXD3D11TextureObject*>(tex), "GFXD3D11TextureTarget::attachTexture - invalid texture object.");
+      AssertFatal(dynamic_cast<GFXD3D11TextureObject*>(tex), "GFXD3D11TextureTarget::attachTexture - invalid texture object.");
 
-      GFXD3D11TextureObject *d3dto = static_cast<GFXD3D11TextureObject*>(tex);
+      GFXD3D11TextureObject *d3dto = dynamic_cast<GFXD3D11TextureObject*>(tex);
 
       // Grab the surface level.
       if( slot == DepthStencil )
@@ -134,7 +134,6 @@ void GFXD3D11TextureTarget::attachTexture( RenderSlot slot, GFXTextureObject *te
             mTargets[slot]->AddRef();
             mTargetViews[slot] = d3dto->getRTView();
             mTargetViews[slot]->AddRef();
-            mResolveTargets[slot] = d3dto;
          } 
          else 
          {
@@ -271,17 +270,21 @@ void GFXD3D11TextureTarget::deactivate()
       return;
 
    //re-gen mip maps
-   for (U32 i = 0; i < 6; i++)
+   for (U32 i = GFXTextureTarget::Color0; i < GFXTextureTarget::MaxRenderSlotId; i++)
    {
-      D3D11_TEXTURE2D_DESC desc;
-      if (mResolveTargets[GFXTextureTarget::Color0 + i])
+      GFXD3D11TextureObject*  targ = mResolveTargets[i];
+      ID3D11ShaderResourceView* pSRView = mTargetSRViews[i];
+      if (targ && targ->getSurface() && pSRView)
       {
-         mResolveTargets[GFXTextureTarget::Color0 + i]->get2DTex()->GetDesc(&desc);
-         if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS)
+         ID3D11Texture2D* tex = dynamic_cast<ID3D11Texture2D*>(targ->getResource());
+         if (tex)
          {
-            ID3D11ShaderResourceView* pSRView = mTargetSRViews[GFXTextureTarget::Color0 + i];
-            if (pSRView)
+            D3D11_TEXTURE2D_DESC desc;
+            tex->GetDesc(&desc);
+            if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS)
+            {
                D3D11DEVICECONTEXT->GenerateMips(pSRView);
+            }
          }
       }
    }   
@@ -341,8 +344,8 @@ GFXD3D11WindowTarget::GFXD3D11WindowTarget()
 
 GFXD3D11WindowTarget::~GFXD3D11WindowTarget()
 {
-   SAFE_RELEASE(mDepthStencilView)
-      SAFE_RELEASE(mDepthStencil);
+   SAFE_RELEASE(mDepthStencilView);
+   SAFE_RELEASE(mDepthStencil);
    SAFE_RELEASE(mBackBufferView);
    SAFE_RELEASE(mBackBuffer);
    SAFE_RELEASE(mSwapChain);

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -1418,7 +1418,7 @@ void GFXTextureManager::_validateTexParams( const U32 width, const U32 height,
    {
       // If a texture is not power-of-2 in size for both dimensions, it must
       // have only 1 mip level.
-      if (profile->isRenderTarget())
+      if (profile->isRenderTarget() && !profile->noMip())
       {
          if (inOutNumMips == 0) //auto
             inOutNumMips = mFloor(mLog2(mMax(width, height))) + 1;

--- a/Templates/BaseGame/game/core/postFX/scripts/HDR/HDR_Bloom/upSampleP.glsl
+++ b/Templates/BaseGame/game/core/postFX/scripts/HDR/HDR_Bloom/upSampleP.glsl
@@ -55,11 +55,10 @@ void main()
 
     upSample.rgb = e*4.0;
     upSample.rgb += (b+d+f+h)*2.0;
-    upSample.rgb += (a+c+g+i);
-    upSample.rgb *= 1.0 / 16.0; 
+    upSample.rgb += (a+c+g+i); 
     finalOut += upSample;
  } 
- finalOut /= mipCount0;
+ finalOut /= pow(mipCount0,3);
  finalOut.a = 1.0;  
   
   OUT_col = finalOut;

--- a/Templates/BaseGame/game/core/postFX/scripts/HDR/HDR_Bloom/upSampleP.hlsl
+++ b/Templates/BaseGame/game/core/postFX/scripts/HDR/HDR_Bloom/upSampleP.hlsl
@@ -51,7 +51,6 @@ float4 main(PFXVertToPix IN) : TORQUE_TARGET0
     upSample.rgb = e*4.0;
     upSample.rgb += (b+d+f+h)*2.0;
     upSample.rgb += (a+c+g+i);
-    upSample.rgb *= 1.0 / 16.0;
     finalOut += upSample;
  } 
  finalOut /= mipCount0;


### PR DESCRIPTION
asset brower previews were asserting due to a cornercase rt assignment also ditch mipgen for rts targetting a texture profile that's marked as nomip, and adjust hdr uopsampling shader to compensate for overdarks