### PR TITLE
hovervehicle stabilizer fix for groundplane (and other things)

### DIFF
--- a/Engine/source/T3D/vehicles/hoverVehicle.cpp
+++ b/Engine/source/T3D/vehicles/hoverVehicle.cpp
@@ -725,8 +725,7 @@ void HoverVehicle::updateForces(F32 /*dt*/)
 
    for (j = 0; j < 2; j++) {
       if (getContainer()->castRay(stabPoints[j].wsPoint, stabPoints[j].wsPoint + stabPoints[j].wsExtension * 2.0,
-                                  TerrainObjectType | 
-                                  WaterObjectType, &rinfo)) 
+         sCollisionMoveMask, &rinfo))
       {
          reallyFloating = false;
 


### PR DESCRIPTION
use the generic collisionmask for the stabilizer castrays