### PR TITLE
fix recursive datablock loading

### DIFF
--- a/Engine/source/console/torquescript/compiledEval.cpp
+++ b/Engine/source/console/torquescript/compiledEval.cpp
@@ -1031,11 +1031,15 @@ Con::EvalResult CodeBlock::exec(U32 ip, const char* functionName, Namespace* thi
 
             if (!ret)
             {
-               // This error is usually caused by failing to call Parent::initPersistFields in the class' initPersistFields().
-               Con::warnf(ConsoleLogEntry::General, "%s: Register object failed for object %s of class %s.", getFileLine(ip - 2), currentNewObject->getName(), currentNewObject->getClassName());
+               if (Con::gObjectCopyFailures == -1)
+               {
+                  // This error is usually caused by failing to call Parent::initPersistFields in the class' initPersistFields(), or relying on an undefined yet dependency
+                  Con::warnf(ConsoleLogEntry::General, "%s: Register object failed for object %s of class %s.", getFileLine(ip - 2), currentNewObject->getName(), currentNewObject->getClassName());
+               }
                delete currentNewObject;
                currentNewObject = NULL;
                ip = failJump;
+               ++Con::gObjectCopyFailures;
                break;
             }
          }
@@ -1047,8 +1051,11 @@ Con::EvalResult CodeBlock::exec(U32 ip, const char* functionName, Namespace* thi
          // If so, preload it.
          if (dataBlock && !dataBlock->preload(true, errorStr))
          {
-            Con::errorf(ConsoleLogEntry::General, "%s: preload failed for %s: %s.", getFileLine(ip - 2),
-               currentNewObject->getName(), errorStr.c_str());
+            if (Con::gObjectCopyFailures == -1)
+            {
+               Con::errorf(ConsoleLogEntry::General, "%s: preload failed for %s: %s.", getFileLine(ip - 2),
+                  currentNewObject->getName(), errorStr.c_str());
+            }
             dataBlock->deleteObject();
             currentNewObject = NULL;
             ip = failJump;

--- a/Engine/source/console/torquescript/compiledEval.cpp
+++ b/Engine/source/console/torquescript/compiledEval.cpp
@@ -1059,6 +1059,7 @@ Con::EvalResult CodeBlock::exec(U32 ip, const char* functionName, Namespace* thi
             dataBlock->deleteObject();
             currentNewObject = NULL;
             ip = failJump;
+            ++Con::gObjectCopyFailures;
             break;
          }
 

--- a/Templates/BaseGame/game/core/utility/scripts/helperFunctions.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/helperFunctions.tscript
@@ -77,7 +77,7 @@ function loadDatablockFiles( %datablockFiles, %recurse )
    for ( %i=0; %i < %count; %i++ )
    {
       %file = %datablockFiles.getKey( %i );
-      if (!isFile(%file) && !isFile(%file @ ".dso") && !isFile(%file @"."@ $TorqueScriptFileExtension @ ".dso") && !isFile(%file @"."@ $TorqueScriptFileExtension))
+      if (!isScriptFile(%file))
          continue;
                   
       exec( %file );
@@ -100,7 +100,7 @@ function recursiveLoadDatablockFiles( %datablockFiles, %previousErrors )
    for ( %i=0; %i < %count; %i++ )
    {      
       %file = %datablockFiles.getKey( %i );
-      if (!isFile(%file) && !isFile(%file @ ".dso") && !isFile(%file @"."@ $TorqueScriptFileExtension @ ".dso") && !isFile(%file @"."@ $TorqueScriptFileExtension))
+      if (!isScriptFile(%file))
          continue;
          
       // Start counting copy constructor creation errors.


### PR DESCRIPTION
$Con::objectCopyFailures tracks failed db loads, and if positive due to a config error, is supposed to retry the file after looping through the rest of the list