### PR TITLE
fix clicking a treeview element tripping expand/collapse

### DIFF
--- a/Engine/source/gui/controls/guiTreeViewCtrl.cpp
+++ b/Engine/source/gui/controls/guiTreeViewCtrl.cpp
@@ -3389,7 +3389,7 @@ void GuiTreeViewCtrl::onMouseDown(const GuiEvent & event)
    mPossibleRenameItem = NULL;
    mRenamingItem = NULL;
    mTempItem = NULL;
-      
+   bool wasSelected = isSelected(item);
    //
    if( event.modifier & SI_MULTISELECT )
    {
@@ -3473,8 +3473,7 @@ void GuiTreeViewCtrl::onMouseDown(const GuiEvent & event)
    else if ( !hitFlags.test(OnImage) )
    {      
       mTempItem = item;
-
-      bool wasSelected = isSelected( item );
+      
       bool multiSelect = getSelectedItemsCount() > 1;
       
       if( !wasSelected || !multiSelect )
@@ -3520,7 +3519,7 @@ void GuiTreeViewCtrl::onMouseDown(const GuiEvent & event)
       return;
 
    //
-   if ( mFullRowSelect || hitFlags.test( OnImage ) )
+   if ((mFullRowSelect || hitFlags.test(OnImage)) && wasSelected)
    {
       item->setExpanded(!item->isExpanded());
       if( !item->isInspectorData() && item->mState.test(Item::VirtualParent) )


### PR DESCRIPTION
set the wasselected check earlier in the test chain, and test against it  so just selecting it doesn't automatically also trip expand/collapse