### PR TITLE
Skurpz/controls menu fixes

### DIFF
--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
@@ -583,7 +583,7 @@ function OptionsMenu::populateAudioSettings(%this)
 
 function OptionsMenu::populateKBMControls(%this)
 {
-   %this.populateKeybinds("keyboard", KBMControlsList);
+   %this.populateKeybinds("keyboard" TAB "mouse", KBMControlsList); 
    
    %this.syncGui();
    
@@ -599,7 +599,7 @@ function OptionsMenu::populateGamepadControls(%this)
    GamepadControlsList.syncGui();
 }
 
-function OptionsMenu::populateKeybinds(%this, %device, %controlsList)
+function OptionsMenu::populateKeybinds(%this, %devices, %controlsList)
 {
 	%controlsList.clear();
 
@@ -662,21 +662,30 @@ function OptionsMenu::populateKeybinds(%this, %device, %controlsList)
       
       for ( %i = 0; %i < $RemapCount; %i++ )
       {
-         if(%device !$= "" && %device !$= $RemapDevice[%i])
+        %entryDevice = "";
+         //Check each field of %devices for device matching the remappable action
+         foreach$(%d in %devices){
+            if(%d $= $RemapDevice[%i]) {
+               %entryDevice = %d;
+               break;
+            }
+         }
+         //If there was no match go to the next remappable action
+         if(%entryDevice $= "")
             continue;
-            
-         %actionMapName = $RemapActionMap[%i].humanReadableName $= "" ? $RemapActionMap[%i].getName() : $RemapActionMap[%i].humanReadableName; 
-            
+
+         %actionMapName = $RemapActionMap[%i].humanReadableName $= "" ? $RemapActionMap[%i].getName() : $RemapActionMap[%i].humanReadableName;
+
          if(%currentActionMap !$= %actionMapName)
             continue;
-            
-         %keyMap = buildFullMapString( %i, $RemapActionMap[%i], %device );
+
+         %keyMap = buildFullMapString( %i, $RemapActionMap[%i], %entryDevice );
 
          %description = $RemapDescription[%i];
-         if ($reportKeymapping)
-            echo("Added ActionMap Entry: " @ %actionMapName @ " | " @ %device @ " | " @ %keymap @ " | " @ %description);
-         
-         %remapEntry = addActionMapEntry(%actionMapName, %device, %keyMap, %i, %description);
+
+         echo("Added ActionMap Entry: " @ %actionMapName @ " | " @ %entryDevice @ " | " @ %keymap @ " | " @ %description);
+
+         %remapEntry = addActionMapEntry(%actionMapName, %entryDevice, %keyMap, %i, %description);
          %controlsList.add(%remapEntry);
       }
    }

--- a/Templates/BaseGame/game/data/UI/scripts/controlsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/controlsMenu.tscript
@@ -126,85 +126,6 @@ function buildFullMapString( %index, %actionMap, %deviceType )
    return %name TAB %mapString; 
 }
 
