### PR TITLE
simplified translucent opacity nudging

### DIFF
--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -3055,7 +3055,7 @@ void ReflectionProbeFeatGLSL::processPix(Vector<ShaderComponent*>& componentList
    Var *ibl = (Var *)LangElement::find("ibl");
    if (!ibl)
    {
-      ibl = new Var("ibl", "float3");
+      ibl = new Var("ibl", "float4");
    }
 
    Var* eyePos = (Var*)LangElement::find("eyePosWorld");
@@ -3086,7 +3086,7 @@ void ReflectionProbeFeatGLSL::processPix(Vector<ShaderComponent*>& componentList
    //Reflection vec
    String computeForwardProbes = String("   @ = computeForwardProbes(@,@,@,@,@,@,@,@,@,\r\n\t\t");
    computeForwardProbes += String("@,@,@,@,@,@,\r\n\t\t");
-   computeForwardProbes += String("@,@).rgb; \r\n");
+   computeForwardProbes += String("@,@); \r\n");
 
    meta->addStatement(new GenOp(computeForwardProbes.c_str(), new DecOp(ibl), surface, cubeMips, numProbes, worldToObjArray, probeConfigData, inProbePosArray, refScaleArray, inRefPosArray, eyePos,
       skylightCubemapIdx, SkylightDamp, BRDFTexture, WetnessTexture, accumTime, dampness,
@@ -3100,7 +3100,7 @@ void ReflectionProbeFeatGLSL::processPix(Vector<ShaderComponent*>& componentList
       ambient->constSortPos = cspPass;
    }
    meta->addStatement(new GenOp("   @.rgb *= @.rgb;\r\n", ibl, ambient));
-   meta->addStatement(new GenOp("   @.rgb = @.rgb;\r\n", curColor, ibl));
+   meta->addStatement(new GenOp("   @ = @;\r\n", curColor, ibl));
 
    output = meta;
 }

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -3143,7 +3143,7 @@ void ReflectionProbeFeatHLSL::processPix(Vector<ShaderComponent*> &componentList
    Var* ibl = (Var*)LangElement::find("ibl");
    if (!ibl)
    {
-      ibl = new Var("ibl", "float3");
+      ibl = new Var("ibl", "float4");
    }
 
    Var* eyePos = (Var*)LangElement::find("eyePosWorld");
@@ -3174,7 +3174,7 @@ void ReflectionProbeFeatHLSL::processPix(Vector<ShaderComponent*> &componentList
 
    String computeForwardProbes = String("   @ = computeForwardProbes(@,@,@,@,@,@,@,@,@,\r\n\t\t");
    computeForwardProbes += String("@,@,TORQUE_SAMPLER2D_MAKEARG(@),TORQUE_SAMPLER2D_MAKEARG(@), @, @,\r\n\t\t"); 
-   computeForwardProbes += String("TORQUE_SAMPLERCUBEARRAY_MAKEARG(@),TORQUE_SAMPLERCUBEARRAY_MAKEARG(@)).rgb; \r\n");
+   computeForwardProbes += String("TORQUE_SAMPLERCUBEARRAY_MAKEARG(@),TORQUE_SAMPLERCUBEARRAY_MAKEARG(@)); \r\n");
       
    meta->addStatement(new GenOp(computeForwardProbes.c_str(), new DecOp(ibl), surface, cubeMips, numProbes, worldToObjArray, probeConfigData, inProbePosArray, refScaleArray, inRefPosArray, eyePos,
       skylightCubemapIdx, SkylightDamp, BRDFTexture, WetnessTexture, accumTime, dampness,
@@ -3188,7 +3188,7 @@ void ReflectionProbeFeatHLSL::processPix(Vector<ShaderComponent*> &componentList
       ambient->constSortPos = cspPass;
    }
    meta->addStatement(new GenOp("   @.rgb *= @.rgb;\r\n", ibl, ambient));
-   meta->addStatement(new GenOp("   @.rgb = @.rgb;\r\n", curColor, ibl));
+   meta->addStatement(new GenOp("   @ = @;\r\n", curColor, ibl));
 
    output = meta;
 }

--- a/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/gl/lighting.glsl
@@ -608,7 +608,8 @@ vec4 computeForwardProbes(Surface surface,
       return vec4(lerp((finalColor), surface.baseColor.rgb,surface.metalness),0);
    else
    {
-      return vec4(finalColor, 0);
+      float reflectionOpacity = min(surface.baseColor.a+surface.baseColor.a*length(finalColor),1.0);
+      return vec4(finalColor, reflectionOpacity);
    }
 }
 

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting.hlsl
@@ -613,7 +613,8 @@ float4 computeForwardProbes(Surface surface,
       return float4(lerp((finalColor), surface.baseColor.rgb,surface.metalness),0);
    else
    {
-      return float4(finalColor, 0);
+      float reflectionOpacity = min(surface.baseColor.a+surface.baseColor.a*length(finalColor),1.0);
+      return float4(finalColor, reflectionOpacity);
    }
 }
 


### PR DESCRIPTION
the basic articulable principle is the thicker and less translucent a given object is, the more it mimics standard solid objects. the more transparent, the less light bounces back since it continues on uninterrupted, casuing less backscatter.