### PR TITLE
navmesh minor tooling fixes

### DIFF
--- a/Engine/source/T3D/item.cpp
+++ b/Engine/source/T3D/item.cpp
@@ -312,6 +312,7 @@ IMPLEMENT_CALLBACK( Item, onLeaveLiquid, void, ( const char* objID, const char* 
 Item::Item()
 {
    mTypeMask |= ItemObjectType | DynamicShapeObjectType;
+   mPathfindingIgnore = true;
    mDataBlock = 0;
    mStatic = false;
    mRotate = false;

--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -1552,7 +1552,7 @@ ConsoleDocClass( Player,
 Player::Player()
 {
    mTypeMask |= PlayerObjectType | DynamicShapeObjectType;
-
+   mPathfindingIgnore = true;
    mDelta.pos = mAnchorPoint = Point3F(0,0,100);
    mDelta.rot = mDelta.head = Point3F(0,0,0);
    mDelta.rotOffset.set(0.0f,0.0f,0.0f);

--- a/Engine/source/T3D/vehicles/vehicle.cpp
+++ b/Engine/source/T3D/vehicles/vehicle.cpp
@@ -376,7 +376,7 @@ Vehicle::Vehicle()
 {
    mDataBlock = 0;
    mTypeMask |= VehicleObjectType | DynamicShapeObjectType;
-
+   mPathfindingIgnore = true;
    mDelta.pos = Point3F(0,0,0);
    mDelta.posVec = Point3F(0,0,0);
    mDelta.warpTicks = mDelta.warpCount = 0;

--- a/Engine/source/navigation/navMesh.cpp
+++ b/Engine/source/navigation/navMesh.cpp
@@ -454,8 +454,8 @@ S32 NavMesh::getLink(const Point3F &pos)
    {
       if(mDeleteLinks[i])
          continue;
-      SphereF start(getLinkStart(i), mLinkRads[i]);
-      SphereF end(getLinkEnd(i), mLinkRads[i]);
+      SphereF start(getLinkStart(i), mMax(mLinkRads[i],0.25f));
+      SphereF end(getLinkEnd(i), mMax(mLinkRads[i], 0.25f));
       if(start.isContained(pos) || end.isContained(pos))
          return i;
    }
@@ -653,7 +653,7 @@ DefineEngineMethod(NavMesh, deleteLinks, void, (),,
 static void buildCallback(SceneObject* object, void* key)
 {
    SceneContainer::CallbackInfo* info = reinterpret_cast<SceneContainer::CallbackInfo*>(key);
-   if (!object->mPathfindingIgnore)
+   if (!object->mPathfindingIgnore && (object->getTypeMask() & MarkerObjectType) == 0)
       object->buildPolyList(info->context, info->polyList, info->boundingBox, info->boundingSphere);
 }
 


### PR DESCRIPTION
don't use MarkerObjectTypes for navmesh generation
do use a minium radius for clicking on a link to select it in the tooling