### PR TITLE
provide a global scriped variable for TSShape::smMaxSkinBones

### DIFF
--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -75,6 +75,10 @@ MODULE_BEGIN( TSShapeInstance )
          "@brief Enables mesh instancing on non-skin meshes that have less that this count of verts.\n"
          "The default value is 2000.  Higher values can degrade performance.\n"
          "@ingroup Rendering\n" );
+
+      Con::addVariable("$MaxSkinBones", TypeS32, &TSShape::smMaxSkinBones,
+         "@brief Max number of bones allowed by a given shape for hardwar skinning. Default 70\n"
+         "@ingroup Rendering\n");
    }
 
 MODULE_END;


### PR DESCRIPTION
allows per project to either expand or educe the cap depending on needs