### PR TITLE
Various fixes pertaining to handling of assets' macros and inspector fields that didn't work with array'd fields

### DIFF
--- a/Engine/source/T3D/assets/CubemapAsset.cpp
+++ b/Engine/source/T3D/assets/CubemapAsset.cpp
@@ -198,10 +198,19 @@ GuiControl* GuiInspectorTypeCubemapAssetPtr::constructEditControl()
    if (retCtrl == NULL)
       return retCtrl;
 
+   StringBuilder varNameStr;
+   varNameStr.append(mCaption);
+   if (mFieldArrayIndex != nullptr)
+   {
+      varNameStr.append("[");
+      varNameStr.append(mFieldArrayIndex);
+      varNameStr.append("]");
+   }
+
    // Change filespec
    char szBuffer[512];
-   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"CubemapAsset\", \"AssetBrowser.changeAsset\", %d, %s);",
-      mInspector->getIdString(), mCaption);
+   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"CubemapAsset\", \"AssetBrowser.changeAsset\", %d, \"%s\");",
+      mInspector->getIdString(), varNameStr.end().c_str());
    mBrowseButton->setField("Command", szBuffer);
 
    setDataField(StringTable->insert("object"), NULL, String::ToString(mInspector->getInspectObject()).c_str());

--- a/Engine/source/T3D/assets/GUIAsset.cpp
+++ b/Engine/source/T3D/assets/GUIAsset.cpp
@@ -262,10 +262,19 @@ GuiControl* GuiInspectorTypeGUIAssetPtr::constructEditControl()
    if (retCtrl == NULL)
       return retCtrl;
 
+   StringBuilder varNameStr;
+   varNameStr.append(mCaption);
+   if (mFieldArrayIndex != nullptr)
+   {
+      varNameStr.append("[");
+      varNameStr.append(mFieldArrayIndex);
+      varNameStr.append("]");
+   }
+
    // Change filespec
    char szBuffer[512];
-   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"GUIAsset\", \"AssetBrowser.changeAsset\", %d, %s);",
-      mInspector->getIdString(), mCaption);
+   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"GUIAsset\", \"AssetBrowser.changeAsset\", %d, \"%s\");",
+      mInspector->getIdString(), varNameStr.end().c_str());
    mBrowseButton->setField("Command", szBuffer);
 
    // Create "Open in ShapeEditor" button

--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -484,13 +484,22 @@ GuiControl* GuiInspectorTypeMaterialAssetPtr::constructEditControl()
 
    if (mInspector->getInspectObject() != nullptr)
    {
-      dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"MaterialAsset\", \"AssetBrowser.changeAsset\", %s, %s);",
-         mInspector->getIdString(), mCaption);
+      StringBuilder varNameStr;
+      varNameStr.append(mCaption);
+      if (mFieldArrayIndex != nullptr)
+      {
+         varNameStr.append("[");
+         varNameStr.append(mFieldArrayIndex);
+         varNameStr.append("]");
+      }
+
+      dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"MaterialAsset\", \"AssetBrowser.changeAsset\", %s, \"%s\");",
+         mInspector->getIdString(), varNameStr.end().c_str());
       mBrowseButton->setField("Command", szBuffer);
 
       setDataField(StringTable->insert("targetObject"), NULL, mInspector->getInspectObject()->getIdString());
 
-      previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
+      previewImage = mInspector->getInspectObject()->getDataField(varNameStr.end().c_str(), NULL);
    }
    else
    {

--- a/Engine/source/T3D/assets/ParticleAsset.cpp
+++ b/Engine/source/T3D/assets/ParticleAsset.cpp
@@ -150,10 +150,19 @@ GuiControl* GuiInspectorTypeParticleAssetPtr::constructEditControl()
    if (retCtrl == NULL)
       return retCtrl;
 
+   StringBuilder varNameStr;
+   varNameStr.append(mCaption);
+   if (mFieldArrayIndex != nullptr)
+   {
+      varNameStr.append("[");
+      varNameStr.append(mFieldArrayIndex);
+      varNameStr.append("]");
+   }
+
    // Change filespec
    char szBuffer[512];
-   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ParticleAsset\", \"AssetBrowser.changeAsset\", %d, %s);",
-      mInspector->getIdString(), mCaption);
+   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ParticleAsset\", \"AssetBrowser.changeAsset\", %d, \"%s\");",
+      mInspector->getIdString(), varNameStr.end().c_str());
    mBrowseButton->setField("Command", szBuffer);
 
    // Create "Open in ShapeEditor" button

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -807,13 +807,22 @@ GuiControl* GuiInspectorTypeShapeAssetPtr::constructEditControl()
 
    if (mInspector->getInspectObject() != nullptr)
    {
-      dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ShapeAsset\", \"AssetBrowser.changeAsset\", %s, %s);",
-         mInspector->getIdString(), mCaption);
+      StringBuilder varNameStr;
+      varNameStr.append(mCaption);
+      if (mFieldArrayIndex != nullptr)
+      {
+         varNameStr.append("[");
+         varNameStr.append(mFieldArrayIndex);
+         varNameStr.append("]");
+      }
+
+      dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ShapeAsset\", \"AssetBrowser.changeAsset\", %s, \"%s\");",
+         mInspector->getIdString(), varNameStr.end().c_str());
       mBrowseButton->setField("Command", szBuffer);
 
       setDataField(StringTable->insert("targetObject"), NULL, mInspector->getInspectObject()->getIdString());
 
