### PR TITLE
clarify input value for some utility commands

### DIFF
--- a/Templates/BaseGame/game/core/utility/scripts/helperFunctions.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/helperFunctions.tscript
@@ -784,13 +784,13 @@ function getNumCanCallOnObjectList(%functionName, %objectsList)
    return %numberWithFunction;
 }
 
-function getImageFileName(%id)
+function getImageFileName(%assetName)
 {
-    %assetDef = AssetDatabase.acquireAsset(%id);
+    %assetDef = AssetDatabase.acquireAsset(%assetName);
     return %assetDef.getImagePath();
 }
 
-function makeTerrainMapsFrom(%id)
+function makeTerrainMapsFrom(%assetName)
 {
-    splitTerrainMaps(getImageFileName(%id));
+    splitTerrainMaps(getImageFileName(%assetName));
 }


### PR DESCRIPTION
 makeTerrainMapsFrom and getImageFileName take the "module:name" of the image. not the simid number