### PR TITLE
Makes sure the loading code for terrain assets is properly assigned.

### DIFF
--- a/Engine/source/T3D/assets/TerrainAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainAsset.cpp
@@ -191,6 +191,9 @@ void TerrainAsset::setTerrainFileName(const char* pScriptFile)
 
 U32 TerrainAsset::load()
 {
+   if (mLoadedState == AssetErrCode::Ok)
+      return mLoadedState;
+
    if (!Torque::FS::IsFile(mTerrainFilePath))
    {
       mLoadedState = BadFileReference;

--- a/Engine/source/T3D/assets/TerrainAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainAsset.cpp
@@ -192,7 +192,10 @@ void TerrainAsset::setTerrainFileName(const char* pScriptFile)
 U32 TerrainAsset::load()
 {
    if (!Torque::FS::IsFile(mTerrainFilePath))
-      return BadFileReference;
+   {
+      mLoadedState = BadFileReference;
+      return mLoadedState;
+   }
 
    mTerrMaterialAssets.clear();
    mTerrMaterialAssetIds.clear();
@@ -229,9 +232,15 @@ U32 TerrainAsset::load()
    mTerrainFile = ResourceManager::get().load(mTerrainFilePath);
 
    if (mTerrainFile)
-      return Ok;
+   {
+      mLoadedState = Ok;
+   }
+   else
+   {
+      mLoadedState = BadFileReference;
+   }
 
-   return BadFileReference;
+   return mLoadedState;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This ensures stuff like saving works properly.