### PR TITLE
trip onadd in additional places

### DIFF
--- a/Engine/source/T3D/gameBase/gameBase.cpp
+++ b/Engine/source/T3D/gameBase/gameBase.cpp
@@ -125,6 +125,11 @@ IMPLEMENT_CALLBACK( GameBase, setControl, void, ( bool controlled ), ( controlle
    "client controls this object.\n" );
 
 
+IMPLEMENT_CALLBACK(GameBase, onAdd, void, (SimObjectId ID), (ID),
+   "Called when this ScriptObject is added to the system.\n"
+   "@param ID Unique object ID assigned when created (%this in script).\n"
+);
+
 GameBaseData::GameBaseData()
 {
    mCategory = StringTable->EmptyString();
@@ -518,6 +523,7 @@ void GameBase::scriptOnAdd()
    // everything is ready.
    if (mDataBlock && !isGhost())
       mDataBlock->onAdd_callback( this );
+   onAdd_callback(getId());
 }
 
 void GameBase::scriptOnNewDataBlock(bool reload)

--- a/Engine/source/T3D/gameBase/gameBase.h
+++ b/Engine/source/T3D/gameBase/gameBase.h
@@ -469,6 +469,8 @@ private:
    void _onDatablockModified();
 protected:
    void    onScopeIdChange() override { setMaskBits(ScopeIdMask); }
+
+   DECLARE_CALLBACK(void, onAdd, (SimObjectId ID));
 };
 
 

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -88,6 +88,16 @@ EndImplementBitfieldType;
 
 IMPLEMENT_CONOBJECT( SimObject );
 
+IMPLEMENT_CALLBACK(SimObject, onAdd, void, (SimObjectId ID), (ID),
+   "Called when this SimObject is added to the system, if the className is set to something\n"
+   "@param ID Unique object ID assigned when created (%this in script).\n"
+);
+
+IMPLEMENT_CALLBACK(SimObject, onRemove, void, (SimObjectId ID), (ID),
+   "Called when this SimObject is removed from the system, if the className is set to something\n"
+   "@param ID Unique object ID assigned when created (%this in script).\n"
+);
+
 // See full description in the new CHM manual
 ConsoleDocClass( SimObject,
    "@brief Base class for almost all objects involved in the simulation.\n\n"
@@ -1689,6 +1699,8 @@ bool SimObject::onAdd()
 
    linkNamespaces();
 
+   onAdd_callback(getId());
+
    return true;
 }
 
@@ -1697,6 +1709,8 @@ bool SimObject::onAdd()
 void SimObject::onRemove()
 {
    mFlags.clear(Added);
+
+   onRemove_callback(getId());
 
    unlinkNamespaces();
 }

--- a/Engine/source/console/simObject.h
+++ b/Engine/source/console/simObject.h
@@ -987,6 +987,9 @@ class SimObject: public ConsoleObject, public TamlCallbacks
       DECLARE_CALLBACK(void, onInspectPostApply, (SimObject* obj));
       DECLARE_CALLBACK(void, onSelected, (SimObject* obj));
       DECLARE_CALLBACK(void, onUnselected, (SimObject* obj));
+
+      DECLARE_CALLBACK(void, onAdd, (SimObjectId ID));
+      DECLARE_CALLBACK(void, onRemove, (SimObjectId ID));
       
       static SimObject* __findObject( const char* id ) { return Sim::findObject( id ); }
       static const char* __getObjectId( ConsoleObject* object )


### PR DESCRIPTION
by request,
adds a per object-instance onadd for datablocks if an object instance *also* defines a class. be mindful not to mix up which namespace is in use there, as you can not tag two different core class instances the same scripted class. implements the same with the same restrictions for simobjects in general