### PR TITLE
Fixes dirty status behavior of Forest Editor

### DIFF
--- a/Engine/source/forest/editor/forestBrushTool.cpp
+++ b/Engine/source/forest/editor/forestBrushTool.cpp
@@ -105,6 +105,11 @@ ConsoleDocClass( ForestBrushTool,
    "@internal"
 );
 
+IMPLEMENT_CALLBACK(ForestBrushTool, onAction, void, (U32 mode, Point3F point), (mode, point),
+   "Called when the editor performs a brush action\n"
+   "@param mode the Int/Enum value of the mode of the action\n"
+   "@param point the position the action was performed at\n");
+
 FRangeValidator fBrushRange(0.0f, 150.0f);
 void ForestBrushTool::initPersistFields()
 {
@@ -338,6 +343,8 @@ void ForestBrushTool::_action( const Point3F &point )
       _paint( point );
    else if ( mMode == Erase || mMode == EraseSelected )
       _erase( point );
+
+   onAction_callback(mMode, point);
 }
 
 inline F32 mCircleArea( F32 radius )

--- a/Engine/source/forest/editor/forestBrushTool.h
+++ b/Engine/source/forest/editor/forestBrushTool.h
@@ -128,7 +128,9 @@ protected:
    Point3F mLastBrushNormal;
 
    /// The creation action we're actively filling.
-   ForestUndoAction *mCurrAction;  
+   ForestUndoAction *mCurrAction;
+
+   DECLARE_CALLBACK(void, onAction, (U32 mode, Point3F point));
 };
 
 typedef ForestBrushTool::BrushMode ForestBrushMode;

--- a/Templates/BaseGame/game/tools/forestEditor/main.tscript
+++ b/Templates/BaseGame/game/tools/forestEditor/main.tscript
@@ -309,6 +309,8 @@ function ForestEditorPlugin::onEditMenuSelect( %this, %editMenu )
 function ForestEditorPlugin::handleDelete( %this )
 {
    ForestTools->SelectionTool.deleteSelection();   
+   
+   ForestEditorPlugin.dirty = true;
 }
 
 function ForestEditorPlugin::handleDeselect( %this )
@@ -319,6 +321,8 @@ function ForestEditorPlugin::handleDeselect( %this )
 function ForestEditorPlugin::handleCut( %this )
 {
    ForestTools->SelectionTool.cutSelection();
+   
+   ForestEditorPlugin.dirty = true;
 }
 
 function ForestEditorPlugin::handleCopy( %this )
@@ -329,4 +333,6 @@ function ForestEditorPlugin::handleCopy( %this )
 function ForestEditorPlugin::handlePaste( %this )
 {
    ForestTools->SelectionTool.pasteSelection();
+   
+   ForestEditorPlugin.dirty = true;
 }

--- a/Templates/BaseGame/game/tools/forestEditor/tools.tscript
+++ b/Templates/BaseGame/game/tools/forestEditor/tools.tscript
@@ -59,3 +59,8 @@ function ForestSelectionTool::onDeactivated( %this )
 {
    %this.clearSelection();
 }
+
+function ForestBrushTool::onAction(%this, %actionMode, %point)
+{
+   ForestEditorPlugin.dirty = true;
+}


### PR DESCRIPTION
Ensures that when performing certain actions like painting, erasing, cutting or pasting, it will mark the forest editor as dirty so it will save as expected