### PR TITLE
dsqs are a  subset of dts data

### DIFF
--- a/Engine/source/ts/assimp/assimpShapeLoader.cpp
+++ b/Engine/source/ts/assimp/assimpShapeLoader.cpp
@@ -993,21 +993,24 @@ TSShape* assimpLoadShape(const Torque::Path &path)
          tss->write(&dtsStream);
       }
 
-      Torque::Path dsqPath(cachedPath);
-      dsqPath.setExtension("dsq");
-      FileStream animOutStream;
-      for (S32 i = 0; i < tss->sequences.size(); i++)
+      if (tss->meshes.empty())
       {
-         const String& seqName = tss->getName(tss->sequences[i].nameIndex);
-         Con::printf("Writing DSQ Animation File for sequence '%s'", seqName.c_str());
-
-         dsqPath.setFileName(cachedPath.getFileName() + "_" + seqName);
-         if (animOutStream.open(dsqPath.getFullPath(), Torque::FS::File::Write))
+         Torque::Path dsqPath(cachedPath);
+         dsqPath.setExtension("dsq");
+         FileStream animOutStream;
+         for (S32 i = 0; i < tss->sequences.size(); i++)
          {
-            tss->exportSequence(&animOutStream, tss->sequences[i], false);
-            animOutStream.close();
-         }
+            const String& seqName = tss->getName(tss->sequences[i].nameIndex);
+            Con::printf("Writing DSQ Animation File for sequence '%s'", seqName.c_str());
 
+            dsqPath.setFileName(cachedPath.getFileName() + "_" + seqName);
+            if (animOutStream.open(dsqPath.getFullPath(), Torque::FS::File::Write))
+            {
+               tss->exportSequence(&animOutStream, tss->sequences[i], false);
+               animOutStream.close();
+            }
+
+         }
       }
 
       loader.updateMaterialsScript(path);

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -737,23 +737,25 @@ TSShape* loadColladaShape(const Torque::Path &path)
             tss->write(&dtsStream);
          }
 
-         Torque::Path dsqPath(cachedPath);
-         dsqPath.setExtension("dsq");
-         FileStream animOutStream;
-         for (S32 i = 0; i < tss->sequences.size(); i++)
+         if (tss->meshes.empty())
          {
-            const String& seqName = tss->getName(tss->sequences[i].nameIndex);
-            Con::printf("Writing DSQ Animation File for sequence '%s'", seqName.c_str());
-
-            dsqPath.setFileName(cachedPath.getFileName() + "_" + seqName);
-            if (animOutStream.open(dsqPath.getFullPath(), Torque::FS::File::Write))
+            Torque::Path dsqPath(cachedPath);
+            dsqPath.setExtension("dsq");
+            FileStream animOutStream;
+            for (S32 i = 0; i < tss->sequences.size(); i++)
             {
-               tss->exportSequence(&animOutStream, tss->sequences[i], false);
-               animOutStream.close();
+               const String& seqName = tss->getName(tss->sequences[i].nameIndex);
+               Con::printf("Writing DSQ Animation File for sequence '%s'", seqName.c_str());
+
+               dsqPath.setFileName(cachedPath.getFileName() + "_" + seqName);
+               if (animOutStream.open(dsqPath.getFullPath(), Torque::FS::File::Write))
+               {
+                  tss->exportSequence(&animOutStream, tss->sequences[i], false);
+                  animOutStream.close();
+               }
+
             }
-
          }
-
 #endif // DAE2DTS_TOOL
 
          // Add collada materials to materials.tscript

--- a/Engine/source/ts/tsShape.h
+++ b/Engine/source/ts/tsShape.h
@@ -681,7 +681,7 @@ class TSShape
    S32 setDetailSize(S32 oldSize, S32 newSize);
    bool removeDetail(S32 size);
 
-   bool isShapeFileType(Torque::Path filePath);
+   static bool isShapeFileType(Torque::Path filePath);
    bool addSequence(const Torque::Path& path, const String& fromSeq, const String& name, S32 startFrame, S32 endFrame, bool padRotKeys, bool padTransKeys);
    bool removeSequence(const String& name);
 

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shapeAnimation.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shapeAnimation.tscript
@@ -11,23 +11,14 @@ function ShapeAnimationAsset::buildBrowserElement(%this, %previewData)
 {
    %previewData.assetName = %this.animationName;
    %previewData.assetPath = %this.scriptFile;
-
-   //Lotta prepwork
-   /*%previewData.doubleClickCommand = %assetDef@".materialDefinitionName.reload(); "
-                                   @ "$Tools::materialEditorList = \"\";"
-                                   @ "EWorldEditor.clearSelection();"
-                                   @ "MaterialEditorGui.currentObject = 0;"
-                                   @ "MaterialEditorGui.currentMode = \"asset\";"
-                                   @ "MaterialEditorGui.currentMaterial = "@%assetDef@".materialDefinitionName;"
-                                   @ "MaterialEditorGui.setActiveMaterial( "@%assetDef@".materialDefinitionName );"
-                                   @ "EditorGui.setEditor(MaterialEditorPlugin); "
-                                   @ "AssetBrowser.hideDialog();";*/
    
    %previewData.previewImage = "ToolsModule:animationIcon_image";
    
    %previewData.assetFriendlyName = %this.assetName;
    %previewData.assetDesc = %this.description;
-   %previewData.tooltip = %this.friendlyName @ "\n" 
-                          @ %this @ "\nShape File path: " 
-                          @ %this.getShapePath();
+   
+   %previewData.tooltip = "Asset Name: " @ %this.assetName @ "\n" @ 
+                           "Asset Type: Animation Asset\n" @ 
+                           "Asset Definition ID: " @  %this @ "\n" @ 
+                           "Animation File path: " @ %this.getAnimationPath();
 }


### PR DESCRIPTION
ensure if an input file contains mesh data *and* an animation, thats a dts, if it's *just* an armature, that's dsq also fix shapeanimation tooltip display
and for furutere utility,  TSShape::isShapeFileType(Torque::Path filePath); is now static since it only requires a path, not an object instance per-se