-      previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
+      previewImage = mInspector->getInspectObject()->getDataField(varNameStr.end().c_str(), NULL);
    }
    else
    {

--- a/Engine/source/T3D/assets/TerrainAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainAsset.cpp
@@ -473,10 +473,19 @@ GuiControl* GuiInspectorTypeTerrainAssetPtr::constructEditControl()
    if (retCtrl == NULL)
       return retCtrl;
 
+   StringBuilder varNameStr;
+   varNameStr.append(mCaption);
+   if (mFieldArrayIndex != nullptr)
+   {
+      varNameStr.append("[");
+      varNameStr.append(mFieldArrayIndex);
+      varNameStr.append("]");
+   }
+
    // Change filespec
    char szBuffer[512];
-   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"TerrainAsset\", \"AssetBrowser.changeAsset\", %s, %s);",
-      mInspector->getIdString(), mCaption);
+   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"TerrainAsset\", \"AssetBrowser.changeAsset\", %s, \"%s\");",
+      mInspector->getIdString(), varNameStr.end().c_str());
    mBrowseButton->setField("Command", szBuffer);
 
    setDataField(StringTable->insert("targetObject"), NULL, mInspector->getInspectObject()->getIdString());

--- a/Engine/source/T3D/assets/TerrainMaterialAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainMaterialAsset.cpp
@@ -49,7 +49,10 @@ StringTableEntry TerrainMaterialAsset::smNoTerrainMaterialAssetFallback = NULL;
 
 IMPLEMENT_CONOBJECT(TerrainMaterialAsset);
 
-ConsoleType(TerrainMaterialAssetPtr, TypeTerrainMaterialAssetPtr, TerrainMaterialAsset, ASSET_ID_FIELD_PREFIX)
+IMPLEMENT_STRUCT(AssetPtr<TerrainMaterialAsset>, AssetPtrTerrainMaterialAsset, , "")
+END_IMPLEMENT_STRUCT
+
+ConsoleType(TerrainMaterialAssetPtr, TypeTerrainMaterialAssetPtr, AssetPtr<TerrainMaterialAsset>, ASSET_ID_FIELD_PREFIX)
 
 //-----------------------------------------------------------------------------
 
@@ -511,10 +514,19 @@ GuiControl* GuiInspectorTypeTerrainMaterialAssetPtr::constructEditControl()
    if (retCtrl == NULL)
       return retCtrl;
 
+   StringBuilder varNameStr;
+   varNameStr.append(mCaption);
+   if (mFieldArrayIndex != nullptr)
+   {
+      varNameStr.append("[");
+      varNameStr.append(mFieldArrayIndex);
+      varNameStr.append("]");
+   }
+
    // Change filespec
    char szBuffer[512];
-   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"TerrainMaterialAsset\", \"AssetBrowser.changeAsset\", %s, %s);",
-      mInspector->getIdString(), mCaption);
+   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"TerrainMaterialAsset\", \"AssetBrowser.changeAsset\", %s, \"%s\");",
+      mInspector->getIdString(), varNameStr.end().c_str());
    mBrowseButton->setField("Command", szBuffer);
 
    setDataField(StringTable->insert("targetObject"), NULL, mInspector->getInspectObject()->getIdString());

--- a/Engine/source/T3D/assets/TerrainMaterialAsset.h
+++ b/Engine/source/T3D/assets/TerrainMaterialAsset.h
@@ -128,7 +128,183 @@ protected:
    static const char* getScriptFile(void* obj, const char* data) { return static_cast<TerrainMaterialAsset*>(obj)->getScriptFile(); }
 };
 
