### PR TITLE
circular volatile buffer safety

### DIFF
--- a/Engine/source/gfx/gl/gfxGLCircularVolatileBuffer.h
+++ b/Engine/source/gfx/gl/gfxGLCircularVolatileBuffer.h
@@ -29,7 +29,7 @@ public:
 
    bool checkOverlap(U32 start, U32 end) 
    {         
-      if( mStart < end && start < mEnd )
+      if ((mStart < end - 1) && (start < mEnd - 1))
          return true;
 
       return false;


### PR DESCRIPTION
add padding to the circular volative buffer overlap test to avoid loop artifacting