-function fillRemapList()
-{
-   %device = $remapListDevice;
-   
-	OptionsMenuSettingsList.clear();
-
-   //build out our list of action maps
-   %actionMapCount = ActionMapGroup.getCount();
-   
-   %actionMapList = "";
-   for(%i=0; %i < %actionMapCount; %i++)
-   {
-      %actionMap = ActionMapGroup.getObject(%i);
-      
-      if(%actionMap == GlobalActionMap.getId())
-         continue;
-      
-      %actionMapName = %actionMap.humanReadableName $= "" ? %actionMap.getName() : %actionMap.humanReadableName;
-      
-      //see if we have any actual listed remappable keys for this movemap. if so, drop it from the listing
-      %hasRemaps = false;
-      for ( %r = 0; %r < $RemapCount; %r++ )
-      {
-         %testMapName = $RemapActionMap[%r].humanReadableName $= "" ? $RemapActionMap[%r].getName() : $RemapActionMap[%r].humanReadableName; 
-         
-         if(%actionMapName $= %testMapName)
-         {
-            //got a match to at least one, so we're ok to continue
-            %hasRemaps = true;
-            break;  
-         }
-      }
-      
-      if(!%hasRemaps)
-         continue;
-      
-      if(%actionMapList $= "")
-         %actionMapList = %actionMapName;
-      else
-         %actionMapList = %actionMapList TAB %actionMapName;
-   }
-   
-   //If we didn't find any valid actionMaps, then just exit out
-   if(%actionMapList $= "")
-      return;
-      
-   if($activeRemapControlSet $= "")
-      $activeRemapControlSet = getField(%actionMapList, 0);
-   
-   OptionsMenuSettingsList.addOptionRow("Control Set", "$activeRemapControlSet", %actionMapList, false, "controlSetChanged", true, "Which keybind control set to edit", $activeRemapControlSet);
-	
-   for ( %i = 0; %i < $RemapCount; %i++ )
-   {
-      if(%device !$= "" && %device !$= $RemapDevice[%i])
-         continue;
-         
-      %actionMapName = $RemapActionMap[%i].humanReadableName $= "" ? $RemapActionMap[%i].getName() : $RemapActionMap[%i].humanReadableName; 
-         
-      if($activeRemapControlSet !$= %actionMapName)
-         continue;
-         
-      %keyMap = buildFullMapString( %i, $RemapActionMap[%i], %device );
-      %description = $RemapDescription[%i];
-      
-      %buttonImageAsset = getButtonBitmap(%device, getField(%keyMap, 1));
-      
-      OptionsMenuSettingsList.addKeybindRow(getField(%keyMap, 0), %buttonImageAsset, "doKeyRemap", true, %description, %i);
-   }
-
-   //OptionsMenuSettingsList.refresh();
-      //OptionsMenu.addRow( %i, %this.buildFullMapString( %i ) );
-}
-
-function controlSetChanged()
-{
-   $activeRemapControlSet = OptionsMenuSettingsList.getObject(0).getCurrentOption();
-   fillRemapList();
-}
-
 function ControlsMenuRebindButton::onClick(%this)
 {
    %name = $RemapName[%this.keybindIndex];
@@ -231,5 +152,6 @@ function redoMapping( %device, %actionMap, %action, %cmd, %oldIndex, %newIndex )
 	//%actionMap.bind( %device, %action, $RemapCmd[%newIndex] );
 	%actionMap.bind( %device, %action, %cmd );
 	
-	fillRemapList();
+	OptionsMenu.populateKBMControls();
+   OptionsMenu.populateGamepadControls();
 }

--- a/Templates/BaseGame/game/data/UI/scripts/utility.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/utility.tscript
@@ -115,7 +115,10 @@ function getButtonBitmap(%device, %button)
    {
       if(%button $= "lshift" || %button $= "rshift")
          %button = "shift";
-         
+
+      if(%button $= "lcontrol" || %button $= "rcontrol")
+         %button = "ctrl";
+
       %assetId = "UI:Keyboard_Black_" @ %button @ "_image";
    }
    else if(%device !$= "")

--- a/Templates/BaseGame/game/data/UI/scripts/utility.tscript
+++ b/Templates/BaseGame/game/data/UI/scripts/utility.tscript
@@ -115,8 +115,7 @@ function getButtonBitmap(%device, %button)
    {
       if(%button $= "lshift" || %button $= "rshift")
          %button = "shift";
-
-      if(%button $= "lcontrol" || %button $= "rcontrol")
+      else if(%button $= "lcontrol" || %button $= "rcontrol")
          %button = "ctrl";
 
       %assetId = "UI:Keyboard_Black_" @ %button @ "_image";


### PR DESCRIPTION
Fixes:  
1. control key show the proper bitmap in the menu now.
2. Re-mappable binds with "mouse" as the device shows up in menu now.
3. Binds list refreshes properly after remapping an action to a key/button that is already being used now.