-DefineConsoleType(TypeTerrainMaterialAssetPtr, TerrainMaterialAsset)
+DECLARE_STRUCT(AssetPtr<TerrainMaterialAsset>)
+DefineConsoleType(TypeTerrainMaterialAssetPtr, AssetPtr<TerrainMaterialAsset>)
+
+#define DECLARE_TERRAINMATERIALASSET(className, name)                                                                                                               \
+private:                                                                                                                                                                      \
+   AssetPtr<TerrainMaterialAsset> m##name##Asset;                                                                                                                                  \
+   StringTableEntry     m##name##File = {StringTable->EmptyString() };                                                                                                   \
+public:                                                                                                                                                                       \
+   void _set##name(StringTableEntry _in){                                                                                                                   \
+      if (m##name##Asset.getAssetId() == _in)                                                                                                                          \
+         return;                                                                                                                                                              \
+      if(_in == NULL || !String::compare(_in,StringTable->EmptyString()))                                                                                                       \
+      {                                                                                                                                                                       \
+         m##name##Asset = NULL;                                                                                                                                        \
+         m##name##File = "";                                                                                                                                           \
+         return;                                                                                                                                                              \
+      }                                                                                                                                                                       \
+      if (!AssetDatabase.isDeclaredAsset(_in))                                                                                                                                \
+      {                                                                                                                                                                       \
+         StringTableEntry terMatAssetId = StringTable->EmptyString();                                                                                                          \
+         AssetQuery query;                                                                                                                                                    \
+         S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in);                                                                                                 \
+         if (foundAssetcount != 0)                                                                                                                                            \
+         {                                                                                                                                                                    \
+            terMatAssetId = query.mAssetList[0];                                                                                                                               \
+         }                                                                                                                                                                    \
+         m##name##Asset = terMatAssetId;                                                                                                                                \
+         m##name##File = _in;                                                                                                                                          \
+      }                                                                                                                                                                       \
+      else                                                                                                                                                                    \
+      {                                                                                                                                                                       \
+         m##name##Asset = _in;                                                                                                                                         \
+         m##name##File = get##name##File();                                                                                                                       \
+      }                                                                                                                                                                       \
+   };                                                                                                                                                                         \
+                                                                                                                                                                              \
+   inline StringTableEntry _get##name##AssetId() const { return m##name##Asset.getAssetId(); }                                                         \
+   TerrainMaterial* get##name() { if (m##name##Asset.notNull()) return m##name##Asset->getMaterialDefinition(); else return NULL; }                                  \
+   AssetPtr<TerrainMaterialAsset> get##name##Asset() { return m##name##Asset; }                                                                                  \
+   static bool _set##name##Data(void* obj, const char* index, const char* data) { static_cast<className*>(obj)->_set##name(_getStringTable()->insert(data)); return false;}\
+   StringTableEntry get##name##File() { return m##name##Asset.notNull() ? m##name##Asset->getScriptFile() : ""; }
+
+#define DECLARE_TERRAINMATERIALASSET_NET(className, name, mask)                                                                                                               \
+private:                                                                                                                                                                      \
+   AssetPtr<TerrainMaterialAsset> m##name##Asset;                                                                                                                                  \
+   StringTableEntry     m##name##File = {StringTable->EmptyString() };                                                                                                   \
+public:                                                                                                                                                                       \
+   void _set##name(StringTableEntry _in){                                                                                                                   \
+      if (m##name##Asset.getAssetId() == _in)                                                                                                                          \
+         return;                                                                                                                                                              \
+      if(_in == NULL || !String::compare(_in,StringTable->EmptyString()))                                                                                                       \
+      {                                                                                                                                                                       \
+         m##name##Asset = NULL;                                                                                                                                        \
+         m##name##File = "";                                                                                                                                           \
+         return;                                                                                                                                                              \
+      }                                                                                                                                                                       \
+      if (!AssetDatabase.isDeclaredAsset(_in))                                                                                                                                \
+      {                                                                                                                                                                       \
+         StringTableEntry terMatAssetId = StringTable->EmptyString();                                                                                                          \
+         AssetQuery query;                                                                                                                                                    \
+         S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in);                                                                                                 \
+         if (foundAssetcount != 0)                                                                                                                                            \
+         {                                                                                                                                                                    \
+            terMatAssetId = query.mAssetList[0];                                                                                                                               \
+         }                                                                                                                                                                    \
+         m##name##Asset = terMatAssetId;                                                                                                                                \
+         m##name##File = _in;                                                                                                                                          \
+      }                                                                                                                                                                       \
+      else                                                                                                                                                                    \
+      {                                                                                                                                                                       \
+         m##name##Asset = _in;                                                                                                                                         \
+         m##name##File = get##name##File();                                                                                                                       \
+      }                                                                                                                                                                       \
+   };                                                                                                                                                                         \
+                                                                                                                                                                              \
+   inline StringTableEntry _get##name##AssetId() const { return m##name##Asset.getAssetId(); }                                                         \
+   TerrainMaterial* get##name() { if (m##name##Asset.notNull()) return m##name##Asset->getMaterialDefinition(); else return NULL; }                                  \
+   AssetPtr<TerrainMaterialAsset> get##name##Asset() { return m##name##Asset; }                                                                                  \
+   static bool _set##name##Data(void* obj, const char* index, const char* data)\
+   {\
+       static_cast<className*>(obj)->_set##name(_getStringTable()->insert(data));\
+       static_cast<className*>(obj)->setMaskBits(mask); \
+       return false;\
+   }\
+   StringTableEntry get##name##File() { return m##name##Asset.notNull() ? m##name##Asset->getScriptFile() : ""; }
+
+#define INITPERSISTFIELD_TERRAINMATERIALASSET(name, consoleClass, docs)                                                                                       \
+   addProtectedField(assetText(name, Asset), TypeTerrainMaterialAssetPtr, Offset(m##name##Asset, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, asset docs.));\
+   addProtectedField(assetText(name, File), TypeFilename, Offset(m##name##File, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, asset docs.), AbstractClassRep::FIELD_HideInInspectors);
+
+#define DECLARE_TERRAINMATERIALASSET_ARRAY(className, name, max)                                                                                                               \
+private:                                                                                                                                                                      \
+   AssetPtr<TerrainMaterialAsset> m##name##Asset[max];                                                                                                                                  \
+   StringTableEntry     m##name##File[max] = {StringTable->EmptyString() };                                                                                                   \
+public:                                                                                                                                                                       \
+   void _set##name(StringTableEntry _in, const U32& index){                                                                                                                   \
+      if (m##name##Asset[index].getAssetId() == _in)                                                                                                                          \
+         return;                                                                                                                                                              \
+      if(_in == NULL || !String::compare(_in,StringTable->EmptyString()))                                                                                                       \
+      {                                                                                                                                                                       \
+         m##name##Asset[index] = NULL;                                                                                                                                        \
+         m##name##File[index] = "";                                                                                                                                           \
+         return;                                                                                                                                                              \
+      }                                                                                                                                                                       \
+      if (!AssetDatabase.isDeclaredAsset(_in))                                                                                                                                \
+      {                                                                                                                                                                       \
+         StringTableEntry terMatAssetId = StringTable->EmptyString();                                                                                                          \
+         AssetQuery query;                                                                                                                                                    \
+         S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in);                                                                                                 \
+         if (foundAssetcount != 0)                                                                                                                                            \
+         {                                                                                                                                                                    \
+            terMatAssetId = query.mAssetList[0];                                                                                                                               \
+         }                                                                                                                                                                    \
+         m##name##Asset[index] = terMatAssetId;                                                                                                                                \
+         m##name##File[index] = _in;                                                                                                                                          \
+      }                                                                                                                                                                       \
+      else                                                                                                                                                                    \
+      {                                                                                                                                                                       \
+         m##name##Asset[index] = _in;                                                                                                                                         \
+         m##name##File[index] = get##name##File(index);                                                                                                                       \
+      }                                                                                                                                                                       \
+   };                                                                                                                                                                         \
+                                                                                                                                                                              \
+   inline StringTableEntry _get##name##AssetId(const U32& index) const { return m##name##Asset[index].getAssetId(); }                                                         \
+   TerrainMaterial* get##name(const U32& index) { if (m##name##Asset[index].notNull()) return m##name##Asset[index]->getMaterialDefinition(); else return NULL; }                                  \
+   AssetPtr<TerrainMaterialAsset> get##name##Asset(const U32& index) { return m##name##Asset[index]; }                                                                                  \
+   static bool _set##name##Data(void* obj, const char* index, const char* data) { static_cast<className*>(obj)->_set##name(_getStringTable()->insert(data), dAtoi(index)); return false;}\
+   StringTableEntry get##name##File(const U32& idx) { return m##name##Asset[idx].notNull() ? m##name##Asset[idx]->getScriptFile() : ""; }
+
+#define DECLARE_TERRAINMATERIALASSET_NET_ARRAY(className, name, max, mask)                                                                                                               \
+private:                                                                                                                                                                      \
+   AssetPtr<TerrainMaterialAsset> m##name##Asset[max];                                                                                                                                  \
+   StringTableEntry     m##name##File[max] = {StringTable->EmptyString() };                                                                                                   \
+public:                                                                                                                                                                       \
+   void _set##name(StringTableEntry _in, const U32& index){                                                                                                                   \
+      if (m##name##Asset[index].getAssetId() == _in)                                                                                                                          \
+         return;                                                                                                                                                              \
+      if(_in == NULL || !String::compare(_in,StringTable->EmptyString()))                                                                                                       \
+      {                                                                                                                                                                       \
+         m##name##Asset[index] = NULL;                                                                                                                                        \
+         m##name##File[index] = "";                                                                                                                                           \
+         return;                                                                                                                                                              \
+      }                                                                                                                                                                       \
+      if (!AssetDatabase.isDeclaredAsset(_in))                                                                                                                                \
+      {                                                                                                                                                                       \
+         StringTableEntry terMatAssetId = StringTable->EmptyString();                                                                                                          \
+         AssetQuery query;                                                                                                                                                    \
+         S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in);                                                                                                 \
+         if (foundAssetcount != 0)                                                                                                                                            \
+         {                                                                                                                                                                    \
+            terMatAssetId = query.mAssetList[0];                                                                                                                               \
+         }                                                                                                                                                                    \
+         m##name##Asset[index] = terMatAssetId;                                                                                                                                \
+         m##name##File[index] = _in;                                                                                                                                          \
+      }                                                                                                                                                                       \
+      else                                                                                                                                                                    \
+      {                                                                                                                                                                       \
+         m##name##Asset[index] = _in;                                                                                                                                         \
+         m##name##File[index] = get##name##File(index);                                                                                                                       \
+      }                                                                                                                                                                       \
+   };                                                                                                                                                                         \
+                                                                                                                                                                              \
+   inline StringTableEntry _get##name##AssetId(const U32& index) const { return m##name##Asset[index].getAssetId(); }                                                         \
+   TerrainMaterial* get##name(const U32& index) { if (m##name##Asset[index].notNull()) return m##name##Asset[index]->getMaterialDefinition(); else return NULL; }                                  \
+   AssetPtr<TerrainMaterialAsset> get##name##Asset(const U32& index) { return m##name##Asset[index]; }                                                                                  \
+   static bool _set##name##Data(void* obj, const char* index, const char* data)\
+   {\
+       static_cast<className*>(obj)->_set##name(_getStringTable()->insert(data), dAtoi(index));\
+       static_cast<className*>(obj)->setMaskBits(mask); \
+       return false;\
+   }\
+   StringTableEntry get##name##File(const U32& idx) { return m##name##Asset[idx].notNull() ? m##name##Asset[idx]->getScriptFile() : ""; }
+
+#define INITPERSISTFIELD_TERRAINMATERIALASSET_ARRAY(name, arraySize, consoleClass, docs)                                                                                       \
+   addProtectedField(assetText(name, Asset), TypeTerrainMaterialAssetPtr, Offset(m##name##Asset, consoleClass), _set##name##Data, &defaultProtectedGetFn, arraySize, assetDoc(name, asset docs.));\
+   addProtectedField(assetText(name, File), TypeFilename, Offset(m##name##File, consoleClass), _set##name##Data, &defaultProtectedGetFn, arraySize, assetDoc(name, asset docs.), AbstractClassRep::FIELD_HideInInspectors);
+
 DefineConsoleType(TypeTerrainMaterialAssetId, String)
 #ifdef TORQUE_TOOLS
 //-----------------------------------------------------------------------------

--- a/Engine/source/T3D/assets/assetMacroHelpers.h
+++ b/Engine/source/T3D/assets/assetMacroHelpers.h
@@ -62,14 +62,26 @@ if (m##name##AssetId != StringTable->EmptyString())\
    if (stream->writeFlag(m##name##Asset.notNull()))\
    {\
       stream->writeString(m##name##Asset.getAssetId());\
-   }
+   }\
+   else if (stream->writeFlag(m##name##File != StringTable->EmptyString()))\
+   {\
+      stream->writeString(m##name##File);\
+   }\
 
 //network recieve - datablock
 #define UNPACKDATA_ASSET_REFACTOR(name)\
    if (stream->readFlag())\
    {\
       _set##name(stream->readSTString());\
-   }
+   }\
+   else if (stream->readFlag())\
+   {\
+      _set##name(stream->readSTString());\
+   }\
+   else\
+   {\
+      _set##name(StringTable->EmptyString());\
+   }\
 
 //network send - object-instance
 #define PACK_ASSET_REFACTOR(netconn, name)\
@@ -77,14 +89,27 @@ if (m##name##AssetId != StringTable->EmptyString())\
    {\
       NetStringHandle assetIdStr = m##name##Asset.getAssetId();\
       netconn->packNetStringHandleU(stream, assetIdStr);\
-   }
+   }\
+   else if (stream->writeFlag(m##name##File != StringTable->EmptyString()))\
+   {\
+      NetStringHandle fileStr = m##name##File;\
+      netconn->packNetStringHandleU(stream, fileStr);\
+   }\
 
 //network recieve - object-instance
 #define UNPACK_ASSET_REFACTOR(netconn, name)\
    if (stream->readFlag())\
    {\
       _set##name(netconn->unpackNetStringHandleU(stream).getString());\
-   }
+   }\
+   else if (stream->readFlag())\
+   {\
+      _set##name(netconn->unpackNetStringHandleU(stream).getString());\
+   }\
+   else\
+   {\
+      _set##name(StringTable->EmptyString());\
+   }\
 
 //network send - datablock
 #define PACKDATA_ASSET_ARRAY_REFACTOR(name, max)\
@@ -93,6 +118,10 @@ for (U32 i = 0; i < max; i++)\
    if (stream->writeFlag(m##name##Asset[i].notNull()))\
    {\
       stream->writeString(m##name##Asset[i].getAssetId()); \
+   }\
+   else if (stream->writeFlag(m##name##File[i] != StringTable->EmptyString()))\
+   {\
+      stream->writeString(m##name##File[i]);\
    }\
 }
 
@@ -103,6 +132,14 @@ for (U32 i = 0; i < max; i++)\
    if (stream->readFlag())\
    {\
       m##name##Asset[i] = stream->readSTString();\
+   }\
+   else if (stream->readFlag())\
+   {\
+      _set##name(stream->readSTString(), i);\
+   }\
+   else\
+   {\
+      _set##name(StringTable->EmptyString(), i);\
    }\
 }
 
@@ -115,6 +152,11 @@ for (U32 i = 0; i < max; i++)\
       NetStringHandle assetIdStr = m##name##Asset[i].getAssetId();\
       netconn->packNetStringHandleU(stream, assetIdStr);\
    }\
+   else if (stream->writeFlag(m##name##File[i] != StringTable->EmptyString()))\
+   {\
+      NetStringHandle fileStr = m##name##File[i];\
+      netconn->packNetStringHandleU(stream, fileStr);\
+   }\
 }
 
 //network recieve - object-instance
@@ -124,6 +166,14 @@ for (U32 i = 0; i < max; i++)\
    if (stream->readFlag())\
    {\
       m##name##Asset[i] = StringTable->insert(netconn->unpackNetStringHandleU(stream).getString());\
+   }\
+   else if (stream->readFlag())\
+   {\
+      _set##name(StringTable->insert(netconn->unpackNetStringHandleU(stream).getString()), i);\
+   }\
+   else\
+   {\
+      _set##name(StringTable->EmptyString(), i);\
    }\
 }
 
@@ -168,8 +218,10 @@ DefineEngineMethod(className, set##name, void, (const char* assetName), , assetT
    {\
       stream->writeString(m##name##Asset.getAssetId());\
    }\
-   else\
-      stream->writeString(m##name##Name);
+   else if(stream->writeFlag(m##name##Name != StringTable->EmptyString()))\
+   {\
+      stream->writeString(m##name##Name);\
+   }\
 
 //network recieve - datablock
 #define UNPACKDATA_ASSET(name)\
@@ -178,11 +230,15 @@ DefineEngineMethod(className, set##name, void, (const char* assetName), , assetT
       m##name##AssetId = stream->readSTString();\
       _set##name(m##name##AssetId);\
    }\
-   else\
+   else if (stream->readFlag())\
    {\
       m##name##Name = stream->readSTString();\
       _set##name(m##name##Name);\
-   }
+   }\
+   else\
+   {\
+      _set##name(StringTable->EmptyString());\
+   }\
 
 //network send - object-instance
 #define PACK_ASSET(netconn, name)\
@@ -191,8 +247,11 @@ DefineEngineMethod(className, set##name, void, (const char* assetName), , assetT
       NetStringHandle assetIdStr = m##name##Asset.getAssetId();\
       netconn->packNetStringHandleU(stream, assetIdStr);\
    }\
-   else\
-      stream->writeString(m##name##Name);
+   else if (stream->writeFlag(m##name##Name != StringTable->EmptyString()))\
+   {\
+      NetStringHandle nameStr = m##name##Name;\
+      netconn->packNetStringHandleU(stream, nameStr);\
+   }\
 
 //network recieve - object-instance
 #define UNPACK_ASSET(netconn, name)\
@@ -201,8 +260,14 @@ DefineEngineMethod(className, set##name, void, (const char* assetName), , assetT
       m##name##AssetId = StringTable->insert(netconn->unpackNetStringHandleU(stream).getString());\
       _set##name(m##name##AssetId);\
    }\
+   else if (stream->readFlag())\
+   {\
+      _set##name(StringTable->insert(netconn->unpackNetStringHandleU(stream).getString()));\
+   }\
    else\
-      m##name##Name = stream->readSTString();
+   {\
+      _set##name(StringTable->EmptyString()); \
+   }\
 
 //script methods for class.asset acces
 //declare general get<entry>, get<entry>Asset and set<entry> methods
@@ -287,8 +352,10 @@ if (m##name##AssetId[index] != StringTable->EmptyString())\
    {\
       stream->writeString(m##name##Asset[index].getAssetId());\
    }\
-   else\
-      stream->writeString(m##name##Name[index]);
+   else if (stream->writeFlag(m##name##Name[index] != StringTable->EmptyString()))\
+   {\
+      stream->writeString(m##name##Name[index].getAssetId());\
+   }\
 
 //network recieve - datablock
 #define UNPACKDATA_ASSET_ARRAY(name, index)\
@@ -297,11 +364,15 @@ if (m##name##AssetId[index] != StringTable->EmptyString())\
       m##name##AssetId[index] = stream->readSTString();\
       _set##name(m##name##AssetId[index], index);\
    }\
-   else\
+   else if (stream->readFlag())\
    {\
       m##name##Name[index] = stream->readSTString();\
       _set##name(m##name##Name[index], index);\
-   }
+   }\
+   else\
+   {\
+      _set##name(StringTable->EmptyString());\
+   }\
 
 //network send - object-instance
 #define PACK_ASSET_ARRAY(netconn, name, index)\
@@ -310,8 +381,11 @@ if (m##name##AssetId[index] != StringTable->EmptyString())\
       NetStringHandle assetIdStr = m##name##Asset[index].getAssetId();\
       netconn->packNetStringHandleU(stream, assetIdStr);\
    }\
-   else\
-      stream->writeString(m##name##Name[index]);
+   else if (stream->writeFlag(m##name##Name[index] != StringTable->EmptyString()))\
+   {\
+      NetStringHandle fileStr = m##name##Name[index].getAssetId();\
+      netconn->packNetStringHandleU(stream, fileStr);\
+   }\
 
 //network recieve - object-instance
 #define UNPACK_ASSET_ARRAY(netconn, name, index)\
@@ -320,10 +394,14 @@ if (m##name##AssetId[index] != StringTable->EmptyString())\
       m##name##AssetId[index] = StringTable->insert(netconn->unpackNetStringHandleU(stream).getString());\
       _set##name(m##name##AssetId[index], index);\
    }\
+   else if (stream->readFlag())\
+   {\
+      m##name##Name[index] = StringTable->insert(netconn->unpackNetStringHandleU(stream).getString());\
+      _set##name(m##name##Name[index], index);\
+   }\
    else\
    {\
-      m##name##Name[index] = stream->readSTString();\
-      _set##name(m##name##Name[index], index);\
+      _set##name(StringTable->EmptyString(), index);\
    }
 
 //script methods for class.asset acces
@@ -363,8 +441,12 @@ DefineEngineMethod(className, set##name, bool, (const char* assetName, S32 index
       const char* enumString = castConsoleTypeToString(static_cast<enumType>(index));\
       Con::printf("pack: %s = %s",enumString, m##name##AssetId[index]);\
    }\
-   else\
-      stream->writeString(m##name##Name[index]);\
+   else if (stream->writeFlag(m##name##File[index] != StringTable->EmptyString()))\
+   {\
+      stream->writeString(m##name##File[index]);\
+      const char* enumString = castConsoleTypeToString(static_cast<enumType>(index));\
+      Con::printf("pack: %s = %s",enumString, m##name##File[index]);\
+   }\
 }
 //network recieve - object-instance
 #define UNPACKDATA_ASSET_ARRAY_ENUMED(name, enumType, index )\
@@ -376,10 +458,16 @@ DefineEngineMethod(className, set##name, bool, (const char* assetName, S32 index
       const char* enumString = castConsoleTypeToString(static_cast<enumType>(index));\
       Con::printf("unpack: %s = %s",enumString, m##name##AssetId[index]);\
    }\
+   else if (stream->readFlag())\
+   {\
+      m##name##File[index] = stream->readSTString();\
+      _set##name(m##name##File[index], index);\
+      const char* enumString = castConsoleTypeToString(static_cast<enumType>(index));\
+      Con::printf("unpack: %s = %s",enumString, m##name##AssetId[index]);\
+   }\
    else\
    {\
-      m##name##Name[index] = stream->readSTString();\
-      _set##name(m##name##AssetId[index], index);\
+      _set##name(StringTable->EmptyString(), index);\
    }\
 }
 

--- a/Engine/source/T3D/assets/stateMachineAsset.cpp
+++ b/Engine/source/T3D/assets/stateMachineAsset.cpp
@@ -184,10 +184,19 @@ GuiControl* GuiInspectorTypeStateMachineAssetPtr::constructEditControl()
    if (retCtrl == NULL)
       return retCtrl;
 
+   StringBuilder varNameStr;
+   varNameStr.append(mCaption);
+   if (mFieldArrayIndex != nullptr)
+   {
+      varNameStr.append("[");
+      varNameStr.append(mFieldArrayIndex);
+      varNameStr.append("]");
+   }
+
    // Change filespec
    char szBuffer[512];
-   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"StateMachineAsset\", \"AssetBrowser.changeAsset\", %d, %s);",
-      mInspector->getIdString(), mCaption);
+   dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"StateMachineAsset\", \"AssetBrowser.changeAsset\", %d, \"%s\");",
+      mInspector->getIdString(), varNameStr.end().c_str());
    mBrowseButton->setField("Command", szBuffer);
 
    // Create "Open in ShapeEditor" button

--- a/Engine/source/T3D/fx/groundCover.cpp
+++ b/Engine/source/T3D/fx/groundCover.cpp
@@ -510,7 +510,12 @@ GroundCover::GroundCover()
       mMinElevation[i] = -99999.0f;
       mMaxElevation[i] = 99999.0f;
 
-      mLayer[i] = StringTable->EmptyString();
+      mLayerAsset[i] = nullptr;
+      mLayerFile[i] = StringTable->EmptyString();
+
+      mShapeAsset[i] = nullptr;
+      mShapeFile[i] = StringTable->EmptyString();
+
       mInvertLayer[i] = false;
 
       mMinClumpCount[i] = 1;
@@ -565,7 +570,10 @@ void GroundCover::initPersistFields()
 
          INITPERSISTFIELD_SHAPEASSET_ARRAY_REFACTOR(Shape, MAX_COVERTYPES, GroundCover, "The cover shape. [Optional]");
 
-         addField( "layer",         TypeTerrainMaterialAssetId, Offset( mLayer, GroundCover ), MAX_COVERTYPES,      "Terrain material assetId to limit coverage to, or blank to not limit." );
+         INITPERSISTFIELD_TERRAINMATERIALASSET_ARRAY(Layer, MAX_COVERTYPES, GroundCover, "Terrain material assetId to limit coverage to, or blank to not limit.");
+
+         //Legacy field
+         addProtectedField("layer", TypeTerrainMaterialAssetPtr, Offset(mLayerAsset, GroundCover), &_setLayerData, &defaultProtectedGetFn, MAX_COVERTYPES, "Terrain material assetId to limit coverage to, or blank to not limit.", AbstractClassRep::FIELD_HideInInspectors); 
 
          addField( "invertLayer",   TypeBool,      Offset( mInvertLayer, GroundCover ), MAX_COVERTYPES,     "Indicates that the terrain material index given in 'layer' is an exclusion mask." );
 
@@ -754,7 +762,6 @@ U32 GroundCover::packUpdate( NetConnection *connection, U32 mask, BitStream *str
          stream->write( mMinElevation[i] );
          stream->write( mMaxElevation[i] );     
 
-         stream->writeString( mLayer[i] );
          stream->writeFlag( mInvertLayer[i] );      
 
          stream->write( mMinClumpCount[i] );
@@ -768,6 +775,7 @@ U32 GroundCover::packUpdate( NetConnection *connection, U32 mask, BitStream *str
          stream->write( mBillboardRects[i].extent.y );
       }
 
+      PACK_ASSET_ARRAY_REFACTOR(connection, Layer, MAX_COVERTYPES)
       PACK_ASSET_ARRAY_REFACTOR(connection, Shape, MAX_COVERTYPES)
 
       stream->writeFlag( mDebugRenderCells );
@@ -825,7 +833,6 @@ void GroundCover::unpackUpdate( NetConnection *connection, BitStream *stream )
          stream->read( &mMinElevation[i] );
          stream->read( &mMaxElevation[i] );     
 
-         mLayer[i] = stream->readSTString();
          mInvertLayer[i] = stream->readFlag();
 
          stream->read( &mMinClumpCount[i] );
@@ -838,6 +845,8 @@ void GroundCover::unpackUpdate( NetConnection *connection, BitStream *stream )
          stream->read( &mBillboardRects[i].extent.x );
          stream->read( &mBillboardRects[i].extent.y );
       }
+
+      UNPACK_ASSET_ARRAY_REFACTOR(connection, Layer, MAX_COVERTYPES)
 
       UNPACK_ASSET_ARRAY_REFACTOR(connection, Shape, MAX_COVERTYPES)
 
@@ -1181,7 +1190,9 @@ GroundCoverCell* GroundCover::_generateCell( const Point2I& index,
       const Box3F typeShapeBounds = typeIsShape ? mShapeInstances[ type ]->getShape()->mBounds : Box3F();
       const F32 typeWindScale = mWindScale[type];
 
-      StringTableEntry typeLayer = mLayer[type];
+      StringTableEntry typeLayer = StringTable->EmptyString();
+      if (mLayerAsset[type].notNull())
+         typeLayer = mLayerAsset[type]->getAssetId();
       const bool typeInvertLayer = mInvertLayer[type];
 
       // We can set this once here... all the placements for this are the same.

--- a/Engine/source/T3D/fx/groundCover.h
+++ b/Engine/source/T3D/fx/groundCover.h
@@ -44,8 +44,12 @@
 #ifndef _SHADERFEATURE_H_
 #include "shaderGen/shaderFeature.h"
 #endif
-
+#ifndef SHAPE_ASSET_H
 #include "T3D/assets/ShapeAsset.h"
+#endif
+#ifndef TERRAINMATERIALASSET_H
+#include "T3D/assets/TerrainMaterialAsset.h"
+#endif
 
 class TerrainBlock;
 class GroundCoverCell;
@@ -315,8 +319,8 @@ protected:
 
    /// Terrain material assetId to limit coverage to, or
    /// left empty to cover entire terrain.
-   StringTableEntry mLayer[MAX_COVERTYPES];
-
+   DECLARE_TERRAINMATERIALASSET_NET_ARRAY(GroundCover, Layer, MAX_COVERTYPES, -1)
+   
    /// Inverts the data layer test making the 
    /// layer an exclusion mask.
    bool mInvertLayer[MAX_COVERTYPES];

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetBrowser.tscript
@@ -1183,7 +1183,7 @@ function AssetBrowser::changeAsset(%this)
       if(%inspectorObject.getNumInspectObjects() != 0)
       {
          %targetObject = %inspectorObject.getInspectObject();
-         %inspectorObject.setObjectField(%this.fieldTargetName, %this.selectedAsset);
+         %cmd = %targetObject @ "." @ %this.fieldTargetName @ "=\"" @ %this.selectedAsset @ "\";";
       }
       else if(startsWith(%this.fieldTargetName, "$"))
       {


### PR DESCRIPTION
- Updates TerrainMaterialAsset to utilize similar macros to everything else
- Updates groundCover to utilize TerrainMaterialAsset macros in place of straight StringTableEntry for type layers Fixes formatting for several asset types' inspector fields so they correctly call down into prompting the AssetBrowser being shown with correct field naming, thus allowing fields that are arrays to have the right index when setting the target variable 
- Updates several asset helper macros to handle blank values for network traffic to actually be sent to client, thus allowing setting an asset to blank on the client, rather than only falling back