### PR TITLE
dial back nullPtr usage

### DIFF
--- a/Engine/source/T3D/Scene.cpp
+++ b/Engine/source/T3D/Scene.cpp
@@ -3,7 +3,7 @@
 #include "T3D/gameBase/gameConnection.h"
 #include "T3D/gameMode.h"
 
-Scene * Scene::smRootScene = nullptr;
+Scene * Scene::smRootScene = NULL;
 Vector<Scene*> Scene::smSceneList;
 
 IMPLEMENT_CALLBACK(Scene, onSaving, void, (const char* fileName), (fileName),
@@ -14,7 +14,7 @@ IMPLEMENT_CALLBACK(Scene, onSaving, void, (const char* fileName), (fileName),
 IMPLEMENT_CO_NETOBJECT_V1(Scene);
 
 Scene::Scene() : 
-   mParentScene(nullptr),
+   mParentScene(NULL),
    mSceneId(-1),
    mIsEditing(false),
    mIsDirty(false),
@@ -197,12 +197,12 @@ void Scene::processTick()
          if (gc)
          {
             GameBase* controlObj = gc->getControlObject();
-            if (controlObj == nullptr)
+            if (controlObj == NULL)
             {
                controlObj = gc->getCameraObject();
             }
 
-            if (mSubScenes[i]->testBox(controlObj != nullptr ? controlObj->getWorldBox() : Box3F::Zero))
+            if (mSubScenes[i]->testBox(controlObj != NULL ? controlObj->getWorldBox() : Box3F::Zero))
                {
                   //we have a client controlling object in the bounds, so we ensure the contents are loaded
                   hasClients = true;
@@ -430,7 +430,7 @@ DefineEngineFunction(getScene, Scene*, (U32 sceneId), (0),
    "@return The id of the Root Scene. Will be 0 if no root scene is loaded")
 {
    if (Scene::smSceneList.empty() || sceneId >= Scene::smSceneList.size())
-      return nullptr;
+      return NULL;
 
    return Scene::smSceneList[sceneId];
 }
@@ -502,12 +502,12 @@ DefineEngineMethod(Scene, getObjectsByClass, String, (String className, bool che
    U32 len = 0;
    S32 i;
    //Get the length of our return string
-   for(U32 i=0; i < objectsList->size(); i++)
+   for(i=0; i < objectsList->size(); i++)
       len += dStrlen((*objectsList)[i]->getIdString());
 
    char* ret = Con::getReturnBuffer(len + 1);
    ret[0] = 0;
-   for (U32 i = 0; i < objectsList->size(); i++)
+   for (i = 0; i < objectsList->size(); i++)
    {
       dStrcat(ret, (*objectsList)[i]->getIdString(), len + 1);
       dStrcat(ret, " ", len + 1);

--- a/Engine/source/T3D/Scene.h
+++ b/Engine/source/T3D/Scene.h
@@ -98,7 +98,7 @@ public:
    static Scene *getRootScene() 
    { 
       if (Scene::smSceneList.empty())
-         return nullptr;
+         return NULL;
 
       return Scene::smSceneList[0];
    }

--- a/Engine/source/T3D/assets/CubemapAsset.cpp
+++ b/Engine/source/T3D/assets/CubemapAsset.cpp
@@ -200,7 +200,7 @@ GuiControl* GuiInspectorTypeCubemapAssetPtr::constructEditControl()
 
    StringBuilder varNameStr;
    varNameStr.append(mCaption);
-   if (mFieldArrayIndex != nullptr)
+   if (mFieldArrayIndex != NULL)
    {
       varNameStr.append("[");
       varNameStr.append(mFieldArrayIndex);

--- a/Engine/source/T3D/assets/GUIAsset.cpp
+++ b/Engine/source/T3D/assets/GUIAsset.cpp
@@ -264,7 +264,7 @@ GuiControl* GuiInspectorTypeGUIAssetPtr::constructEditControl()
 
    StringBuilder varNameStr;
    varNameStr.append(mCaption);
-   if (mFieldArrayIndex != nullptr)
+   if (mFieldArrayIndex != NULL)
    {
       varNameStr.append("[");
       varNameStr.append(mFieldArrayIndex);

--- a/Engine/source/T3D/assets/GameObjectAsset.cpp
+++ b/Engine/source/T3D/assets/GameObjectAsset.cpp
@@ -221,7 +221,7 @@ const char* GameObjectAsset::create()
    //Entity* e = dynamic_cast<Entity*>(pSimObject);
    //e->_setGameObject(getAssetId());
 
-   pSimObject->setDataField(StringTable->insert("GameObject"), nullptr, getAssetId());
+   pSimObject->setDataField(StringTable->insert("GameObject"), NULL, getAssetId());
 
    return pSimObject->getIdString();
 }

--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -501,7 +501,7 @@ GFXTexHandle ImageAsset::getTexture(GFXTextureProfile* requestedProfile)
          }
    }
 
-   return nullptr;
+   return NULL;
 }
 
 const char* ImageAsset::getImageTypeNameFromType(ImageAsset::ImageTypes type)
@@ -700,7 +700,7 @@ const char* ImageAsset::getImageInfo()
       if (newTex)
       {
          dSprintf(returnBuffer, bufSize, "%s %d %d %d", GFXStringTextureFormat[newTex->getFormat()], newTex->getHeight(), newTex->getWidth(), newTex->getDepth());
-         newTex = nullptr;
+         newTex = NULL;
       }
       else
       {
@@ -776,7 +776,7 @@ GuiControl* GuiInspectorTypeImageAssetPtr::constructEditControl()
 
    const char* previewImage;
 
-   if (mInspector->getInspectObject() != nullptr)
+   if (mInspector->getInspectObject() != NULL)
    {
       dSprintf(szBuffer, sizeof(szBuffer), "AssetBrowser.showDialog(\"ImageAsset\", \"AssetBrowser.changeAsset\", %s);",
          getIdString());
@@ -810,7 +810,7 @@ GuiControl* GuiInspectorTypeImageAssetPtr::constructEditControl()
 
    editTextCtrl->setPlaceholderText("(None)");
 
-   GuiControlProfile* toolDefaultProfile = nullptr;
+   GuiControlProfile* toolDefaultProfile = NULL;
    Sim::findObject("ToolsGuiDefaultProfile", toolDefaultProfile);
 
    //
@@ -840,7 +840,7 @@ GuiControl* GuiInspectorTypeImageAssetPtr::constructEditControl()
    // Create "Open in Editor" button
    mEditButton = new GuiBitmapButtonCtrl();
 
-   if (mInspector->getInspectObject() != nullptr)
+   if (mInspector->getInspectObject() != NULL)
       dSprintf(szBuffer, sizeof(szBuffer), "%d.apply(\"\");", getId());
    else
       dSprintf(szBuffer, sizeof(szBuffer), "%s = \"\";", mVariableName);
@@ -973,7 +973,7 @@ void GuiInspectorTypeImageAssetPtr::updateValue()
 void GuiInspectorTypeImageAssetPtr::updatePreviewImage()
 {
    const char* previewImage;
-   if (mInspector->getInspectObject() != nullptr)
+   if (mInspector->getInspectObject() != NULL)
       previewImage = getData();
    else
       previewImage = Con::getVariable(mVariableName);

--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -134,7 +134,7 @@ MaterialAsset::MaterialAsset()
    mScriptFile = StringTable->EmptyString();
    mScriptPath = StringTable->EmptyString();
    mMatDefinitionName = StringTable->EmptyString();
-   mMaterialDefinition = nullptr;
+   mMaterialDefinition = NULL;
 }
 
 //-----------------------------------------------------------------------------
@@ -419,7 +419,7 @@ SimObjectPtr<Material> MaterialAsset::findMaterialDefinitionByAssetId(StringTabl
       SimObjectPtr<Material> matDef = dynamic_cast<Material*>(matSet->findObjectByInternalName(assetId));
       return matDef;
    }
-   return nullptr;
+   return NULL;
 }
 
 #ifdef TORQUE_TOOLS
@@ -482,11 +482,11 @@ GuiControl* GuiInspectorTypeMaterialAssetPtr::constructEditControl()
 
    const char* previewImage;
 
-   if (mInspector->getInspectObject() != nullptr)
+   if (mInspector->getInspectObject() != NULL)
    {
       StringBuilder varNameStr;
       varNameStr.append(mCaption);
-      if (mFieldArrayIndex != nullptr)
+      if (mFieldArrayIndex != NULL)
       {
          varNameStr.append("[");
          varNameStr.append(mFieldArrayIndex);
@@ -523,7 +523,7 @@ GuiControl* GuiInspectorTypeMaterialAssetPtr::constructEditControl()
    if (Sim::findObject("ToolsGuiTextEditProfile", toolEditProfile))
       editTextCtrl->setControlProfile(toolEditProfile);
 
-   GuiControlProfile* toolDefaultProfile = nullptr;
+   GuiControlProfile* toolDefaultProfile = NULL;
    Sim::findObject("ToolsGuiDefaultProfile", toolDefaultProfile);
 
    //
@@ -609,7 +609,7 @@ void GuiInspectorTypeMaterialAssetPtr::updateValue()
 void GuiInspectorTypeMaterialAssetPtr::updatePreviewImage()
 {
    const char* matAssetId;
-   if (mInspector->getInspectObject() != nullptr)
+   if (mInspector->getInspectObject() != NULL)
       matAssetId = mInspector->getInspectObject()->getDataField(mCaption, NULL);
    else
       matAssetId = Con::getVariable(mVariableName);

--- a/Engine/source/T3D/assets/MaterialAsset.h
+++ b/Engine/source/T3D/assets/MaterialAsset.h
@@ -244,7 +244,7 @@ public: \
          if (m##name && String(m##name##Asset->getMaterialDefinitionName()).equal(m##name->getName(), String::NoCase))\
             return false;\
          \
-         Material* tempMat = nullptr;\
+         Material* tempMat = NULL;\
          \
          if (!Sim::findObject(m##name##Asset->getMaterialDefinitionName(), tempMat))\
             Con::errorf("%s::_set%s() - Material %s was not found.", macroText(className), macroText(name), m##name##Asset->getMaterialDefinitionName());\

--- a/Engine/source/T3D/assets/ParticleAsset.cpp
+++ b/Engine/source/T3D/assets/ParticleAsset.cpp
@@ -152,7 +152,7 @@ GuiControl* GuiInspectorTypeParticleAssetPtr::constructEditControl()
 
    StringBuilder varNameStr;
    varNameStr.append(mCaption);
-   if (mFieldArrayIndex != nullptr)
+   if (mFieldArrayIndex != NULL)
    {
       varNameStr.append("[");
       varNameStr.append(mFieldArrayIndex);

--- a/Engine/source/T3D/assets/ShapeAnimationAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAnimationAsset.cpp
@@ -200,7 +200,7 @@ void ShapeAnimationAsset::setAnimationFile(const char* pAnimationFile)
 
 S32 ShapeAnimationAsset::getAnimationCount()
 { 
-   if (mSourceShape == nullptr)
+   if (mSourceShape == NULL)
       return 0;
 
    return mSourceShape->sequences.size(); 

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -636,7 +636,7 @@ ShapeAnimationAsset* ShapeAsset::getAnimation(S32 index)
       return mAnimationAssets[index];
    }
 
-   return nullptr;
+   return NULL;
 }
 
 #ifdef TORQUE_TOOLS
@@ -805,11 +805,11 @@ GuiControl* GuiInspectorTypeShapeAssetPtr::constructEditControl()
 
    const char* previewImage;
 
-   if (mInspector->getInspectObject() != nullptr)
+   if (mInspector->getInspectObject() != NULL)
    {
       StringBuilder varNameStr;
       varNameStr.append(mCaption);
-      if (mFieldArrayIndex != nullptr)
+      if (mFieldArrayIndex != NULL)
       {
          varNameStr.append("[");
          varNameStr.append(mFieldArrayIndex);
@@ -846,7 +846,7 @@ GuiControl* GuiInspectorTypeShapeAssetPtr::constructEditControl()
    if (Sim::findObject("ToolsGuiTextEditProfile", toolEditProfile))
       editTextCtrl->setControlProfile(toolEditProfile);
 
-   GuiControlProfile* toolDefaultProfile = nullptr;
+   GuiControlProfile* toolDefaultProfile = NULL;
    Sim::findObject("ToolsGuiDefaultProfile", toolDefaultProfile);
 
    //
@@ -932,7 +932,7 @@ void GuiInspectorTypeShapeAssetPtr::updateValue()
 void GuiInspectorTypeShapeAssetPtr::updatePreviewImage()
 {
    const char* previewImage;
-   if (mInspector->getInspectObject() != nullptr)
+   if (mInspector->getInspectObject() != NULL)
       previewImage = mInspector->getInspectObject()->getDataField(mCaption, NULL);
    else
       previewImage = Con::getVariable(mVariableName);

--- a/Engine/source/T3D/assets/ShapeAsset.h
+++ b/Engine/source/T3D/assets/ShapeAsset.h
@@ -135,7 +135,7 @@ public:
    inline AssetPtr<MaterialAsset> getMaterialAsset(U32 matId)
    {
       if (matId >= mMaterialAssets.size())
-         return nullptr;
+         return NULL;
       else
          return mMaterialAssets[matId];
    }

--- a/Engine/source/T3D/assets/TerrainAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainAsset.cpp
@@ -475,7 +475,7 @@ GuiControl* GuiInspectorTypeTerrainAssetPtr::constructEditControl()
 
    StringBuilder varNameStr;
    varNameStr.append(mCaption);
-   if (mFieldArrayIndex != nullptr)
+   if (mFieldArrayIndex != NULL)
    {
       varNameStr.append("[");
       varNameStr.append(mFieldArrayIndex);

--- a/Engine/source/T3D/assets/TerrainMaterialAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainMaterialAsset.cpp
@@ -129,8 +129,8 @@ TerrainMaterialAsset::TerrainMaterialAsset()
    mScriptFile = StringTable->EmptyString();
    mScriptPath = StringTable->EmptyString();
    mMatDefinitionName = StringTable->EmptyString();
-   mMaterialDefinition = nullptr;
-   mFXMaterialDefinition = nullptr;
+   mMaterialDefinition = NULL;
+   mFXMaterialDefinition = NULL;
 }
 
 //-----------------------------------------------------------------------------
@@ -432,7 +432,7 @@ SimObjectPtr<TerrainMaterial> TerrainMaterialAsset::findMaterialDefinitionByAsse
    SimSet* terrainMatSet;
    if (!Sim::findObject("TerrainMaterialSet", terrainMatSet))
    {
-      return nullptr;
+      return NULL;
    }
 
    SimObjectPtr<TerrainMaterial> matDef = dynamic_cast<TerrainMaterial*>(terrainMatSet->findObjectByInternalName(assetId));
@@ -516,7 +516,7 @@ GuiControl* GuiInspectorTypeTerrainMaterialAssetPtr::constructEditControl()
 
    StringBuilder varNameStr;
    varNameStr.append(mCaption);
-   if (mFieldArrayIndex != nullptr)
+   if (mFieldArrayIndex != NULL)
    {
       varNameStr.append("[");
       varNameStr.append(mFieldArrayIndex);

--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -441,10 +441,10 @@ AssetImportObject::AssetImportObject() :
    dirty(false),
    importStatus(AssetImportObject::NotProcessed),
    generatedAsset(false),
-   parentAssetItem(nullptr),
+   parentAssetItem(NULL),
    tamlFilePath(""),
    imageSuffixType(""),
-   shapeInfo(nullptr),
+   shapeInfo(NULL),
    filePathString(StringTable->EmptyString())
 {
 
@@ -520,7 +520,7 @@ AssetImporter::AssetImporter() :
    isReimport(false),
    assetHeirarchyChanged(false),
    importLogBuffer(""),
-   activeImportConfig(nullptr),
+   activeImportConfig(NULL),
    mDumpLogs(true)
 {
 }
@@ -565,10 +565,10 @@ AssetImportObject* AssetImporter::addImportingFile(Torque::Path filePath)
    {
       dSprintf(importLogBuffer, sizeof(importLogBuffer), "Unable to import file %s because it is of an unrecognized/unsupported type.", filePath.getFullPath().c_str());
       activityLog.push_back(importLogBuffer);
-      return nullptr;
+      return NULL;
    }
 
-   AssetImportObject* newAssetItem = addImportingAsset(assetType, filePath, nullptr, "");
+   AssetImportObject* newAssetItem = addImportingAsset(assetType, filePath, NULL, "");
 
    originalImportingFiles.push_back(filePath);
 
@@ -577,14 +577,14 @@ AssetImportObject* AssetImporter::addImportingFile(Torque::Path filePath)
 
 void AssetImporter::addImportingAssetItem(AssetImportObject* assetItem, AssetImportObject* parentItem)
 {
-   if (assetItem == nullptr)
+   if (assetItem == NULL)
    {
       dSprintf(importLogBuffer, sizeof(importLogBuffer), "Cannot add a null AssetImportObject to import session!");
       activityLog.push_back(importLogBuffer);
       return;
    }
 
-   if (parentItem != nullptr)
+   if (parentItem != NULL)
    {
       dSprintf(importLogBuffer, sizeof(importLogBuffer), "Added Child Importing Asset to %s", parentItem->assetName.c_str());
       activityLog.push_back(importLogBuffer);
@@ -675,7 +675,7 @@ AssetImportObject* AssetImporter::addImportingAsset(String assetType, Torque::Pa
       assetImportObj->cleanAssetName = assetName;
    }
 
-   if (parentItem != nullptr)
+   if (parentItem != NULL)
    {
       dSprintf(importLogBuffer, sizeof(importLogBuffer), "Added Child Importing Asset to %s", parentItem->assetName.c_str());
       activityLog.push_back(importLogBuffer);
@@ -715,7 +715,7 @@ void AssetImporter::deleteImportingAsset(AssetImportObject* assetItem)
 AssetImportObject* AssetImporter::findImportingAssetByName(String assetName, AssetImportObject* assetItem)
 {
    Vector<AssetImportObject*> itemList = importingAssets;
-   if (assetItem != nullptr)
+   if (assetItem != NULL)
       itemList = assetItem->childAssetItems;
 
    for (U32 i = 0; i < itemList.size(); i++)
@@ -727,11 +727,11 @@ AssetImportObject* AssetImporter::findImportingAssetByName(String assetName, Ass
 
       //If it wasn't a match, try recusing on the children(if any)
       AssetImportObject* retItem = findImportingAssetByName(assetName, itemList[i]);
-      if (retItem != nullptr)
+      if (retItem != NULL)
          return retItem;
    }
 
-   return nullptr;
+   return NULL;
 }
 
 ModuleDefinition* AssetImporter::getModuleFromPath(Torque::Path filePath)
@@ -1008,7 +1008,7 @@ S32 AssetImporter::getAssetItemCount()
 AssetImportObject* AssetImporter::getAssetItem(U32 index)
 {
    if (index >= importingAssets.size())
-      return nullptr;
+      return NULL;
 
    return importingAssets[index];
 }
@@ -1021,7 +1021,7 @@ S32 AssetImporter::getAssetItemChildCount(AssetImportObject* assetItem)
 AssetImportObject* AssetImporter::getAssetItemChild(AssetImportObject* assetItem, U32 index)
 {
    if (index >= assetItem->childAssetItems.size())
-      return nullptr;
+      return NULL;
 
    return assetItem->childAssetItems[index];
 }
@@ -1521,7 +1521,7 @@ void AssetImportConfig::loadSISFile(Torque::Path filePath)
 void AssetImporter::processImportAssets(AssetImportObject* assetItem)
 {
    Vector<AssetImportObject*> itemList = importingAssets;
-   if (assetItem != nullptr)
+   if (assetItem != NULL)
       itemList = assetItem->childAssetItems;
 
    assetHeirarchyChanged = false;
@@ -1584,7 +1584,7 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
    dSprintf(importLogBuffer, sizeof(importLogBuffer), "Preparing Image for Import: %s", assetItem->assetName.c_str());
    activityLog.push_back(importLogBuffer);
 
-   if ((activeImportConfig->GenerateMaterialOnImport && assetItem->parentAssetItem == nullptr)/* || assetItem->parentAssetItem != nullptr*/)
+   if ((activeImportConfig->GenerateMaterialOnImport && assetItem->parentAssetItem == NULL))
    {
       //find our suffix match, if any
       String noSuffixName = assetItem->assetName;
@@ -1601,27 +1601,27 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
       //We try to automatically populate materials under the naming convention: materialName: Rock, image maps: Rock_Albedo, Rock_Normal, etc
 
       AssetImportObject* materialAsset = findImportingAssetByName(noSuffixName);
-      if (materialAsset != nullptr && materialAsset->assetType != String("MaterialAsset"))
+      if (materialAsset != NULL && materialAsset->assetType != String("MaterialAsset"))
       {
          //We may have a situation where an asset matches the no-suffix name, but it's not a material asset. Ignore this
          //asset item for now
 
-         materialAsset = nullptr;
+         materialAsset = NULL;
       }
 
       //If we didn't find a matching material asset in our current items, we'll make one now
-      if (materialAsset == nullptr)
+      if (materialAsset == NULL)
       {
          if (!assetItem->filePath.isEmpty())
          {
-            materialAsset = addImportingAsset("MaterialAsset", assetItem->filePath, nullptr, noSuffixName);
+            materialAsset = addImportingAsset("MaterialAsset", assetItem->filePath, NULL, noSuffixName);
          }
       }
 
       //Not that, one way or another, we have the generated material asset, lets move on to associating our image with it
-      if (materialAsset != nullptr && materialAsset != assetItem->parentAssetItem)
+      if (materialAsset != NULL && materialAsset != assetItem->parentAssetItem)
       {
-         if (assetItem->parentAssetItem != nullptr)
+         if (assetItem->parentAssetItem != NULL)
          {
             //If the image had an existing parent, it gets removed from that parent's child item list
             assetItem->parentAssetItem->childAssetItems.remove(assetItem);
@@ -1673,7 +1673,7 @@ void AssetImporter::processImageAsset(AssetImportObject* assetItem)
    else
    {
       //If we're processing an unaffiliated image without generating materials for it, we can check some other bits
-      if (assetItem->parentAssetItem == nullptr)
+      if (assetItem->parentAssetItem == NULL)
       {
          if (assetItem->typeHint != String::EmptyString)
          {
@@ -1786,7 +1786,7 @@ void AssetImporter::processMaterialAsset(AssetImportObject* assetItem)
          dSprintf(importLogBuffer, sizeof(importLogBuffer), "Attempting to Auto-Populate Material Maps");
          activityLog.push_back(importLogBuffer);
 
-         AssetImportObject* matchedImageTypes[ImageAsset::ImageTypeCount] = { nullptr };
+         AssetImportObject* matchedImageTypes[ImageAsset::ImageTypeCount] = { NULL };
 
          String materialImageNoSuffix;
 
@@ -1946,7 +1946,7 @@ void AssetImporter::processMaterialAsset(AssetImportObject* assetItem)
                }
 
                //If we're the abledo slot and after all that we didn't find anything, it probably is a suffixless image
-               if (t == ImageAsset::Albedo && matchedImageTypes[t] == nullptr)
+               if (t == ImageAsset::Albedo && matchedImageTypes[t] == NULL)
                {
                   String testPath = assetItem->filePath.getRootAndPath() + "/" + assetItem->cleanAssetName;
                   String imagePath = AssetImporter::findImagePath(testPath);
@@ -1997,7 +1997,7 @@ void AssetImporter::processShapeAsset(AssetImportObject* assetItem)
    String fileName = assetItem->filePath.getFileName();
    String fileExt = assetItem->filePath.getExtension();
 
-   if (assetItem->shapeInfo == nullptr)
+   if (assetItem->shapeInfo == NULL)
    {
       GuiTreeViewCtrl* shapeInfo = new GuiTreeViewCtrl();
       shapeInfo->registerObject();
@@ -2028,11 +2028,11 @@ void AssetImporter::processShapeAsset(AssetImportObject* assetItem)
          assetItem->assetName += activeImportConfig->AddedShapeSuffix;
    }
 
-   S32 meshCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_meshCount"), nullptr));
+   S32 meshCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_meshCount"), NULL));
 
-   S32 animCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_animCount"), nullptr));
+   S32 animCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_animCount"), NULL));
 
-   S32 materialCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_materialCount"), nullptr));
+   S32 materialCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_materialCount"), NULL));
    S32 matItem = assetItem->shapeInfo->findItemByName("Materials");
 
    dSprintf(importLogBuffer, sizeof(importLogBuffer), "   Shape Info: Mesh Count: %i | Material Count: %i | Anim Count: %i", meshCount, animCount, materialCount);
@@ -2091,7 +2091,7 @@ void AssetImporter::processShapeAnimationAsset(AssetImportObject* assetItem)
    String fileName = assetItem->filePath.getFileName();
    String fileExt = assetItem->filePath.getExtension();
 
-   if (assetItem->shapeInfo == nullptr)
+   if (assetItem->shapeInfo == NULL)
    {
       GuiTreeViewCtrl* shapeInfo = new GuiTreeViewCtrl();
       shapeInfo->registerObject();
@@ -2122,7 +2122,7 @@ void AssetImporter::processShapeAnimationAsset(AssetImportObject* assetItem)
          assetItem->assetName += activeImportConfig->AddedShapeAnimationSuffix;
    }
 
-   S32 animCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_animCount"), nullptr));
+   S32 animCount = dAtoi(assetItem->shapeInfo->getDataField(StringTable->insert("_animCount"), NULL));
 
    dSprintf(importLogBuffer, sizeof(importLogBuffer), "   Shape Animation Info: Anim Count: %i", animCount);
    activityLog.push_back(importLogBuffer);
@@ -2177,7 +2177,7 @@ void AssetImporter::processShapeMaterialInfo(AssetImportObject* assetItem, S32 m
 
    String materialItemValue = assetItem->shapeInfo->getItemValue(materialItemId);
 
-   AssetImportObject* matAssetItem = nullptr;
+   AssetImportObject* matAssetItem = NULL;
 
    //If it happens to just be a color value instead of an image, we'll go ahead and skip doing any lookups
    //TODO: properly map the 'texture' color to the material that gets created
@@ -2377,7 +2377,7 @@ void AssetImporter::validateAsset(AssetImportObject* assetItem)
 void AssetImporter::resetAssetValidationStatus(AssetImportObject* assetItem)
 {
    Vector<AssetImportObject*> itemList = importingAssets;
-   if (assetItem != nullptr)
+   if (assetItem != NULL)
       itemList = assetItem->childAssetItems;
 
    for (U32 i = 0; i < itemList.size(); i++)
@@ -2399,7 +2399,7 @@ bool AssetImporter::checkAssetForCollision(AssetImportObject* assetItemToCheck, 
    bool results = false;
 
    Vector<AssetImportObject*> itemList = importingAssets;
-   if (assetItem != nullptr)
+   if (assetItem != NULL)
       itemList = assetItem->childAssetItems;
 
    for (U32 i = 0; i < itemList.size(); i++)
@@ -2450,7 +2450,7 @@ void AssetImporter::resolveAssetItemIssues(AssetImportObject* assetItem)
       if (activeImportConfig->DuplicateAutoResolution == String("AutoPrune"))
       {
          //delete the item
-         if (assetItem->parentAssetItem == nullptr)
+         if (assetItem->parentAssetItem == NULL)
          {
             //if there's no parent, just delete
             deleteImportingAsset(assetItem);
@@ -2559,7 +2559,7 @@ void AssetImporter::resolveAssetItemIssues(AssetImportObject* assetItem)
 void AssetImporter::resetImportConfig()
 {
    //use a default import config
-   if (activeImportConfig == nullptr)
+   if (activeImportConfig == NULL)
    {
       activeImportConfig = new AssetImportConfig();
       activeImportConfig->registerObject();
@@ -2615,7 +2615,7 @@ StringTableEntry AssetImporter::autoImportFile(Torque::Path filePath, String typ
    //Find out if the filepath has an associated module to it. If we're importing in-place, it needs to be within a module's directory
    ModuleDefinition* targetModuleDef = AssetImporter::getModuleFromPath(filePath);
 
-   if (targetModuleDef == nullptr)
+   if (targetModuleDef == NULL)
    {
       dSprintf(importLogBuffer, sizeof(importLogBuffer), "Unable to import file %s because it is not in a valid module folder.", filePath.getFullPath().c_str());
       activityLog.push_back(importLogBuffer);
@@ -2633,7 +2633,7 @@ StringTableEntry AssetImporter::autoImportFile(Torque::Path filePath, String typ
 
    resetImportConfig();
 
-   AssetImportObject* assetItem = addImportingAsset(assetType, filePath, nullptr, "");
+   AssetImportObject* assetItem = addImportingAsset(assetType, filePath, NULL, "");
 
    processImportAssets();
 
@@ -2672,7 +2672,7 @@ void AssetImporter::importAssets(AssetImportObject* assetItem)
 {
    ModuleDefinition* moduleDef = ModuleDatabase.findModule(targetModuleId.c_str(), 1);
 
-   if (moduleDef == nullptr)
+   if (moduleDef == NULL)
    {
       dSprintf(importLogBuffer, sizeof(importLogBuffer), "AssetImporter::importAssets - Unable to find moduleId %s", targetModuleId.c_str());
       activityLog.push_back(importLogBuffer);
@@ -2681,7 +2681,7 @@ void AssetImporter::importAssets(AssetImportObject* assetItem)
    }
 
    Vector<AssetImportObject*> itemList = importingAssets;
-   if (assetItem != nullptr)
+   if (assetItem != NULL)
       itemList = assetItem->childAssetItems;
 
    for (U32 i = 0; i < itemList.size(); i++)
@@ -2788,7 +2788,7 @@ void AssetImporter::importAssets(AssetImportObject* assetItem)
 void AssetImporter::acquireAssets(AssetImportObject* assetItem)
 {
    Vector<AssetImportObject*> itemList = importingAssets;
-   if (assetItem != nullptr)
+   if (assetItem != NULL)
       itemList = assetItem->childAssetItems;
 
    for (U32 i = 0; i < itemList.size(); i++)
@@ -2840,7 +2840,7 @@ Torque::Path AssetImporter::importImageAsset(AssetImportObject* assetItem)
    //file path for reimporting support later
    if (!isReimport)
    {
-      newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, originalPath.c_str());
+      newAsset->setDataField(StringTable->insert("originalFilePath"), NULL, originalPath.c_str());
    }
 
    if (assetItem->typeHint != String::EmptyString)
@@ -2891,10 +2891,10 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
 
    if (!isReimport && Torque::FS::IsFile(qualifiedFromFile))
    {
-   newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, qualifiedFromFile);
+   newAsset->setDataField(StringTable->insert("originalFilePath"), NULL, qualifiedFromFile);
    }
 
-   newAsset->setDataField(StringTable->insert("materialDefinitionName"), nullptr, assetName);
+   newAsset->setDataField(StringTable->insert("materialDefinitionName"), NULL, assetName);
 
    //iterate through and write out the material maps dependencies
    S32 dependencySlotId = 0;
@@ -2911,7 +2911,7 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
       char dependencyFieldDef[512];
       dSprintf(dependencyFieldDef, 512, "%s=%s:%s", ASSET_ID_SIGNATURE, targetModuleId.c_str(), childItem->assetName.c_str());
 
-      newAsset->setDataField(StringTable->insert(dependencyFieldName), nullptr, dependencyFieldDef);
+      newAsset->setDataField(StringTable->insert(dependencyFieldName), NULL, dependencyFieldDef);
 
       dependencySlotId++;
    }
@@ -2919,10 +2919,10 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
    //build the ORMConfig file if we're flagged to and have valid image maps
    if (activeImportConfig->CreateORMConfig)
    {
-      AssetImportObject* ormMap = nullptr;
-      AssetImportObject* roughnessMap = nullptr;
-      AssetImportObject* metalnessMap = nullptr;
-      AssetImportObject* aoMap = nullptr;
+      AssetImportObject* ormMap = NULL;
+      AssetImportObject* roughnessMap = NULL;
+      AssetImportObject* metalnessMap = NULL;
+      AssetImportObject* aoMap = NULL;
 
       //We need to find any/all respective image maps for the given channels
       for (U32 i = 0; i < assetItem->childAssetItems.size(); i++)
@@ -2942,9 +2942,9 @@ Torque::Path AssetImporter::importMaterialAsset(AssetImportObject* assetItem)
             aoMap = childItem;
       }
 
-      if (ormMap != nullptr && ormMap->generatedAsset)
+      if (ormMap != NULL && ormMap->generatedAsset)
       {
-         if (roughnessMap != nullptr || metalnessMap != nullptr || aoMap != nullptr)
+         if (roughnessMap != NULL || metalnessMap != NULL || aoMap != NULL)
          {
             U32 channelKey[4] = { 0,1,2,3 };
 
@@ -3065,7 +3065,7 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
    //file path for reimporting support later
    if (!isReimport && Torque::FS::IsFile(originalPath))
    {
-      newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, originalPath.c_str());
+      newAsset->setDataField(StringTable->insert("originalFilePath"), NULL, originalPath.c_str());
    }
 
    //iterate through and write out the material maps dependencies
@@ -3085,7 +3085,7 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
          char dependencyFieldDef[512];
          dSprintf(dependencyFieldDef, 512, "%s=%s:%s", ASSET_ID_SIGNATURE, targetModuleId.c_str(), childItem->assetName.c_str());
   
-         newAsset->setDataField(StringTable->insert(dependencyFieldName), nullptr, dependencyFieldDef);
+         newAsset->setDataField(StringTable->insert(dependencyFieldName), NULL, dependencyFieldDef);
 
          dependencySlotId++;
       }
@@ -3097,7 +3097,7 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
          char dependencyFieldDef[512];
          dSprintf(dependencyFieldDef, 512, "%s=%s:%s", ASSET_ID_SIGNATURE, targetModuleId.c_str(), childItem->assetName.c_str());
 
-         newAsset->setDataField(StringTable->insert(dependencyFieldName), nullptr, dependencyFieldDef);
+         newAsset->setDataField(StringTable->insert(dependencyFieldName), NULL, dependencyFieldDef);
 
          dependencySlotId++;
       }
@@ -3156,7 +3156,7 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
 
       //find/create shape constructor
       TSShapeConstructor* constructor = TSShapeConstructor::findShapeConstructorByFilename(Torque::Path(constructorPath).getFullPath());
-      if (constructor == nullptr)
+      if (constructor == NULL)
       {
          String fullAssetName = assetItem->moduleName + ":" + assetItem->assetName;
          constructor = new TSShapeConstructor(StringTable->insert(fullAssetName.c_str()));
@@ -3315,7 +3315,7 @@ Torque::Path AssetImporter::importSoundAsset(AssetImportObject* assetItem)
    //file path for reimporting support later
    if (!isReimport && String::compare(qualifiedFromFile, qualifiedToFile) && Torque::FS::IsFile(qualifiedFromFile))
    {
-      newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, qualifiedFromFile);
+      newAsset->setDataField(StringTable->insert("originalFilePath"), NULL, qualifiedFromFile);
    }
 
    Taml tamlWriter;
@@ -3376,7 +3376,7 @@ Torque::Path AssetImporter::importShapeAnimationAsset(AssetImportObject* assetIt
    //file path for reimporting support later
    if (!isReimport && String::compare(qualifiedFromFile, qualifiedToFile) && Torque::FS::IsFile(qualifiedFromFile))
    {
-      newAsset->setDataField(StringTable->insert("originalFilePath"), nullptr, qualifiedFromFile);
+      newAsset->setDataField(StringTable->insert("originalFilePath"), NULL, qualifiedFromFile);
    }
 
    Taml tamlWriter;

--- a/Engine/source/T3D/assets/assetImporter.h
+++ b/Engine/source/T3D/assets/assetImporter.h
@@ -719,7 +719,7 @@ public:
    /// <para>@param assetItem, if null, will loop over and recurse the main import asset items, if a specific AssetImportObject is passed in, it will recurse it's children</para>
    /// <para>@return AssetImportObject that was found</para>
    /// </summary>
-   AssetImportObject* findImportingAssetByName(String assetName, AssetImportObject* assetItem = nullptr);
+   AssetImportObject* findImportingAssetByName(String assetName, AssetImportObject* assetItem = NULL);
 
    /// <summary>
    /// Finds the module associated with a given file path
@@ -800,7 +800,7 @@ public:
    /// Process AssetImportObject's to prepare them for importing.
    /// <para>@param assetItem, If null, will loop over the top-level asset items list, if a specific item is provided, will process it's children</para>
    /// </summary>
-   void processImportAssets(AssetImportObject* assetItem = nullptr);
+   void processImportAssets(AssetImportObject* assetItem = NULL);
 
    /// <summary>
    /// Process a specific AssetImportObject that is an ImageAsset type to prepare it for importing
@@ -854,7 +854,7 @@ public:
    /// Reset the validation status of asset items
    /// <para>@param assetItem, If null, will loop over the top-level asset items list, if a specific item is provided, will reset it's children</para>
    /// </summary>
-   void resetAssetValidationStatus(AssetImportObject* assetItem = nullptr);
+   void resetAssetValidationStatus(AssetImportObject* assetItem = NULL);
 
    /// <summary>
    /// Checks asset items for any collisions in the current import session
@@ -862,7 +862,7 @@ public:
    /// <para>@param assetItem, if null, will loop over and recurse the main import asset items, if a specific AssetImportObject is passed in, it will recurse it's children</para>
    /// <para>@return If a collision was detected</para>
    /// </summary>
-   bool checkAssetForCollision(AssetImportObject* assetItemToCheckFor, AssetImportObject* assetItem = nullptr);
+   bool checkAssetForCollision(AssetImportObject* assetItemToCheckFor, AssetImportObject* assetItem = NULL);
 
    /// <summary>
    /// Attempts to automatically resolve import issues according to the import config settings
@@ -882,7 +882,7 @@ public:
    /// Runs the import process in the current session
    /// <para>@param assetItem, if null, will loop over and recurse the main import asset items, if a specific AssetImportObject is passed in, it will recurse it's children</para>
    /// </summary>
-   void importAssets(AssetImportObject* assetItem = nullptr);
+   void importAssets(AssetImportObject* assetItem = NULL);
 
    /// <summary>
    /// Runs the import processing on a specific ImageAsset item
@@ -923,7 +923,7 @@ public:
    /// Iterates over all the items in the current session and acquires them, which jumpstarts the loading/init'ng process on them, making the available for use immediately
    /// <para>@param assetItem, if null, will loop over and recurse the main import asset items, if a specific AssetImportObject is passed in, it will recurse it's children</para>
    /// </summary>
-   void acquireAssets(AssetImportObject* assetItem = nullptr);
+   void acquireAssets(AssetImportObject* assetItem = NULL);
 
    //
    /// <summary>
@@ -934,7 +934,7 @@ public:
 
    void setImportConfig(AssetImportConfig* importConfig)
    {
-      if (importConfig != nullptr)
+      if (importConfig != NULL)
       {
          dSprintf(importLogBuffer, sizeof(importLogBuffer), "Loading import config: %s!", importConfig->getName());
          activityLog.push_back(importLogBuffer);

--- a/Engine/source/T3D/assets/assetImporter_ScriptBinding.h
+++ b/Engine/source/T3D/assets/assetImporter_ScriptBinding.h
@@ -117,7 +117,7 @@ DefineEngineMethod(AssetImporter, getAssetItemChildCount, S32, (AssetImportObjec
    "@param assetItem The AssetImportObject to get the number of children of.\n"
    "@return The number of child items")
 {
-   if (assetItem == nullptr)
+   if (assetItem == NULL)
       return 0;
 
    return object->getAssetItemChildCount(assetItem);
@@ -129,8 +129,8 @@ DefineEngineMethod(AssetImporter, getAssetItemChild, AssetImportObject*, (AssetI
    "@param index The index of the child to get.\n"
    "@return The child AssetImportObect")
 {
-   if (assetItem == nullptr)
-      return nullptr;
+   if (assetItem == NULL)
+      return NULL;
 
    return object->getAssetItemChild(assetItem, index);
 }

--- a/Engine/source/T3D/assets/stateMachineAsset.cpp
+++ b/Engine/source/T3D/assets/stateMachineAsset.cpp
@@ -186,7 +186,7 @@ GuiControl* GuiInspectorTypeStateMachineAssetPtr::constructEditControl()
 
    StringBuilder varNameStr;
    varNameStr.append(mCaption);
-   if (mFieldArrayIndex != nullptr)
+   if (mFieldArrayIndex != NULL)
    {
       varNameStr.append("[");
       varNameStr.append(mFieldArrayIndex);

--- a/Engine/source/T3D/convexShape.cpp
+++ b/Engine/source/T3D/convexShape.cpp
@@ -939,7 +939,7 @@ bool ConvexShape::buildExportPolyList(ColladaUtils::ExportData* exportData, cons
       ColladaUtils::ExportData::meshLODData* meshData = &exportData->meshData.last();
 
       //Fill out the info we'll need later to actually append our mesh data for the detail levels during the processing phase
-      meshData->shapeInst = nullptr;
+      meshData->shapeInst = NULL;
       meshData->originatingObject = this;
       meshData->meshTransform = mObjToWorld;
       meshData->scale = mObjScale;
@@ -1266,7 +1266,7 @@ void ConvexShape::_updateMaterial()
 
       Material* material = mSurfaceTextures[i].getMaterialResource();
 
-      if (material == nullptr)
+      if (material == NULL)
          continue;
 
       mSurfaceTextures[i].materialInst = material->createMatInstance();
@@ -1291,7 +1291,7 @@ void ConvexShape::_updateMaterial()
 
    Material* material = getMaterialResource();
 
-   if (material == nullptr)
+   if (material == NULL)
       return;
 
    mMaterialInst = material->createMatInstance();

--- a/Engine/source/T3D/fx/groundCover.cpp
+++ b/Engine/source/T3D/fx/groundCover.cpp
@@ -510,13 +510,13 @@ GroundCover::GroundCover()
       mMinElevation[i] = -99999.0f;
       mMaxElevation[i] = 99999.0f;
 
-      mLayerAsset[i] = nullptr;
+      mLayerAsset[i] = NULL;
       mLayerFile[i] = StringTable->EmptyString();
 
-      mShapeAsset[i] = nullptr;
+      mShapeAsset[i] = NULL;
       mShapeFile[i] = StringTable->EmptyString();
 
-      mInvertLayer[i] = false;
+      mInvertLayer[i] = NULL;
 
       mMinClumpCount[i] = 1;
       mMaxClumpCount[i] = 1;
@@ -895,7 +895,7 @@ void GroundCover::_initShapes()
 
    for ( S32 i=0; i < MAX_COVERTYPES; i++ )
    {
-      if ( mShapeAsset[i].isNull() || getShape(i) == nullptr)
+      if ( mShapeAsset[i].isNull() || getShape(i) == NULL)
          continue;
 
       if ( isClientObject() && !getShape(i)->preloadMaterialList(getShapeFile(i)) && NetConnection::filesWereDownloaded() )
@@ -1573,7 +1573,7 @@ void GroundCover::_updateCoverGrid( const Frustum &culler )
 void GroundCover::prepRenderImage( SceneRenderState *state )
 {
    // Reset stats each time we hit the diffuse pass.
-   if (mMaterialInst == nullptr)
+   if (mMaterialInst == NULL)
       return;
 
    if( state->isDiffusePass() )

--- a/Engine/source/T3D/fx/particle.cpp
+++ b/Engine/source/T3D/fx/particle.cpp
@@ -933,7 +933,7 @@ GuiControl* GuiInspectorTypeParticleDataList::constructEditControl()
    Parent::updateValue();
    const char* data = getData();
 
-   if (data != nullptr && !String::isEmpty(data))
+   if (data != NULL && !String::isEmpty(data))
    {
       U32 particlesCount = StringUnit::getUnitCount(data, " ");
       for (U32 i=1; i < particlesCount; i++)
@@ -988,7 +988,7 @@ GuiControl* GuiInspectorTypeParticleDataList::_buildParticleEntryField(const S32
       Parent::updateValue();
       const char* data = getData();
 
-      if (data != nullptr && !String::isEmpty(data))
+      if (data != NULL && !String::isEmpty(data))
       {
          const char* particleSlotData = StringUnit::getUnit(data, index, " ");
          listBtn->setText(particleSlotData);

--- a/Engine/source/T3D/gameBase/gameBase.cpp
+++ b/Engine/source/T3D/gameBase/gameBase.cpp
@@ -783,7 +783,7 @@ DefineEngineMethod( GameBase, applyRadialImpulse, void, ( Point3F origin, F32 ra
 DefineEngineMethod(GameBase, attachChild, bool, (GameBase* _subObject), (nullAsType<GameBase*>()), "(SceneObject subObject)"
               "attach an object to this one, preserving its present transform.")
 {
-    if (_subObject != nullptr)
+    if (_subObject != NULL)
     {              
 		if (_subObject->getParent() != object){
 			Con::errorf("Object is (%d)", _subObject->getId());
@@ -805,7 +805,7 @@ DefineEngineMethod(GameBase, attachChild, bool, (GameBase* _subObject), (nullAsT
 DefineEngineMethod(GameBase, detachChild, bool, (GameBase* _subObject), (nullAsType<GameBase*>()), "(SceneObject subObject)"
               "attach an object to this one, preserving its present transform.")
 {
-   if (_subObject != nullptr)
+   if (_subObject != NULL)
 	{
       _subObject->clearProcessAfter();
 		return _subObject->attachToParent(NULL);

--- a/Engine/source/T3D/gameMode.cpp
+++ b/Engine/source/T3D/gameMode.cpp
@@ -83,7 +83,7 @@ void GameMode::onRemove()
 
 void GameMode::findGameModes(const char* gameModeList, Vector<GameMode*> *outGameModes)
 {
-   if (outGameModes == nullptr)
+   if (outGameModes == NULL)
       return;
 
    Vector<String> gameModeNames;

--- a/Engine/source/T3D/groundPlane.cpp
+++ b/Engine/source/T3D/groundPlane.cpp
@@ -92,7 +92,7 @@ GroundPlane::GroundPlane()
 
 GroundPlane::~GroundPlane()
 {
-   mMaterial = nullptr;
+   mMaterial = NULL;
 
    if(mMaterialInst)
       SAFE_DELETE(mMaterialInst);

--- a/Engine/source/T3D/lighting/reflectionProbe.cpp
+++ b/Engine/source/T3D/lighting/reflectionProbe.cpp
@@ -132,8 +132,8 @@ ReflectionProbe::ReflectionProbe()
    mResourcesCreated = false;
    mPrefilterSize = 64;
    mPrefilterMipLevels = mLog2(F32(mPrefilterSize));
-   mPrefilterMap = nullptr;
-   mIrridianceMap = nullptr;
+   mPrefilterMap = NULL;
+   mIrridianceMap = NULL;
 
    mProbeRefOffset = Point3F::Zero;
    mEditPosOffset = false;
@@ -617,26 +617,26 @@ void ReflectionProbe::processBakedCubemap()
       return;
 
    String irrPath = getIrradianceMapPath();
-   if ((mIrridianceMap == nullptr || mIrridianceMap->mCubemap.isNull()) && Platform::isFile(irrPath))
+   if ((mIrridianceMap == NULL || mIrridianceMap->mCubemap.isNull()) && Platform::isFile(irrPath))
    {
       mIrridianceMap->setCubemapFile(FileName(irrPath));
       mIrridianceMap->updateFaces();
    }
 
-   if (mIrridianceMap == nullptr || mIrridianceMap->mCubemap.isNull())
+   if (mIrridianceMap == NULL || mIrridianceMap->mCubemap.isNull())
    {
       Con::errorf("ReflectionProbe::processBakedCubemap() - Unable to load baked irradiance map at %s", getIrradianceMapPath().c_str());
       return;
    }
 
    String prefilPath = getPrefilterMapPath();
-   if ((mPrefilterMap == nullptr || mPrefilterMap->mCubemap.isNull()) && Platform::isFile(prefilPath))
+   if ((mPrefilterMap == NULL || mPrefilterMap->mCubemap.isNull()) && Platform::isFile(prefilPath))
    {
       mPrefilterMap->setCubemapFile(FileName(prefilPath));
       mPrefilterMap->updateFaces();
    }
 
-   if (mPrefilterMap == nullptr || mPrefilterMap->mCubemap.isNull())
+   if (mPrefilterMap == NULL || mPrefilterMap->mCubemap.isNull())
    {
       Con::errorf("ReflectionProbe::processBakedCubemap() - Unable to load baked prefilter map at %s", getPrefilterMapPath().c_str());
       return;
@@ -680,7 +680,7 @@ void ReflectionProbe::processStaticCubemap()
       mIrridianceMap->updateFaces();
    }
 
-   if (mIrridianceMap == nullptr || mIrridianceMap->mCubemap.isNull())
+   if (mIrridianceMap == NULL || mIrridianceMap->mCubemap.isNull())
    {
       Con::errorf("ReflectionProbe::processStaticCubemap() - Unable to load baked irradiance map at %s", irradFileName);
       return;
@@ -695,7 +695,7 @@ void ReflectionProbe::processStaticCubemap()
       mPrefilterMap->updateFaces();
    }
 
-   if (mPrefilterMap == nullptr || mPrefilterMap->mCubemap.isNull())
+   if (mPrefilterMap == NULL || mPrefilterMap->mCubemap.isNull())
    {
       Con::errorf("ReflectionProbe::processStaticCubemap() - Unable to load baked prefilter map at %s", prefilterFileName);
       return;
@@ -738,7 +738,7 @@ void ReflectionProbe::processStaticCubemap()
       IBLUtilities::SaveCubeMap(prefilterFileName, mPrefilterMap->mCubemap);
    }
 
-   if ((mIrridianceMap != nullptr && !mIrridianceMap->mCubemap.isNull()) && (mPrefilterMap != nullptr && !mPrefilterMap->mCubemap.isNull()))
+   if ((mIrridianceMap != NULL && !mIrridianceMap->mCubemap.isNull()) && (mPrefilterMap != NULL && !mPrefilterMap->mCubemap.isNull()))
    {
       mProbeInfo.mPrefilterCubemap = mPrefilterMap->mCubemap;
       mProbeInfo.mIrradianceCubemap = mIrridianceMap->mCubemap;
@@ -888,7 +888,7 @@ void ReflectionProbe::prepRenderImage(SceneRenderState *state)
    PROBEMGR->submitProbe(&mProbeInfo);
 
 #ifdef TORQUE_TOOLS
-   if (ReflectionProbe::smRenderPreviewProbes && gEditingMission && mPrefilterMap != nullptr)
+   if (ReflectionProbe::smRenderPreviewProbes && gEditingMission && mPrefilterMap != NULL)
    {
       if(!mEditorShapeInst)
          createEditorResources();
@@ -914,7 +914,7 @@ void ReflectionProbe::prepRenderImage(SceneRenderState *state)
 
       BaseMatInstance* probePrevMat = mEditorShapeInst->getMaterialList()->getMaterialInst(0);
 
-      if (probePrevMat == nullptr)
+      if (probePrevMat == NULL)
          return;
 
       setPreviewMatParameters(state, probePrevMat);

--- a/Engine/source/T3D/lighting/skylight.cpp
+++ b/Engine/source/T3D/lighting/skylight.cpp
@@ -59,7 +59,7 @@ extern bool gEditingMission;
 extern ColorI gCanvasClearColor;
 bool Skylight::smRenderSkylights = true;
 
-SimObjectPtr<Skylight> Skylight::smSkylightProbe = nullptr;
+SimObjectPtr<Skylight> Skylight::smSkylightProbe = NULL;
 
 IMPLEMENT_CO_NETOBJECT_V1(Skylight);
 
@@ -176,7 +176,7 @@ void Skylight::prepRenderImage(SceneRenderState *state)
    PROBEMGR->submitProbe(&mProbeInfo);
 
 #ifdef TORQUE_TOOLS
-   if (Skylight::smRenderPreviewProbes && gEditingMission && mEditorShapeInst && mPrefilterMap != nullptr)
+   if (Skylight::smRenderPreviewProbes && gEditingMission && mEditorShapeInst && mPrefilterMap != NULL)
    {
       GFXTransformSaver saver;
 

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -3911,7 +3911,7 @@ void Player::updateActionThread()
 
             if (!footfallDustOverride && rInfo.t <= 0.5f && mWaterCoverage == 0.0f
                                          && material && material->mShowDust
-                                         && mDataBlock->footPuffEmitter != nullptr)
+                                         && mDataBlock->footPuffEmitter != NULL)
             {
                // New emitter every time for visibility reasons
                ParticleEmitter * emitter = new ParticleEmitter;

--- a/Engine/source/assets/assetBase.h
+++ b/Engine/source/assets/assetBase.h
@@ -125,7 +125,7 @@ public:
 
    virtual bool            isAssetValid(void) const
    {
-      return mpOwningAssetManager != nullptr && mAssetInitialized && (mLoadedState == AssetErrCode::Ok || mLoadedState == AssetErrCode::UsingFallback);
+      return mpOwningAssetManager != NULL && mAssetInitialized && (mLoadedState == AssetErrCode::Ok || mLoadedState == AssetErrCode::UsingFallback);
    }
 
    void                    refreshAsset(void);

--- a/Engine/source/console/consoleInternal.cpp
+++ b/Engine/source/console/consoleInternal.cpp
@@ -932,8 +932,8 @@ void Namespace::shutdown()
 
    gNamespaceCache.clear();
 
-   mNamespaceList = nullptr;
-   mGlobalNamespace = nullptr;
+   mNamespaceList = NULL;
+   mGlobalNamespace = NULL;
    mAllocator.freeBlocks();
 }
 

--- a/Engine/source/console/consoleTypes.h
+++ b/Engine/source/console/consoleTypes.h
@@ -39,7 +39,7 @@
 #include "console/engineStructs.h"
 #endif
 
-template<typename T> inline const T nullAsType(){ return nullptr; }
+template<typename T> inline const T nullAsType(){ return NULL; }
 
 /// @file
 /// Legacy TS-based console type definitions.

--- a/Engine/source/console/returnBuffer.cpp
+++ b/Engine/source/console/returnBuffer.cpp
@@ -24,7 +24,7 @@
 
 ReturnBuffer::ReturnBuffer()
 {
-   mBuffer = nullptr;
+   mBuffer = NULL;
    mBufferSize = 0;
    mStart = 0;
 

--- a/Engine/source/console/simDictionary.cpp
+++ b/Engine/source/console/simDictionary.cpp
@@ -152,7 +152,7 @@ void SimNameDictionary::remove(SimObject* obj)
       if (*walk == obj)
       {
          *walk = obj->nextNameObject;
-         obj->nextNameObject = nullptr;
+         obj->nextNameObject = NULL;
          hashEntryCount--;
 
          Mutex::unlockMutex(mutex);
@@ -281,7 +281,7 @@ void SimManagerNameDictionary::remove(SimObject* obj)
       if (*walk == obj)
       {
          *walk = obj->nextManagerNameObject;
-         obj->nextManagerNameObject = nullptr;
+         obj->nextManagerNameObject = NULL;
          hashEntryCount--;
 
          Mutex::unlockMutex(mutex);

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -122,8 +122,8 @@ SimObject::SimObject()
    mOriginalName         = NULL;
    mInternalName         = NULL;
    mInheritFrom          = NULL;
-   nextNameObject        = nullptr;
-   nextManagerNameObject = nullptr;
+   nextNameObject        = NULL;
+   nextManagerNameObject = NULL;
    nextIdObject          = NULL;
 
    mFilename             = NULL;
@@ -174,10 +174,10 @@ SimObject::~SimObject()
    if( mCopySource )
       mCopySource->unregisterReference( &mCopySource );
 
-   AssertFatal(nextNameObject == nullptr,avar(
+   AssertFatal(nextNameObject == NULL,avar(
       "SimObject::~SimObject:  Not removed from dictionary: name %s, id %i",
 	   mObjectName, mId));
-   AssertFatal(nextManagerNameObject == nullptr,avar(
+   AssertFatal(nextManagerNameObject == NULL,avar(
       "SimObject::~SimObject:  Not removed from manager dictionary: name %s, id %i",
 	   mObjectName,mId));
    AssertFatal(mFlags.test(Added) == 0, "SimObject::object "
@@ -1008,7 +1008,7 @@ void SimObject::assignFieldsFrom(SimObject *parent)
             dMemcpy( bufferSecure, szBuffer, dStrlen( szBuffer ) );
 
             //If we have an index worth mentioning, process it for pass-along as well to ensure we set stuff correctly
-            char* elementIdxBuffer = nullptr;
+            char* elementIdxBuffer = NULL;
             if (f->elementCount > 1)
             {
                elementIdxBuffer = Con::getArgBuffer(256);

--- a/Engine/source/console/simSet.cpp
+++ b/Engine/source/console/simSet.cpp
@@ -891,7 +891,7 @@ DefineEngineMethod( SimSet, listObjects, void, (),,
    for(itr = object->begin(); itr != object->end(); itr++)
    {
       SimObject *obj = *itr;
-      if (obj == nullptr) continue;
+      if (obj == NULL) continue;
       bool isSet = dynamic_cast<SimSet *>(obj) != 0;
       const char *name = obj->getName();
       if(name)

--- a/Engine/source/console/torquescript/compiler.cpp
+++ b/Engine/source/console/torquescript/compiler.cpp
@@ -270,7 +270,7 @@ U32 CompilerStringTable::addFloatString(F64 value)
 void CompilerStringTable::reset()
 {
    // Reset list and associated variables
-   list = nullptr;
+   list = NULL;
    totalLen = 0;
    hashTable.clear();  // Clear the lookup table too
 }

--- a/Engine/source/core/util/refBase.h
+++ b/Engine/source/core/util/refBase.h
@@ -56,7 +56,7 @@ public:
       friend class WeakRefBase;
       constexpr explicit WeakReference(WeakRefBase *object) :mObject(object), mRefCount(0) {}
 
-      ~WeakReference() { AssertFatal(mObject==nullptr, "Deleting weak reference which still points at an object."); }
+      ~WeakReference() { AssertFatal(mObject==NULL, "Deleting weak reference which still points at an object."); }
 
       // Object we reference
       WeakRefBase *mObject;
@@ -66,7 +66,7 @@ public:
    };
 
 public:
-   constexpr WeakRefBase() : mReference(nullptr) {}
+   constexpr WeakRefBase() : mReference(NULL) {}
    virtual ~WeakRefBase()  { clearWeakReferences(); }
 
    WeakReference* getWeakReference();
@@ -88,11 +88,11 @@ template< typename T > class SimObjectPtr;
 template <class T> class WeakRefPtr
 {
 public:
-   constexpr WeakRefPtr()  : mReference(nullptr) {}
-   WeakRefPtr(T *ptr)      : mReference(nullptr) { set(ptr); }
-   WeakRefPtr(const WeakRefPtr<T> & ref) { mReference = nullptr; set(ref.mReference); }
+   constexpr WeakRefPtr()  : mReference(NULL) {}
+   WeakRefPtr(T *ptr)      : mReference(NULL) { set(ptr); }
+   WeakRefPtr(const WeakRefPtr<T> & ref) { mReference = NULL; set(ref.mReference); }
    
-   ~WeakRefPtr() { set(static_cast<WeakRefBase::WeakReference *>(nullptr)); }
+   ~WeakRefPtr() { set(static_cast<WeakRefBase::WeakReference *>(NULL)); }
 
    WeakRefPtr<T>& operator=(const WeakRefPtr<T>& ref)
    {
@@ -107,7 +107,7 @@ public:
    }
 
    /// Returns true if the pointer is not set.
-   [[nodiscard]] constexpr bool isNull()        const { return mReference == nullptr || mReference->get() == nullptr; }
+   [[nodiscard]] constexpr bool isNull()        const { return mReference == NULL || mReference->get() == NULL; }
    
    /// Returns true if the pointer is set.
    [[nodiscard]] constexpr bool isValid()       const { return mReference && mReference->get(); }
@@ -117,14 +117,14 @@ public:
    [[nodiscard]] constexpr operator T*()        const { return getPointer(); }
    
    /// Returns the pointer.
-   [[nodiscard]] constexpr T* getPointer()      const { return mReference ? (T*)mReference->get() : nullptr; }
+   [[nodiscard]] constexpr T* getPointer()      const { return mReference ? (T*)mReference->get() : NULL; }
 
 protected:
    void set(WeakRefBase::WeakReference* ref)
    {
       if (mReference)
          mReference->decRefCount();
-      mReference = nullptr;
+      mReference = NULL;
       if (ref)
       {
          mReference = ref;
@@ -132,10 +132,10 @@ protected:
       }
    }
 
-   void set(T* obj) { set(obj ? obj->getWeakReference() : nullptr); }
+   void set(T* obj) { set(obj ? obj->getWeakReference() : NULL); }
 private:
    template< typename > friend class SimObjectPtr;
-   WeakRefBase::WeakReference * mReference {nullptr};
+   WeakRefBase::WeakReference * mReference {NULL};
 };
 
 /// Union of an arbitrary type with a WeakRefBase.  The exposed type will
@@ -147,11 +147,11 @@ class WeakRefUnion
    typedef WeakRefUnion<ExposedType> Union;
 
 public:
-   constexpr WeakRefUnion() : mPtr(nullptr) {}
-   constexpr WeakRefUnion(const WeakRefPtr<WeakRefBase> & ref, ExposedType * ptr) : mPtr(nullptr) { set(ref, ptr); }
-   constexpr WeakRefUnion(const Union & lock)                                     : mPtr(nullptr) { *this = lock; }
-   constexpr WeakRefUnion(WeakRefBase * ref)       : mPtr(nullptr) { set(ref, dynamic_cast<ExposedType*>(ref)); }
-   ~WeakRefUnion() { mWeakReference = nullptr; }
+   constexpr WeakRefUnion() : mPtr(NULL) {}
+   constexpr WeakRefUnion(const WeakRefPtr<WeakRefBase> & ref, ExposedType * ptr) : mPtr(NULL) { set(ref, ptr); }
+   constexpr WeakRefUnion(const Union & lock)                                     : mPtr(NULL) { *this = lock; }
+   constexpr WeakRefUnion(WeakRefBase * ref)       : mPtr(NULL) { set(ref, dynamic_cast<ExposedType*>(ref)); }
+   ~WeakRefUnion() { mWeakReference = NULL; }
 
    Union & operator=(const Union & ptr)
    {
@@ -172,7 +172,7 @@ public:
    [[nodiscard]] constexpr bool operator != (const Union &t )        const { return getPointer() != t.getPointer(); }
    [[nodiscard]] constexpr bool isNull()                             const { return mWeakReference.isNull() || !mPtr; }
 
-   [[nodiscard]] constexpr ExposedType* getPointer()        const { return !mWeakReference.isNull() ? mPtr : nullptr; }
+   [[nodiscard]] constexpr ExposedType* getPointer()        const { return !mWeakReference.isNull() ? mPtr : NULL; }
    [[nodiscard]] constexpr ExposedType* operator->()        const { return getPointer(); }
    [[nodiscard]] constexpr ExposedType& operator*()         const { return *getPointer(); }
    [[nodiscard]] constexpr operator ExposedType*()          const { return getPointer(); }
@@ -223,7 +223,7 @@ class StrongObjectRef
 
 public:
    /// Constructor, assigns from the object and increments its reference count if it's not NULL
-   StrongObjectRef(StrongRefBase *object = nullptr) : mObject( object ) { incRef(); }
+   StrongObjectRef(StrongRefBase *object = NULL) : mObject( object ) { incRef(); }
 
    /// Destructor, dereferences the object, if there is one
    ~StrongObjectRef() { decRef(); }
@@ -281,8 +281,8 @@ public:
       return *this;
    }
 
-   [[nodiscard]] constexpr bool isNull()  const  { return mObject == nullptr; }
-   [[nodiscard]] constexpr bool isValid() const  { return mObject != nullptr; }
+   [[nodiscard]] constexpr bool isNull()  const  { return mObject == NULL; }
+   [[nodiscard]] constexpr bool isValid() const  { return mObject != NULL; }
    [[nodiscard]] T* operator->() const { return getPointer(); }
    T& operator*() const  { return *getPointer(); }
    operator T*() const { return getPointer(); }
@@ -299,13 +299,13 @@ class StrongRefUnion
    typedef StrongRefUnion<ExposedType> Union;
 
 public:
-   StrongRefUnion() : mPtr(nullptr) {}
+   StrongRefUnion() : mPtr(NULL) {}
 
-   StrongRefUnion(const StrongRefPtr<StrongRefBase> & ref, ExposedType * ptr) : mPtr(nullptr) { set(ref, ptr); }
-   StrongRefUnion(const Union & lock)                                         : mPtr(nullptr) { *this = lock; }
-   StrongRefUnion(StrongRefBase * ref)         : mPtr(nullptr) { set(ref, dynamic_cast<ExposedType*>(ref)); }
+   StrongRefUnion(const StrongRefPtr<StrongRefBase> & ref, ExposedType * ptr) : mPtr(NULL) { set(ref, ptr); }
+   StrongRefUnion(const Union & lock)                                         : mPtr(NULL) { *this = lock; }
+   StrongRefUnion(StrongRefBase * ref)         : mPtr(NULL) { set(ref, dynamic_cast<ExposedType*>(ref)); }
 
-   ~StrongRefUnion() { mReference = nullptr; }
+   ~StrongRefUnion() { mReference = NULL; }
 
    Union & operator=(const Union & ptr)
    {
@@ -351,8 +351,8 @@ template< class T >
 class StrongWeakRefPtr
 {
 public:
-   constexpr StrongWeakRefPtr()           : mReference( nullptr ) {}
-   constexpr StrongWeakRefPtr( T* ptr )   : mReference( nullptr ) { _set( ptr ); }
+   constexpr StrongWeakRefPtr()           : mReference( NULL ) {}
+   constexpr StrongWeakRefPtr( T* ptr )   : mReference( NULL ) { _set( ptr ); }
    ~StrongWeakRefPtr()
    {
       if( mReference )
@@ -365,7 +365,7 @@ public:
       }
    }
 
-   [[nodiscard]] constexpr bool isNull()              const { return ( _get() == nullptr ); }
+   [[nodiscard]] constexpr bool isNull()              const { return ( _get() == NULL ); }
    [[nodiscard]] constexpr bool operator ==( T* ptr ) const { return ( _get() == ptr ); }
    [[nodiscard]] constexpr bool operator !=( T* ptr ) const { return ( _get() != ptr ); }
    [[nodiscard]] constexpr bool operator !()          const { return isNull(); }
@@ -390,7 +390,7 @@ private:
       if( mReference )
          return static_cast< T* >( mReference->get() );
       else
-         return nullptr;
+         return NULL;
    }
    void _set( T* ptr )
    {
@@ -410,7 +410,7 @@ private:
          mReference->incRefCount();
       }
       else
-         mReference = nullptr;
+         mReference = NULL;
    }
 };
 
@@ -420,9 +420,9 @@ inline void WeakRefBase::clearWeakReferences()
 {
    if (mReference)
    {
-      mReference->mObject = nullptr;
+      mReference->mObject = NULL;
       mReference->decRefCount();
-      mReference = nullptr;
+      mReference = NULL;
    }
 }
 

--- a/Engine/source/core/util/tDictionary.h
+++ b/Engine/source/core/util/tDictionary.h
@@ -193,7 +193,7 @@ private:
    {
       Node* mNext;
       Pair mPair;
-      Node(): mNext(nullptr) {}
+      Node(): mNext(NULL) {}
       Node(Pair p,Node* n)
          :  mNext(n),
             mPair(p)
@@ -226,8 +226,8 @@ public:
 
       _Iterator()
       {
-         mHashTable = nullptr;
-         mLink = nullptr;
+         mHashTable = NULL;
+         mLink = NULL;
       }
 
       _Iterator(M* table,E* ptr)
@@ -320,7 +320,7 @@ public:
 template<typename Key, typename Value> HashTable<Key,Value>::HashTable() : mNodeAllocator(512)
 {
    mTableSize = 0;
-   mTable = nullptr;
+   mTable = NULL;
    mSize = 0;
 }
 
@@ -328,7 +328,7 @@ template<typename Key, typename Value> HashTable<Key,Value>::HashTable(const Has
 {
    mSize = 0;
    mTableSize = 0;
-   mTable = nullptr;
+   mTable = NULL;
    *this = p;
 }
 
@@ -357,7 +357,7 @@ typename HashTable<Key,Value>::Node* HashTable<Key,Value>::_next(U32 index) cons
    for (; index < mTableSize; index++)
       if (Node* node = mTable[index])
          return node;
-   return nullptr;
+   return NULL;
 }
 
 template<typename Key, typename Value>
@@ -402,7 +402,7 @@ void HashTable<Key,Value>::_destroy()
       
    mNodeAllocator.freeBlocks();
    delete[] mTable;
-   mTable = nullptr;
+   mTable = NULL;
 }
 
 
@@ -509,7 +509,7 @@ typename HashTable<Key,Value>::Iterator HashTable<Key,Value>::insertEqual(const 
 template<typename Key, typename Value>
 void HashTable<Key,Value>::erase(const Key& key)
 {
-   if (mTable == nullptr)
+   if (mTable == NULL)
       return;
    Node** prev = &mTable[_index(key)];
    for (Node* itr = *prev; itr; prev = &itr->mNext, itr = itr->mNext)
@@ -529,7 +529,7 @@ void HashTable<Key,Value>::erase(const Key& key)
 template<typename Key, typename Value>
 void HashTable<Key,Value>::erase(Iterator node)
 {
-   if (mTable == nullptr)
+   if (mTable == NULL)
       return;
    Node** prev = &mTable[_index(node->key)];
    for (Node* itr = *prev; itr; prev = &itr->mNext, itr = itr->mNext)
@@ -547,7 +547,7 @@ void HashTable<Key,Value>::erase(Iterator node)
 template<typename Key, typename Value>
 void HashTable<Key,Value>::erase(const Key & key, const Value & value)
 {
-   if (mTable == nullptr)
+   if (mTable == NULL)
       return;
    Node** prev = &mTable[_index(key)];
    for (Node* itr = *prev; itr; prev = &itr->mNext, itr = itr->mNext)
@@ -591,7 +591,7 @@ typename HashTable<Key,Value>::Iterator HashTable<Key,Value>::find(const Key& ke
       for (Node* itr = mTable[_index(key)]; itr; itr = itr->mNext)
          if ( KeyCmp::equals<Key>( itr->mPair.key, key ) )
             return Iterator(this,itr);
-   return Iterator(this, nullptr);
+   return Iterator(this, NULL);
 }
 
 template<typename Key, typename Value>
@@ -605,7 +605,7 @@ typename HashTable<Key,Value>::ConstIterator HashTable<Key,Value>::find(const Ke
             return ConstIterator(this,itr);
       }
    }
-   return ConstIterator(this, nullptr);
+   return ConstIterator(this, NULL);
 }
 
 template<typename Key, typename Value>
@@ -659,13 +659,13 @@ inline typename HashTable<Key,Value>::ConstIterator HashTable<Key,Value>::begin(
 template<typename Key, typename Value>
 inline typename HashTable<Key,Value>::Iterator HashTable<Key,Value>::end()
 {
-   return Iterator(this, nullptr);
+   return Iterator(this, NULL);
 }
 
 template<typename Key, typename Value>
 inline typename HashTable<Key,Value>::ConstIterator HashTable<Key,Value>::end() const
 {
-   return ConstIterator(this, nullptr);
+   return ConstIterator(this, NULL);
 }
 
 

--- a/Engine/source/environment/decalRoad.cpp
+++ b/Engine/source/environment/decalRoad.cpp
@@ -290,7 +290,7 @@ DecalRoad::DecalRoad()
 
    INIT_ASSET(Material);
 
-   mMaterialInst = nullptr;
+   mMaterialInst = NULL;
 }
 
 DecalRoad::~DecalRoad()
@@ -1087,7 +1087,7 @@ void DecalRoad::_initMaterial()
 
       SAFE_DELETE(mMaterialInst);
 
-      Material* tMat = nullptr;
+      Material* tMat = NULL;
 
       if (!Sim::findObject(mMaterialAsset->getMaterialDefinitionName(), tMat))
          Con::errorf("DecalRoad::_initMaterial - Material %s was not found.", mMaterialAsset->getMaterialDefinitionName());

--- a/Engine/source/environment/meshRoad.cpp
+++ b/Engine/source/environment/meshRoad.cpp
@@ -1326,7 +1326,7 @@ void MeshRoad::_initMaterial()
       {
          SAFE_DELETE(mMatInst[Top]);
 
-         Material* tMat = nullptr;
+         Material* tMat = NULL;
          if (!Sim::findObject(mTopMaterialAsset->getMaterialDefinitionName(), tMat))
             Con::errorf("MeshRoad::_initMaterial - Material %s was not found.", mTopMaterialAsset->getMaterialDefinitionName());
 
@@ -1348,7 +1348,7 @@ void MeshRoad::_initMaterial()
 
          SAFE_DELETE(mMatInst[Bottom]);
 
-         Material* tMat = nullptr;
+         Material* tMat = NULL;
          if (!Sim::findObject(mBottomMaterialAsset->getMaterialDefinitionName(), tMat))
             Con::errorf("MeshRoad::_initMaterial - Material %s was not found.", mBottomMaterialAsset->getMaterialDefinitionName());
 
@@ -1369,7 +1369,7 @@ void MeshRoad::_initMaterial()
       {
          SAFE_DELETE(mMatInst[Side]);
 
-         Material* tMat = nullptr;
+         Material* tMat = NULL;
          if (!Sim::findObject(mSideMaterialAsset->getMaterialDefinitionName(), tMat))
             Con::errorf("MeshRoad::_initMaterial - Material %s was not found.", mSideMaterialAsset->getMaterialDefinitionName());
 

--- a/Engine/source/gfx/gl/gfxGLCircularVolatileBuffer.h
+++ b/Engine/source/gfx/gl/gfxGLCircularVolatileBuffer.h
@@ -184,7 +184,7 @@ public:
       {
          AssertFatal(0, "GLCircularVolatileBuffer::lock - size must be > 0");
          outOffset = 0;
-         outPtr = nullptr;
+         outPtr = NULL;
          return;
       }
 

--- a/Engine/source/gui/containers/guiDragAndDropCtrl.cpp
+++ b/Engine/source/gui/containers/guiDragAndDropCtrl.cpp
@@ -215,7 +215,7 @@ void GuiDragAndDropControl::onMouseDragged( const GuiEvent& event )
    
    // Allow the control under the drag to react to a potential drop
    GuiControl* enterTarget = findDragTarget( event.mousePoint, "onControlDragEnter" );
-   if(enterTarget != nullptr)
+   if(enterTarget != NULL)
       Con::printf("GuiDragAndDropControl::onMouseDragged() - enterTarget: %d", enterTarget->getId());
 
    if( mLastTarget != enterTarget )

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -1033,7 +1033,7 @@ void GuiGameListMenuCtrl::clearRows()
    for (U32 i = 0; i < mRows.size(); i++)
    {
       if (mRows[i]->mBitmap != StringTable->EmptyString())
-         mRows[i]->mBitmapTex = nullptr;
+         mRows[i]->mBitmapTex = NULL;
    }
 
    mRows.clear();

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.h
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.h
@@ -86,7 +86,7 @@ protected:
       GFXTexHandle               mBitmapTex;
 
       Row() : mLabel(StringTable->EmptyString()), mScriptCallback(StringTable->EmptyString()), mTooltip(StringTable->EmptyString()), mIconIndex(-1), mHeightPad(0), mUseHighlightIcon(false), mEnabled(true),
-         mSelectedOption(0), mWrapOptions(false), mMode(Mode::Default), mValue(0), mStepSize(1), mRange(Point2F(0, 1)), mBitmap(StringTable->EmptyString()), mBitmapTex(nullptr)
+         mSelectedOption(0), mWrapOptions(false), mMode(Mode::Default), mValue(0), mStepSize(1), mRange(Point2F(0, 1)), mBitmap(StringTable->EmptyString()), mBitmapTex(NULL)
       {
          VECTOR_SET_ASSOCIATION(mOptions);
       }

--- a/Engine/source/gui/controls/guiMLTextCtrl.cpp
+++ b/Engine/source/gui/controls/guiMLTextCtrl.cpp
@@ -278,7 +278,7 @@ GuiMLTextCtrl::GuiMLTextCtrl()
   mTypeOverTimeSpeedMS(10),
   mTypeOverTimeIndex(0),
    mTypeoutSoundRate(-1),
-   mTypeoutSound(nullptr)
+   mTypeoutSound(NULL)
 {   
    mActive = true;
    //mInitialText = StringTable->EmptyString();

--- a/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
+++ b/Engine/source/gui/controls/guiPopUpCtrlEx.cpp
@@ -338,7 +338,7 @@ GuiPopUpMenuCtrlEx::GuiPopUpMenuCtrlEx(void)
    mSc = NULL;
    mReplaceText = false;
    mTextSearchItems = false;
-   mSearchEdit = nullptr;
+   mSearchEdit = NULL;
 }
 
 //------------------------------------------------------------------------------

--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -4540,7 +4540,7 @@ void GuiTreeViewCtrl::reparentItems(Vector<Item*> selectedItems, Item* newParent
       // Snag the current parent set if any for future reference
       SimSet * parentSet = NULL;
 
-      if (oldParent != nullptr && oldParent->isInspectorData())
+      if (oldParent != NULL && oldParent->isInspectorData())
       {
          parentSet = dynamic_cast<SimSet*>(oldParent->getObject());
       }
@@ -4872,7 +4872,7 @@ void GuiTreeViewCtrl::reparentItems(Vector<Item*> selectedItems, Item* newParent
 S32 GuiTreeViewCtrl::getTabLevel(S32 itemId)
 {
    Item* item = getItem(itemId);
-   if (item != nullptr)
+   if (item != NULL)
    {
       return item->mTabLevel;
    }
@@ -5745,7 +5745,7 @@ DefineEngineMethod(GuiTreeViewCtrl, reparentItem, void, (S32 itemId, S32 parentI
 
    const Vector< GuiTreeViewCtrl::Item* > & selectedItems = object->getItems();
    Vector<GuiTreeViewCtrl::Item*> items;
-   GuiTreeViewCtrl::Item * parent = nullptr;
+   GuiTreeViewCtrl::Item * parent = NULL;
 
    for (S32 i = 0; i < selectedItems.size(); ++i)
    {
@@ -5760,7 +5760,7 @@ DefineEngineMethod(GuiTreeViewCtrl, reparentItem, void, (S32 itemId, S32 parentI
       }
    }
 
-   if (!items.empty() && parent != nullptr)
+   if (!items.empty() && parent != NULL)
    {
       object->reparentItems(items, parent);
    }

--- a/Engine/source/gui/core/guiCanvas.cpp
+++ b/Engine/source/gui/core/guiCanvas.cpp
@@ -162,8 +162,8 @@ GuiCanvas::GuiCanvas(): GuiControl(),
                         mLastRenderMs(0),
                         mPlatformWindow(NULL),
                         mDisplayWindow(true),
-                        mMenuBarCtrl(nullptr),
-                        mMenuBackground(nullptr),
+                        mMenuBarCtrl(NULL),
+                        mMenuBackground(NULL),
                         mConstrainMouse(false)
 {
    setBounds(0, 0, 640, 480);
@@ -359,7 +359,7 @@ void GuiCanvas::setMenuBar(SimObject *obj)
           return;
        }
 
-       if (mMenuBackground == nullptr)
+       if (mMenuBackground == NULL)
        {
            mMenuBackground = new GuiControl();
            mMenuBackground->registerObject();

--- a/Engine/source/gui/core/guiTypes.cpp
+++ b/Engine/source/gui/core/guiTypes.cpp
@@ -199,7 +199,7 @@ bool GuiControlProfile::protectedSetBitmap( void *object, const char *index, con
    if( profile->mLoadCount > 0 )
    {
       profile->mBitmapArrayRects.clear();
-      profile->mBitmap = nullptr;
+      profile->mBitmap = NULL;
 
       if (profile->mBitmapName != StringTable->EmptyString())
       {

--- a/Engine/source/gui/editor/guiInspector.cpp
+++ b/Engine/source/gui/editor/guiInspector.cpp
@@ -803,7 +803,7 @@ void GuiInspector::sendInspectPostApply()
 
 S32 GuiInspector::createInspectorGroup(StringTableEntry groupName, S32 index)
 {
-   GuiInspectorGroup* newGroup = nullptr;
+   GuiInspectorGroup* newGroup = NULL;
    newGroup = findExistentGroup(groupName);
    if (newGroup)
       return newGroup->getId();  //if we already have a group under this name, just return it
@@ -830,7 +830,7 @@ S32 GuiInspector::createInspectorGroup(StringTableEntry groupName, S32 index)
 void GuiInspector::removeInspectorGroup(StringTableEntry groupName)
 {
    GuiInspectorGroup* group = findExistentGroup(groupName);
-   if (group == nullptr)
+   if (group == NULL)
       return;
 
    mGroups.remove(group);

--- a/Engine/source/gui/editor/guiInspector.h
+++ b/Engine/source/gui/editor/guiInspector.h
@@ -87,7 +87,7 @@ public:
       if (!mTargets.empty())
          return mTargets[index];
       else
-         return nullptr;
+         return NULL;
    }
 
    S32 getComponentGroupTargetId() { return mComponentGroupTargetId; }

--- a/Engine/source/gui/editor/guiMenuBar.cpp
+++ b/Engine/source/gui/editor/guiMenuBar.cpp
@@ -180,7 +180,7 @@ void GuiMenuBar::onRemove()
    if (Sim::findObject("PopUpMenuControl", backgroundCtrl))
    {
       if (backgroundCtrl->mMenuBarCtrl == this)
-         backgroundCtrl->mMenuBarCtrl = nullptr;
+         backgroundCtrl->mMenuBarCtrl = NULL;
    }
 
    Parent::onRemove();
@@ -310,7 +310,7 @@ void GuiMenuBar::onMouseMove(const GuiEvent &event)
 {
    MenuEntry *hit = findHitMenu(event.mousePoint);
 
-   if (mouseDownMenu != nullptr && hit != nullptr)
+   if (mouseDownMenu != NULL && hit != NULL)
    {
       //we have a standing click, so just update and go
       mouseDownMenu = mouseOverMenu = hit;
@@ -526,15 +526,15 @@ void GuiMenuBar::processTick()
 
 void GuiMenuBar::insert(SimObject* pObject, S32 pos)
 {
-   PopupMenu* menu = nullptr;
-   if (pObject != nullptr)
+   PopupMenu* menu = NULL;
+   if (pObject != NULL)
    {
       menu = dynamic_cast<PopupMenu*>(pObject);
    }
 
-   if (menu == nullptr)
+   if (menu == NULL)
    {
-      if (pObject != nullptr)
+      if (pObject != NULL)
       {
          Con::errorf("GuiMenuBar::insert() - attempted to insert non-popupMenu object: %d", pObject->getId());
       }
@@ -564,15 +564,15 @@ void GuiMenuBar::insert(SimObject* pObject, S32 pos)
 
 void GuiMenuBar::remove(SimObject* pObject)
 {
-   PopupMenu* menu = nullptr;
-   if (pObject != nullptr)
+   PopupMenu* menu = NULL;
+   if (pObject != NULL)
    {
       menu = dynamic_cast<PopupMenu*>(pObject);
    }
 
-   if (menu == nullptr)
+   if (menu == NULL)
    {
-      if (pObject != nullptr)
+      if (pObject != NULL)
       {
          Con::errorf("GuiMenuBar::insert() - attempted to insert non-popupMenu object: %d", pObject->getId());
       }
@@ -597,7 +597,7 @@ void GuiMenuBar::remove(SimObject* pObject)
 PopupMenu* GuiMenuBar::getMenu(U32 index)
 {
    if (index >= mMenuList.size())
-      return nullptr;
+      return NULL;
 
    return mMenuList[index].popupMenu;
 }
@@ -610,7 +610,7 @@ PopupMenu* GuiMenuBar::findMenu(String barTitle)
          return mMenuList[i].popupMenu;
    }
 
-   return nullptr;
+   return NULL;
 }
 
 //-----------------------------------------------------------------------------
@@ -631,7 +631,7 @@ DefineEngineMethod(GuiMenuBar, removeFromCanvas, void, (), , "()")
    GuiCanvas* canvas = object->getRoot();
 
    if(canvas)
-      canvas->setMenuBar(nullptr);
+      canvas->setMenuBar(NULL);
 }
 #endif
 
@@ -648,7 +648,7 @@ DefineEngineMethod(GuiMenuBar, getMenu, S32, (S32 index), (0), "(Index)")
 //-----------------------------------------------------------------------------
 DefineEngineMethod(GuiMenuBar, insert, void, (SimObject* pObject, S32 pos), (nullAsType<SimObject*>(), -1), "(object, pos) insert object at position")
 {
-   if(pObject == nullptr)
+   if(pObject == NULL)
    {
       Con::errorf("GuiMenuBar::insert() - null object");
       return;
@@ -658,7 +658,7 @@ DefineEngineMethod(GuiMenuBar, insert, void, (SimObject* pObject, S32 pos), (nul
 
 DefineEngineMethod(GuiMenuBar, remove, void, (SimObject* pObject), (nullAsType<SimObject*>()), "(object, pos) remove object")
 {
-   if (pObject == nullptr)
+   if (pObject == NULL)
    {
       Con::errorf("GuiMenuBar::remove() - null object");
       return;

--- a/Engine/source/gui/editor/guiPopupMenuCtrl.cpp
+++ b/Engine/source/gui/editor/guiPopupMenuCtrl.cpp
@@ -27,7 +27,7 @@
 
 GuiPopupMenuBackgroundCtrl::GuiPopupMenuBackgroundCtrl()
 {
-   mMenuBarCtrl = nullptr;
+   mMenuBarCtrl = NULL;
 }
 
 void GuiPopupMenuBackgroundCtrl::onMouseDown(const GuiEvent &event)
@@ -62,7 +62,7 @@ void GuiPopupMenuBackgroundCtrl::close()
    if(getRoot())
       getRoot()->removeObject(this);
 
-   mMenuBarCtrl = nullptr;
+   mMenuBarCtrl = NULL;
 }
 
 S32 GuiPopupMenuBackgroundCtrl::findPopupMenu(PopupMenu* menu)
@@ -91,8 +91,8 @@ GuiPopupMenuTextListCtrl::GuiPopupMenuTextListCtrl()
 {
    isSubMenu = false; //  Added
 
-   mMenuBar = nullptr;
-   mPopup = nullptr;
+   mMenuBar = NULL;
+   mPopup = NULL;
 
    mLastHighlightedMenuIdx = -1;
    mBackground = NULL;
@@ -284,7 +284,7 @@ void GuiPopupMenuTextListCtrl::onCellHighlighted(Point2I cell)
    {
       MenuItem *list = &mPopup->mMenuItems[selectionIndex];
 
-      if (list->mIsSubmenu && list->mSubMenu != nullptr)
+      if (list->mIsSubmenu && list->mSubMenu != NULL)
       {
          list->mSubMenu->showPopup(getRoot(), getPosition().x + mCellSize.x, getPosition().y + (selectionIndex * mCellSize.y));
       }

--- a/Engine/source/gui/editor/guiShapeEdPreview.cpp
+++ b/Engine/source/gui/editor/guiShapeEdPreview.cpp
@@ -570,7 +570,7 @@ bool GuiShapeEdPreview::mountShape(const char* shapeAssetId, const char* nodeNam
 
    ShapeAsset* model = AssetDatabase.acquireAsset<ShapeAsset>(shapeAssetId);
 
-   if (model == nullptr || !model->getShapeResource())
+   if (model == NULL || !model->getShapeResource())
       return false;
 
    TSShapeInstance* tsi = new TSShapeInstance(model->getShapeResource(), true );

--- a/Engine/source/gui/editor/inspector/field.cpp
+++ b/Engine/source/gui/editor/inspector/field.cpp
@@ -269,7 +269,7 @@ void GuiInspectorField::setWordData(const S32& wordIndex, const char* data, bool
 
    if (mSpecialEditField)
    {
-      if (mTargetObject != nullptr && mVariableName != StringTable->EmptyString())
+      if (mTargetObject != NULL && mVariableName != StringTable->EmptyString())
       {
          const char* fieldData = mTargetObject->getDataField(mVariableName, NULL);
          const char* wordData = StringUnit::getUnit(fieldData, wordIndex, " \t\n");
@@ -495,7 +495,7 @@ void GuiInspectorField::setData( const char* data, bool callbacks )
 {
    if (mSpecialEditField)
    {
-      if (mTargetObject != nullptr && mVariableName != StringTable->EmptyString())
+      if (mTargetObject != NULL && mVariableName != StringTable->EmptyString())
       {
          mTargetObject->setDataField(mVariableName, NULL, data);
 
@@ -645,7 +645,7 @@ const char* GuiInspectorField::getData( U32 inspectObjectIndex )
    }
    else
    {
-      if (mTargetObject != nullptr && mVariableName != StringTable->EmptyString())
+      if (mTargetObject != NULL && mVariableName != StringTable->EmptyString())
       {
          return mTargetObject->getDataField(mVariableName, NULL);
       }
@@ -911,7 +911,7 @@ void GuiInspectorField::_registerEditControl(GuiControl* ctrl, StringTableEntry 
    ctrl->setInternalName(suffix);
 
    char szName[512];
-   if (mInspector->getInspectObject() != nullptr)
+   if (mInspector->getInspectObject() != NULL)
       dSprintf(szName, 512, "IE_%s_%d_%s_%s_Field", ctrl->getClassName(), mInspector->getInspectObject()->getId(), suffix, mCaption);
    else
       dSprintf(szName, 512, "IE_%s_%s_%s_Field", ctrl->getClassName(), suffix, mCaption);

--- a/Engine/source/gui/editor/inspector/group.cpp
+++ b/Engine/source/gui/editor/inspector/group.cpp
@@ -696,7 +696,7 @@ void GuiInspectorGroup::addInspectorField(StringTableEntry name, StringTableEntr
    else
       fieldGui = constructField(fieldType);
 
-   if (fieldGui == nullptr)
+   if (fieldGui == NULL)
    {
       //call down into script and see if there's special handling for that type of field
       //this allows us to have completely special-case field types implemented entirely in script
@@ -750,7 +750,7 @@ void GuiInspectorGroup::removeInspectorField(StringTableEntry name)
    {
       GuiInspectorField* field = dynamic_cast<GuiInspectorField*>(mStack->getObject(i));
 
-      if (field == nullptr)
+      if (field == NULL)
          continue;
 
       if (field->getFieldName() == name || field->getSpecialEditVariableName() == name)
@@ -764,7 +764,7 @@ void GuiInspectorGroup::removeInspectorField(StringTableEntry name)
 void GuiInspectorGroup::hideInspectorField(StringTableEntry fieldName, bool setHidden)
 {
    SimObject* inspectObj = mParent->getInspectObject();
-   if (inspectObj == nullptr)
+   if (inspectObj == NULL)
       return;
 
    AbstractClassRep::Field* field = const_cast<AbstractClassRep::Field*>(inspectObj->getClassRep()->findField(fieldName));
@@ -787,7 +787,7 @@ void GuiInspectorGroup::replaceInspectorField(StringTableEntry fieldName, GuiIns
    {
       GuiInspectorField* field = dynamic_cast<GuiInspectorField*>(mStack->getObject(i));
 
-      if (field == nullptr)
+      if (field == NULL)
          continue;
 
       if (field->getFieldName() == fieldName || field->getSpecialEditVariableName() == fieldName)
@@ -878,7 +878,7 @@ DefineEngineMethod(GuiInspectorGroup, findField, S32, (const char* fieldName),,
       return 0;
 
    GuiInspectorField* field = object->findField(StringTable->insert(fieldName));
-   if (field == nullptr)
+   if (field == NULL)
       return 0;
 
    return field->getId();

--- a/Engine/source/gui/editor/inspector/variableField.cpp
+++ b/Engine/source/gui/editor/inspector/variableField.cpp
@@ -97,7 +97,7 @@ bool GuiInspectorVariableField::onAdd()
 
 void GuiInspectorVariableField::setData( const char* data, bool callbacks )
 {   
-   if (mOwnerObject == nullptr && mVariableName == StringTable->EmptyString())
+   if (mOwnerObject == NULL && mVariableName == StringTable->EmptyString())
    {
       if (!mCaption || mCaption[0] == 0)
          return;
@@ -106,7 +106,7 @@ void GuiInspectorVariableField::setData( const char* data, bool callbacks )
    }
    else
    {
-      if (mOwnerObject != nullptr)
+      if (mOwnerObject != NULL)
       {
          //Special case: if our object is a Settings class, we'll assume that we're trying to get/set the fields via the Setting class's normal behavior
          //otherwise, use fields as normal

--- a/Engine/source/gui/editor/inspector/variableInspector.cpp
+++ b/Engine/source/gui/editor/inspector/variableInspector.cpp
@@ -72,7 +72,7 @@ void GuiVariableInspector::update()
    for (U32 i = 0; i < mFields.size(); i++)
    {
       //first, get the var's group name. if the group exists, we'll add to it's list
-      GuiInspectorVariableGroup *group = nullptr;
+      GuiInspectorVariableGroup *group = NULL;
 
       for (U32 g = 0; g < mGroups.size(); g++)
       {
@@ -83,7 +83,7 @@ void GuiVariableInspector::update()
          }
       }
 
-      if (group == nullptr)
+      if (group == NULL)
       {
          group = new GuiInspectorVariableGroup();
 
@@ -164,7 +164,7 @@ void GuiVariableInspector::addField(const char* name, const char* label, const c
 
    //establish the field on the ownerObject(if we have one)
    //This way, we can let the field hook into the object's field and modify it when changed
-   if (newField->mOwnerObject != nullptr)
+   if (newField->mOwnerObject != NULL)
    {
       if (!newField->mOwnerObject->isField(newField->mFieldName))
       {

--- a/Engine/source/gui/editor/popupMenu.cpp
+++ b/Engine/source/gui/editor/popupMenu.cpp
@@ -47,7 +47,7 @@ public:
 PopupMenu::PopupMenu()
 {
    mMenuItems = 0;
-	mMenuBarCtrl = nullptr;
+	mMenuBarCtrl = NULL;
 
 	mBarTitle = StringTable->EmptyString();
 	mBounds = RectI(0, 0, 64, 64);
@@ -57,7 +57,7 @@ PopupMenu::PopupMenu()
 	mDrawBitmapOnly = false;
 	mDrawBorder = false;
 
-	mTextList = nullptr;
+	mTextList = NULL;
 
 	mIsSubmenu = false;
 
@@ -168,8 +168,8 @@ S32 PopupMenu::insertItem(S32 pos, const char *title, const char* accelerator, c
    newItem.mEnabled = !newItem.mIsSpacer;
 
    newItem.mIsSubmenu = false;
-   newItem.mSubMenu = nullptr;
-   newItem.mSubMenuParentMenu = nullptr;
+   newItem.mSubMenu = NULL;
+   newItem.mSubMenuParentMenu = NULL;
 
    mMenuItems.push_back(newItem);
 
@@ -308,7 +308,7 @@ void PopupMenu::showPopup(GuiCanvas *owner, S32 x /* = -1 */, S32 y /* = -1 */)
    if (!profile)
       return;
 
-   if (mTextList == nullptr)
+   if (mTextList == NULL)
    {
       mTextList = new GuiPopupMenuTextListCtrl();
       mTextList->registerObject();
@@ -350,7 +350,7 @@ void PopupMenu::showPopup(GuiCanvas *owner, S32 x /* = -1 */, S32 y /* = -1 */)
    owner->pushDialogControl(backgroundCtrl, 10);
 
    //Set the background control's menubar, if any, and if it's not already set
-   if(backgroundCtrl->mMenuBarCtrl == nullptr)
+   if(backgroundCtrl->mMenuBarCtrl == NULL)
       backgroundCtrl->mMenuBarCtrl = getMenuBarCtrl();
 
    backgroundCtrl->setExtent(owner->getExtent());
@@ -473,7 +473,7 @@ void PopupMenu::hidePopupSubmenus()
 {
    for (U32 i = 0; i < mMenuItems.size(); i++)
    {
-      if (mMenuItems[i].mSubMenu != nullptr)
+      if (mMenuItems[i].mSubMenu != NULL)
          mMenuItems[i].mSubMenu->hidePopup();
    }
 }

--- a/Engine/source/gui/shaderEditor/guiShaderEditor.cpp
+++ b/Engine/source/gui/shaderEditor/guiShaderEditor.cpp
@@ -781,7 +781,7 @@ GuiShaderNode* GuiShaderEditor::findHitNode(const Point2I& pt)
       }
    }
 
-   return nullptr;
+   return NULL;
 }
 
 bool GuiShaderEditor::findHitSocket(const Point2I& pt)
@@ -929,7 +929,7 @@ bool GuiShaderEditor::hasConnection(NodeSocket* inSocket, NodeConnection*& conn)
    {
       if (con->inSocket == dynamic_cast<NodeInput*>(inSocket) || con->outSocket == dynamic_cast<NodeOutput*>(inSocket))
       {
-         if (conn != nullptr)
+         if (conn != NULL)
             conn = con;
          return true;
       }

--- a/Engine/source/gui/utility/guiInputCtrl.cpp
+++ b/Engine/source/gui/utility/guiInputCtrl.cpp
@@ -65,7 +65,7 @@ GuiInputCtrl::GuiInputCtrl()
    mSendModifierEvents(false),
    mIgnoreMouseEvents(false)
 {
-   mActionmap = nullptr;
+   mActionmap = NULL;
 }
 
 //------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ bool GuiInputCtrl::onWake()
    if( !smDesignTime && !mIgnoreMouseEvents)
       mouseLock();
 
-   if(mActionmap != nullptr)
+   if(mActionmap != NULL)
    {
       if (getRoot()->isActive())
       {
@@ -144,7 +144,7 @@ void GuiInputCtrl::onSleep()
    Parent::onSleep();
    mouseUnlock();
 
-   if (mActionmap != nullptr)
+   if (mActionmap != NULL)
    {
       SimSet* actionMapSet = Sim::getActiveActionMapSet();
       actionMapSet->removeObject(mActionmap);
@@ -174,7 +174,7 @@ void GuiInputCtrl::setActive(bool value)
 
 void GuiInputCtrl::handleCanvasSetActive(GuiCanvas* canvas, bool isActive)
 {
-   if (mActionmap == nullptr)
+   if (mActionmap == NULL)
       return;
 
    if (getRoot() == canvas)
@@ -231,7 +231,7 @@ bool GuiInputCtrl::onInputEvent( const InputEventInfo &event )
    if (mIgnoreMouseEvents && event.deviceType == MouseDeviceType)
       return false;
 
-   if (mActionmap != nullptr)
+   if (mActionmap != NULL)
          return false;
 
    char deviceString[32];

--- a/Engine/source/gui/utility/guiRenderTargetVizCtrl.cpp
+++ b/Engine/source/gui/utility/guiRenderTargetVizCtrl.cpp
@@ -60,10 +60,10 @@ GuiRenderTargetVizCtrl::GuiRenderTargetVizCtrl()
 {
    mTargetName = StringTable->EmptyString();
 
-   mTarget = nullptr;
-   mTargetTexture = nullptr;
+   mTarget = NULL;
+   mTargetTexture = NULL;
 
-   mCameraObject = nullptr;
+   mCameraObject = NULL;
 }
 
 //-----------------------------------------------------------------------------
@@ -97,7 +97,7 @@ void GuiRenderTargetVizCtrl::onRender(Point2I      offset,
    //Draw backdrop
    GFX->getDrawUtil()->drawRectFill(boundsRect, ColorI::BLACK);
 
-   if (mCameraObject != nullptr)
+   if (mCameraObject != NULL)
    {
       Camera* camObject = dynamic_cast<Camera*>(mCameraObject);
 

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
@@ -172,7 +172,7 @@ void GuiConvexEditorCtrl::setVisible( bool val )
          }
 
          Scene* scene = Scene::getRootScene();
-         if (scene != nullptr)
+         if (scene != NULL)
          {
             //Make our proxy objects "real" again
             for (U32 i = 0; i < mProxyObjects.size(); ++i)
@@ -228,7 +228,7 @@ void GuiConvexEditorCtrl::setVisible( bool val )
          mSavedGizmoFlags = mGizmoProfile->flags;
 
          Scene* scene = Scene::getRootScene();
-         if (scene != nullptr)
+         if (scene != NULL)
          {
             for (U32 c = 0; c < scene->size(); ++c)
             {

--- a/Engine/source/gui/worldEditor/worldEditor.cpp
+++ b/Engine/source/gui/worldEditor/worldEditor.cpp
@@ -1888,7 +1888,7 @@ WorldEditor::WorldEditor()
    mFadeIcons = true;
    mFadeIconsDist = 8.f;
 
-   mActiveEditorTool = nullptr;
+   mActiveEditorTool = NULL;
 }
 
 WorldEditor::~WorldEditor()
@@ -1982,7 +1982,7 @@ void WorldEditor::on3DMouseMove(const Gui3DMouseEvent & event)
    mHitObject = NULL;
 
    //If we have an active tool and it's intercepted our input, bail out
-   if (mActiveEditorTool != nullptr && mActiveEditorTool->onMouseMove(event))
+   if (mActiveEditorTool != NULL && mActiveEditorTool->onMouseMove(event))
       return;
 
    //
@@ -2014,7 +2014,7 @@ void WorldEditor::on3DMouseMove(const Gui3DMouseEvent & event)
 void WorldEditor::on3DMouseDown(const Gui3DMouseEvent & event)
 {
    //If we have an active tool and it's intercepted our input, bail out
-   if (mActiveEditorTool != nullptr && mActiveEditorTool->onMouseDown(event))
+   if (mActiveEditorTool != NULL && mActiveEditorTool->onMouseDown(event))
       return;
 
    mMouseDown = true;
@@ -2085,7 +2085,7 @@ void WorldEditor::on3DMouseDown(const Gui3DMouseEvent & event)
 void WorldEditor::on3DMouseUp( const Gui3DMouseEvent &event )
 {
    //If we have an active tool and it's intercepted our input, bail out
-   if (mActiveEditorTool != nullptr && mActiveEditorTool->onMouseUp(event))
+   if (mActiveEditorTool != NULL && mActiveEditorTool->onMouseUp(event))
       return;
 
    const bool wasUsingAxisGizmo = mUsingAxisGizmo;
@@ -2249,7 +2249,7 @@ void WorldEditor::on3DMouseUp( const Gui3DMouseEvent &event )
 void WorldEditor::on3DMouseDragged(const Gui3DMouseEvent & event)
 {
    //If we have an active tool and it's intercepted our input, bail out
-   if (mActiveEditorTool != nullptr && mActiveEditorTool->onMouseDragged(event))
+   if (mActiveEditorTool != NULL && mActiveEditorTool->onMouseDragged(event))
       return;
 
    if ( !mMouseDown )
@@ -2488,7 +2488,7 @@ void WorldEditor::renderScene( const RectI &updateRect )
 
    smRenderSceneSignal.trigger(this);
 
-   if (mActiveEditorTool != nullptr)
+   if (mActiveEditorTool != NULL)
       mActiveEditorTool->render();
 	
    // Grab this before anything here changes it.

--- a/Engine/source/materials/materialManager.cpp
+++ b/Engine/source/materials/materialManager.cpp
@@ -165,7 +165,7 @@ Material * MaterialManager::getMaterialDefinitionByName(const String &matName)
 Material* MaterialManager::getMaterialDefinitionByMapTo(const String& mapTo)
 {
    // Get the material
-   Material* foundMat = nullptr;
+   Material* foundMat = NULL;
 
    for (SimSet::iterator itr = mMaterialSet->begin(); itr != mMaterialSet->end(); ++itr)
    {
@@ -546,7 +546,7 @@ DefineEngineFunction(getMaterialInstances, void, (BaseMaterialDefinition* target
    "@brief Dumps a formatted list of currently allocated material instances to the console.\n\n"
    "@ingroup Materials")
 {
-   if (target == nullptr || tree == nullptr)
+   if (target == NULL || tree == NULL)
       return;
 
    MATMGR->getMaterialInstances(target, tree);

--- a/Engine/source/module/moduleManager.cpp
+++ b/Engine/source/module/moduleManager.cpp
@@ -1049,7 +1049,7 @@ ModuleDefinition* ModuleManager::findModuleByFilePath(StringTableEntry filePath)
       }
    }
 
-   return nullptr;
+   return NULL;
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -1207,8 +1207,8 @@ void PostEffect::_setupCubemapTexture(U32 stage, GFXCubemapHandle &inputTex)
 {
    RectI viewport = GFX->getViewport();
 
-   mActiveTextures[stage] = nullptr;
-   mActiveNamedTarget[stage] = nullptr;
+   mActiveTextures[stage] = NULL;
+   mActiveNamedTarget[stage] = NULL;
    mActiveTextureViewport[stage] = viewport;
 
    if (inputTex.isValid())
@@ -1219,8 +1219,8 @@ void PostEffect::_setupCubemapArrayTexture(U32 stage, GFXCubemapArrayHandle &inp
 {
    RectI viewport = GFX->getViewport();
 
-   mActiveTextures[stage] = nullptr;
-   mActiveNamedTarget[stage] = nullptr;
+   mActiveTextures[stage] = NULL;
+   mActiveNamedTarget[stage] = NULL;
    mActiveTextureViewport[stage] = viewport;
 
    if (inputTex.isValid())

--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -73,7 +73,7 @@ S32 RenderProbeMgr::smProbeBakeResolution = 64;
 //
 ProbeRenderInst::ProbeRenderInst() :
    mCubemapIndex(0),
-   mProbeInfo(nullptr)
+   mProbeInfo(NULL)
 {
 }
 
@@ -171,8 +171,8 @@ void ProbeShaderConstants::_onShaderReload()
 //
 RenderProbeMgr::RenderProbeMgr()
 : RenderBinManager(RenderPassManager::RIT_Probes, 1.0f, 1.0f),
-   mLastShader(nullptr),
-   mLastConstants(nullptr),
+   mLastShader(NULL),
+   mLastConstants(NULL),
    mHasSkylight(false),
    mSkylightCubemapIdx(-1),
    mSkylightDamp(true),
@@ -182,7 +182,7 @@ RenderProbeMgr::RenderProbeMgr()
    mEffectiveProbeCount = 0;
    mMipCount = 0;
 
-   mProbeArrayEffect = nullptr;
+   mProbeArrayEffect = NULL;
 
    smProbeManager = this;
 
@@ -205,7 +205,7 @@ RenderProbeMgr::RenderProbeMgr(RenderInstType riType, F32 renderOrder, F32 proce
    mHasSkylight = false;
    mSkylightCubemapIdx = -1;
    mSkylightDamp = true;
-   mLastConstants = nullptr;
+   mLastConstants = NULL;
    mMipCount = 0;
    mUseHDRCaptures = true;
 }
@@ -412,7 +412,7 @@ void RenderProbeMgr::registerProbe(ReflectionProbe::ProbeInfo* newProbe)
 void RenderProbeMgr::unregisterProbe(ReflectionProbe::ProbeInfo* probeInfo)
 {
    ProbeRenderInst* probe = findProbeInst(probeInfo);
-   if (probe == nullptr)
+   if (probe == NULL)
       return;
 
    if (probe->mCubemapIndex == INVALID_CUBE_SLOT)
@@ -438,7 +438,7 @@ PostEffect* RenderProbeMgr::getProbeArrayEffect()
       mProbeArrayEffect = dynamic_cast<PostEffect*>(Sim::findObject("reflectionProbeArrayPostFX"));
 
       if (!mProbeArrayEffect)
-         return nullptr;
+         return NULL;
 
       mProbeArrayEffect->setShaderConst("$numProbes", (S32)0);
       mProbeArrayEffect->setShaderConst("$skylightCubemapIdx", (S32)-1);
@@ -466,7 +466,7 @@ void RenderProbeMgr::updateProbeTexture(ReflectionProbe::ProbeInfo* probeInfo)
 {
    //If we don't have a registered probe, there's no point in updating the cubemap array for it
    ProbeRenderInst* probe = findProbeInst(probeInfo);
-   if (probe == nullptr)
+   if (probe == NULL)
       return;
    U32 scaledSize = getProbeTexSize();
    //Some basic sanity checking that we have valid cubemaps to work with
@@ -527,14 +527,14 @@ void RenderProbeMgr::bakeProbe(ReflectionProbe* probe)
    U32 prefilterMipLevels = mLog2(F32(resolution)) + 1;
    bool renderWithProbes = Con::getIntVariable("$pref::ReflectionProbes::RenderWithProbes", false);
 
-   ReflectionProbe* clientProbe = nullptr;
+   ReflectionProbe* clientProbe = NULL;
 
    if (probe->isServerObject())
       clientProbe = static_cast<ReflectionProbe*>(probe->getClientObject());
    else
       return;
 
-   if (clientProbe == nullptr)
+   if (clientProbe == NULL)
       return;
 
    String probePrefilterPath = clientProbe->getPrefilterMapPath();
@@ -832,7 +832,7 @@ void RenderProbeMgr::_setupPerFrameParameters(const SceneRenderState* state)
 
 void RenderProbeMgr::render( SceneRenderState *state )
 {
-   if (getProbeArrayEffect() == nullptr)
+   if (getProbeArrayEffect() == NULL)
    {
       mActiveProbes.clear();
       return;
@@ -953,7 +953,7 @@ DefineEngineMethod(RenderProbeMgr, bakeProbe, void, (ReflectionProbe* probe), (n
    "@brief Bakes the cubemaps for a reflection probe\n\n.")
 {
    object->preBake();
-   if(probe != nullptr)
+   if(probe != NULL)
       object->bakeProbe(probe);
    object->postBake();
 }

--- a/Engine/source/renderInstance/renderProbeMgr.h
+++ b/Engine/source/renderInstance/renderProbeMgr.h
@@ -329,7 +329,7 @@ protected:
          }
       }
 
-      return nullptr;
+      return NULL;
    }
 
 public:
@@ -482,7 +482,7 @@ public:
 
 RenderProbeMgr* RenderProbeMgr::getProbeManager()
 {
-   if (smProbeManager == nullptr)
+   if (smProbeManager == NULL)
    {
       RenderProbeMgr* probeManager = new RenderProbeMgr();
 

--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -1855,7 +1855,7 @@ DefineEngineMethod(SceneObject, getChild, S32, (S32 _index), (0), "getChild(S32 
 DefineEngineMethod(SceneObject, attachChildAt, bool, (SceneObject* _subObject, MatrixF _offset, S32 _node), (nullAsType<SceneObject*>(), MatrixF::Identity, 0), "(SceneObject subObject, MatrixF offset, S32 offset)"
               "Mount object to this one with the specified offset expressed in our coordinate space.")
 {   
-   if (_subObject != nullptr)
+   if (_subObject != NULL)
    {
       return object->attachChildAt(_subObject, _offset, _node);
    }

--- a/Engine/source/sfx/media/sfxSndStream.cpp
+++ b/Engine/source/sfx/media/sfxSndStream.cpp
@@ -94,7 +94,7 @@ SFXSndStream* SFXSndStream::create(Stream* stream)
       return sfxStream;
 
    delete sfxStream;
-   return nullptr;
+   return NULL;
 }
 
 void SFXSndStream::reset()

--- a/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
+++ b/Engine/source/shaderGen/GLSL/shaderFeatureGLSL.cpp
@@ -391,7 +391,7 @@ Var* ShaderFeatureGLSL::getOutTexCoord(   const char *name,
 		{
 			// Statement allows for casting of different types which
 		   // eliminates vector truncation problems.
-         String statement = String::ToString( "   @ = %s(@ * @);\r\n", type );
+         String statement = String::ToString( "   @ = %s(@) * @;\r\n", type );
          meta->addStatement( new GenOp( statement, texCoord, inTex, tileScale) );
 		}
 	}

--- a/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
+++ b/Engine/source/shaderGen/HLSL/shaderFeatureHLSL.cpp
@@ -391,7 +391,7 @@ Var* ShaderFeatureHLSL::getOutTexCoord(   const char *name,
       {
 		   // Statement allows for casting of different types which
          // eliminates vector truncation problems.
-         String statement = String::ToString( "   @ = (%s)(@ * @);\r\n", type );
+         String statement = String::ToString( "   @ = (%s)(@) * @;\r\n", type );
          meta->addStatement( new GenOp( statement, texCoord, inTex, tileScale) );
       }
    }

--- a/Engine/source/shaderGen/customShaderFeature.cpp
+++ b/Engine/source/shaderGen/customShaderFeature.cpp
@@ -53,10 +53,10 @@ ConsoleDocClass(CustomShaderFeatureData,
 CustomShaderFeatureData::CustomShaderFeatureData()
 {
 #ifdef TORQUE_D3D11
-   mFeatureHLSL = nullptr;
+   mFeatureHLSL = NULL;
 #endif
 #ifdef TORQUE_OPENGL
-   mFeatureGLSL = nullptr;
+   mFeatureGLSL = NULL;
 #endif
 }
 

--- a/Engine/source/shaderGen/featureMgr.cpp
+++ b/Engine/source/shaderGen/featureMgr.cpp
@@ -111,14 +111,14 @@ ShaderFeature* FeatureMgr::createFeature(const FeatureType& type, void* argStruc
       }
    }
 
-   return nullptr;
+   return NULL;
 }
 
 void FeatureMgr::registerFeature(   const FeatureType &type, 
                                     ShaderFeature *feature,
                                     CreateShaderFeatureDelegate featureDelegate)
 {
-   if (feature == nullptr && featureDelegate == nullptr)
+   if (feature == NULL && featureDelegate == NULL)
    {
       AssertFatal(false, "FeatureMgr::registerFeature - no feature or featureDelegate defined, cannot create this feature.");
    }

--- a/Engine/source/shaderGen/featureMgr.h
+++ b/Engine/source/shaderGen/featureMgr.h
@@ -97,8 +97,8 @@ public:
    /// <param name="feature">The shader feature (can be null if featureDelegate defined)</param>
    /// <param name="featureDelegate">The feature delegate create function.</param>
    void registerFeature(const FeatureType& type,
-                        ShaderFeature* feature = nullptr,
-                        CreateShaderFeatureDelegate featureDelegate = nullptr);
+                        ShaderFeature* feature = NULL,
+                        CreateShaderFeatureDelegate featureDelegate = NULL);
 
    // Unregister a feature.
    void unregisterFeature( const FeatureType &type );

--- a/Engine/source/shaderGen/featureSet.cpp
+++ b/Engine/source/shaderGen/featureSet.cpp
@@ -87,7 +87,7 @@ void* FeatureSet::getArguments(U32 index) const
    if (mFeatures[index].argStruct)
       return mFeatures[index].argStruct;
 
-   return nullptr;
+   return NULL;
 }
 
 void FeatureSet::clear()

--- a/Engine/source/shaderGen/shaderGen.cpp
+++ b/Engine/source/shaderGen/shaderGen.cpp
@@ -258,7 +258,7 @@ void ShaderGen::_processVertFeatures( Vector<GFXShaderMacro> &macros, bool macro
       S32 index;
       const FeatureType &type = features.getAt( i, &index );
       void* args = features.getArguments(i);
-      ShaderFeature* feature = nullptr;
+      ShaderFeature* feature = NULL;
       if(args)
          feature = FEATUREMGR->createFeature(type, args);
       else
@@ -307,7 +307,7 @@ void ShaderGen::_processPixFeatures( Vector<GFXShaderMacro> &macros, bool macros
       S32 index;
       const FeatureType &type = features.getAt( i, &index );
       void* args = features.getArguments(i);
-      ShaderFeature* feature = nullptr;
+      ShaderFeature* feature = NULL;
       if (args)
          feature = FEATUREMGR->createFeature(type, args);
       else
@@ -354,7 +354,7 @@ void ShaderGen::_printFeatureList(Stream &stream)
       S32 index;
       const FeatureType &type = features.getAt( i, &index );
       void* args = features.getArguments(i);
-      ShaderFeature* feature = nullptr;
+      ShaderFeature* feature = NULL;
       if (args)
          feature = FEATUREMGR->createFeature(type, args);
       else

--- a/Engine/source/sim/netConnection.h
+++ b/Engine/source/sim/netConnection.h
@@ -864,7 +864,7 @@ public:
    void setScopeObject(NetObject *object);
 
    /// Get the object around which we are currently scoping network traffic.
-   NetObject* getScopeObject() { return nullptr; };
+   NetObject* getScopeObject() { return NULL; };
 
    /// Add an object to scope.
    void objectInScope(NetObject *object);

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -1008,7 +1008,7 @@ void TerrainBlock::addMaterial( const String &name, U32 insertAt )
             if (terrMatAsset && terrMatAsset->getMaterialDefinitionName() == terrMatName)
             {
                //Do iterative logic to find the next available slot and write to it with our new mat field
-               mTerrainAsset->setDataField(StringTable->insert("terrainMaterialAsset"), nullptr, aq->mAssetList[i]);
+               mTerrainAsset->setDataField(StringTable->insert("terrainMaterialAsset"), NULL, aq->mAssetList[i]);
             }
          }
       }

--- a/Engine/source/ts/assimp/assimpAppNode.cpp
+++ b/Engine/source/ts/assimp/assimpAppNode.cpp
@@ -296,7 +296,7 @@ aiNode* AssimpAppNode::findChildNodeByName(const char* nodeName, aiNode* rootNod
       if (retNode)
          return retNode;
    }
-   return nullptr;
+   return NULL;
 }
 
 void AssimpAppNode::addChild(AssimpAppNode* child)

--- a/Engine/source/ts/assimp/assimpAppNode.h
+++ b/Engine/source/ts/assimp/assimpAppNode.h
@@ -78,7 +78,7 @@ protected:
 
 public:
 
-   AssimpAppNode(const aiScene* scene, const aiNode* node, AssimpAppNode* parentNode = nullptr);
+   AssimpAppNode(const aiScene* scene, const aiNode* node, AssimpAppNode* parentNode = NULL);
    virtual ~AssimpAppNode()
    {
       //

--- a/Engine/source/ts/collada/colladaUtils.cpp
+++ b/Engine/source/ts/collada/colladaUtils.cpp
@@ -3019,7 +3019,7 @@ void ColladaUtils::ExportData::processData()
             curDetail->mesh.setTransform(&meshData[meshNum].meshTransform, meshData[meshNum].scale);
             curDetail->mesh.setObject(meshData[meshNum].originatingObject);
 
-            if (meshData[meshNum].shapeInst != nullptr)
+            if (meshData[meshNum].shapeInst != NULL)
             {
 
                if (!meshData[meshNum].shapeInst->buildPolyList(&curDetail->mesh, detailLevelIdx))
@@ -3032,7 +3032,7 @@ void ColladaUtils::ExportData::processData()
             {
                //special handling classes
                ConvexShape* convexShp = dynamic_cast<ConvexShape*>(meshData[meshNum].originatingObject);
-               if (convexShp != nullptr)
+               if (convexShp != NULL)
                {
                   if (!convexShp->buildPolyList(PLC_Export, &curDetail->mesh, meshData[meshNum].originatingObject->getWorldBox(), meshData[meshNum].originatingObject->getWorldSphere()))
                   {

--- a/Engine/source/ts/collada/colladaUtils.h
+++ b/Engine/source/ts/collada/colladaUtils.h
@@ -195,7 +195,7 @@ namespace ColladaUtils
             return -1;
          }
 
-         meshLODData() : shapeInst(nullptr), meshTransform(true), originatingObject(nullptr), scale(0)
+         meshLODData() : shapeInst(NULL), meshTransform(true), originatingObject(NULL), scale(0)
          {}
       };
 

--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -891,7 +891,7 @@ bool TSShapeInstance::hasAccumulation()
    for ( U32 i = 0; i < mMaterialList->size(); ++i )
    {
       BaseMatInstance* mat = mMaterialList->getMaterialInst(i);
-      if (mat != nullptr && mat->hasAccumulation() )
+      if (mat != NULL && mat->hasAccumulation() )
          result = true;
    }
    return result;


### PR DESCRIPTION
while it still remains a good idea to port as many NULL compares and assignments over to nullPtr as feasable, we do still need to sort out how to better support scripted empty, false, and zero assigns for things like objectIDs.

this means we'll need to both fully convert the backend of the parser to support that kind of thing, but also alter most if not all exisiting NULLs. up to and including things like SAFE_DELETE. while that's certainly feasable, given there's aproximatel 400 nullptr assigns/checks prior to this commit, and roughly 1800 of the prior, if it terminates in a script call and not an aip one direct, we'll be dialing that back until such time as fork fully fopcused on converting and resolving any lingering mismatches is completed.