### PR TITLE
playaudio related fixes

### DIFF
--- a/Engine/source/T3D/assets/SoundAsset.cpp
+++ b/Engine/source/T3D/assets/SoundAsset.cpp
@@ -167,7 +167,7 @@ SoundAsset::SoundAsset()
    mProfileDesc.mScatterDistance = Point3F(0.f, 0.f, 0.f);
    mProfileDesc.mPriority = 1.0f;
    mProfileDesc.mSourceGroup = NULL;
-
+   mProfileDesc.mFadeInEase = EaseF();
    mIsPlaylist = false;
 
    mPlaylist.mNumSlotsToPlay = SFXPlayList::SFXPlaylistSettings::NUM_SLOTS;

--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -2347,14 +2347,12 @@ void ShapeBase::updateAudioState(SoundThread& st)
       if ( isGhost() ) 
       {
          // if asset is valid, play
-         if (st.asset->isAssetValid() )
+         if (st.asset->load() == AssetBase::Ok)
          {
-            if (st.asset->load() == AssetBase::Ok)
-            {
-               st.sound = SFX->createSource(st.asset->getSFXTrack(), &getTransform());
-               if (st.sound)
-                  st.sound->play();
-            }
+            SFXTrack* trk = st.asset->getSFXTrack();
+            st.sound = SFX->createSource(trk, &getTransform());
+            if (st.sound)
+               st.sound->play();
          }
          else
             st.play = false;


### PR DESCRIPTION
soundassets in general: initialize the ease to default for the ShapeBase::updateAudioState, we never call that without first checking if the asset is defined, *and* isvalid is not valid if it's never tried loading it. so that's both redundant *and* actively counterproductive for a filter