### PR TITLE
Fix for String arguments for functions

### DIFF
--- a/Engine/source/console/torquescript/astNodes.cpp
+++ b/Engine/source/console/torquescript/astNodes.cpp
@@ -1529,6 +1529,7 @@ U32 FunctionDeclStmtNode::compileStmt(CodeStream& codeStream, U32 ip)
 
    CodeBlock::smInFunction = false;
 
+   setCurrentStringTable(&getGlobalStringTable());
    // check for argument setup
    for (VarNode* walk = args; walk; walk = (VarNode*)((StmtNode*)walk)->getNext())
    {
@@ -1541,6 +1542,7 @@ U32 FunctionDeclStmtNode::compileStmt(CodeStream& codeStream, U32 ip)
          ip = walk->defaultValue->compile(codeStream, ip, walkType);
       }
    }
+   setCurrentStringTable(&getFunctionStringTable());
 
    codeStream.emit(OP_FUNC_DECL);
    codeStream.emitSTE(fnName);


### PR DESCRIPTION
strings that are arguments for a function need to be put into the global string table. PrecompileIdent does this for the function name etc so it pulls from that during compiled eval

```
function test(%x = "test")
{
   echo(%x);
}
```

Should now result in test being output before it was pulling a random string.

Issue Reported by Abbey