### PR TITLE
Expanded Script Assert Context

### DIFF
--- a/Engine/source/T3D/SubScene.cpp
+++ b/Engine/source/T3D/SubScene.cpp
@@ -225,7 +225,16 @@ bool SubScene::evaluateCondition()
       Con::setBoolVariable(resVar.c_str(), false);
       String command = resVar + "=" + mLoadIf + ";";
 
-      Con::evaluatef(command.c_str());
+      StringTableEntry objectName = getName();
+      if (objectName != NULL)
+         objectName = getIdString();
+
+      StringTableEntry groupName = getGroup()->getName();
+      if (groupName != NULL)
+         groupName = getGroup()->getIdString();
+
+      String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
+      Con::evaluate(command.c_str(), false, context);
       return Con::getBoolVariable(resVar.c_str());
    }
    return true;

--- a/Engine/source/T3D/missionMarker.cpp
+++ b/Engine/source/T3D/missionMarker.cpp
@@ -367,7 +367,17 @@ bool SpawnSphere::testCondition()
    String resVar = getIdString() + String(".result");
    Con::setBoolVariable(resVar.c_str(), false);
    String command = resVar + "=" + mSpawnIf + ";";
-   Con::evaluatef(command.c_str());
+
+   StringTableEntry objectName = getName();
+   if (objectName != NULL)
+      objectName = getIdString();
+
+   StringTableEntry groupName = getGroup()->getName();
+   if (groupName != NULL)
+      groupName = getGroup()->getIdString();
+
+   String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
+   Con::evaluate(command.c_str(), false, context);
    if (Con::getBoolVariable(resVar.c_str()) == 1)
    {
       return true;

--- a/Engine/source/T3D/trigger.cpp
+++ b/Engine/source/T3D/trigger.cpp
@@ -704,7 +704,17 @@ bool Trigger::testCondition()
    String resVar = getIdString() + String(".result");
    Con::setBoolVariable(resVar.c_str(), false);
    String command = resVar + "=" + mTripIf + ";";
-   Con::evaluatef(command.c_str());
+
+   StringTableEntry objectName = getName();
+   if (objectName != NULL)
+      objectName = getIdString();
+
+   StringTableEntry groupName = getGroup()->getName();
+   if (groupName != NULL)
+      groupName = getGroup()->getIdString();
+
+   String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
+   Con::evaluate(command.c_str(), false, context);
    if (Con::getBoolVariable(resVar.c_str()) == 1)
    {
       return true;
@@ -743,8 +753,15 @@ void Trigger::potentialEnterObject(GameBase* enter)
          String command = String("%obj = ") + enter->getIdString() + ";";
          command = command + String("%this = ") + getIdString() + ";" + mEnterCommand;
 
-         StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getIdString();
-         String context = String::ToString("%s, %s", getGroup(), objectName);
+         StringTableEntry objectName = getName();
+         if (objectName != NULL)
+            objectName = getIdString();
+
+         StringTableEntry groupName = getGroup()->getName();
+         if (groupName != NULL)
+            groupName = getGroup()->getIdString();
+
+         String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
          Con::evaluate(command.c_str(), false, context);
       }
 
@@ -795,8 +812,15 @@ void Trigger::processTick(const Move* move)
                String command = String("%obj = ") + remove->getIdString() + ";";
                command = command + String("%this = ") + getIdString() + ";" + mLeaveCommand;
 
-               StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getIdString();
-               String context = String::ToString("%s, %s", getGroup(), objectName);
+               StringTableEntry objectName = getName();
+               if (objectName != NULL)
+                  objectName = getIdString();
+
+               StringTableEntry groupName = getGroup()->getName();
+               if (groupName != NULL)
+                  groupName = getGroup()->getIdString();
+
+               String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
                Con::evaluate(command.c_str(), false, context);
             }
             if (testTrippable() && testCondition())
@@ -807,8 +831,15 @@ void Trigger::processTick(const Move* move)
 
       if (evalCmD(&mTickCommand))
       {
-         StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getIdString();
-         String context = String::ToString("%s, %s", getGroup(), objectName);
+         StringTableEntry objectName = getName();
+         if (objectName != NULL)
+            objectName = getIdString();
+
+         StringTableEntry groupName = getGroup()->getName();
+         if (groupName != NULL)
+            groupName = getGroup()->getIdString();
+
+         String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
          Con::evaluate(mTickCommand.c_str(), false, context);
       }
 

--- a/Engine/source/T3D/trigger.cpp
+++ b/Engine/source/T3D/trigger.cpp
@@ -742,7 +742,10 @@ void Trigger::potentialEnterObject(GameBase* enter)
       {
          String command = String("%obj = ") + enter->getIdString() + ";";
          command = command + String("%this = ") + getIdString() + ";" + mEnterCommand;
-         Con::evaluate(command.c_str());
+
+         StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getIdString();
+         String context = String::ToString("%s, %s", getGroup(), objectName);
+         Con::evaluate(command.c_str(), false, context);
       }
 
       if( mDataBlock && testTrippable() && testCondition())
@@ -791,7 +794,10 @@ void Trigger::processTick(const Move* move)
             {
                String command = String("%obj = ") + remove->getIdString() + ";";
                command = command + String("%this = ") + getIdString() + ";" + mLeaveCommand;
-               Con::evaluate(command.c_str());
+
+               StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getIdString();
+               String context = String::ToString("%s, %s", getGroup(), objectName);
+               Con::evaluate(command.c_str(), false, context);
             }
             if (testTrippable() && testCondition())
                mDataBlock->onLeaveTrigger_callback( this, remove );
@@ -800,7 +806,11 @@ void Trigger::processTick(const Move* move)
       }
 
       if (evalCmD(&mTickCommand))
-         Con::evaluate(mTickCommand.c_str());
+      {
+         StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getIdString();
+         String context = String::ToString("%s, %s", getGroup(), objectName);
+         Con::evaluate(mTickCommand.c_str(), false, context);
+      }
 
       if (mObjects.size() != 0 && testTrippable() && testCondition())
          mDataBlock->onTickTrigger_callback( this );

--- a/Engine/source/console/consoleFunctions.cpp
+++ b/Engine/source/console/consoleFunctions.cpp
@@ -2367,8 +2367,7 @@ DefineEngineFunction( exec, bool, ( const char* fileName, bool noCalls, bool jou
 
 DefineEngineFunction( eval, const char*, ( const char* consoleString, bool echo ), (false), "eval(consoleString)")
 {
-   Con::EvalResult returnValue = Con::evaluate(consoleString, echo, NULL);
-
+   Con::EvalResult returnValue = Con::evaluate(consoleString, echo, Platform::makeRelativePathName(Con::getCurrentScriptModulePath(), NULL));
    return Con::getReturnBuffer(returnValue.value.getString());
 }
 

--- a/Engine/source/console/torquescript/astNodes.cpp
+++ b/Engine/source/console/torquescript/astNodes.cpp
@@ -60,7 +60,7 @@ inline FuncVars* getFuncVars(S32 lineNumber)
    if (gFuncVars == &gGlobalScopeFuncVars)
    {
       const char* lineTxt = CodeBlock::smCurrentLineText;
-      const char* str = avar("Attemping to use local variable in global scope. File: %s Line Num: %d \nLine: %s", CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineTxt);
+      const char* str = avar("Attemping to use local variable in global scope. File: %s\nLine Num: %d\nLine: \"%s\"", CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineTxt);
       scriptErrorHandler(str);
    }
    return gFuncVars;

--- a/Engine/source/console/torquescript/astNodes.cpp
+++ b/Engine/source/console/torquescript/astNodes.cpp
@@ -59,7 +59,8 @@ inline FuncVars* getFuncVars(S32 lineNumber)
 {
    if (gFuncVars == &gGlobalScopeFuncVars)
    {
-      const char* str = avar("Attemping to use local variable in global scope. File: %s Line: %d", CodeBlock::smCurrentParser->getCurrentFile(), lineNumber);
+      const char* lineTxt = CodeBlock::smCurrentLineText;
+      const char* str = avar("Attemping to use local variable in global scope. File: %s Line Num: %d \nLine: %s", CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineTxt);
       scriptErrorHandler(str);
    }
    return gFuncVars;

--- a/Engine/source/console/torquescript/codeBlock.cpp
+++ b/Engine/source/console/torquescript/codeBlock.cpp
@@ -35,7 +35,7 @@ using namespace Compiler;
 
 bool           CodeBlock::smInFunction = false;
 CodeBlock *    CodeBlock::smCodeBlockList = NULL;
-StringTableEntry CodeBlock::smCurrentLineText = StringTable->EmptyString();
+const char* CodeBlock::smCurrentLineText = "\0";
 TorqueScriptParser *CodeBlock::smCurrentParser = NULL;
 
 extern FuncVars gEvalFuncVars;
@@ -625,6 +625,7 @@ Con::EvalResult CodeBlock::compileExec(StringTableEntry fileName, const char *in
 
    if (!Script::gStatementList)
    {
+      smCurrentLineText = "\0";
       delete this;
       return Con::EvalResult(Con::getVariable("$ScriptError"));
    }
@@ -670,7 +671,10 @@ Con::EvalResult CodeBlock::compileExec(StringTableEntry fileName, const char *in
       Con::warnf(ConsoleLogEntry::General, "precompile size mismatch, precompile: %d compile: %d", codeSize, lastIp);
 
    // repurpose argc as local register counter for global state
-   return (exec(0, fileName, NULL, localRegisterCount, 0, noCalls, NULL, setFrame));
+   Con::EvalResult execResult = (exec(0, fileName, NULL, localRegisterCount, 0, noCalls, NULL, setFrame));
+
+   smCurrentLineText = "\0";
+   return execResult;
 }
 
 //-------------------------------------------------------------------------

--- a/Engine/source/console/torquescript/codeBlock.cpp
+++ b/Engine/source/console/torquescript/codeBlock.cpp
@@ -35,6 +35,7 @@ using namespace Compiler;
 
 bool           CodeBlock::smInFunction = false;
 CodeBlock *    CodeBlock::smCodeBlockList = NULL;
+StringTableEntry CodeBlock::smCurrentLineText = StringTable->EmptyString();
 TorqueScriptParser *CodeBlock::smCurrentParser = NULL;
 
 extern FuncVars gEvalFuncVars;
@@ -578,6 +579,7 @@ Con::EvalResult CodeBlock::compileExec(StringTableEntry fileName, const char *in
    consoleAllocReset();
 
    name = fileName;
+   smCurrentLineText = inString;
 
    if (fileName)
    {

--- a/Engine/source/console/torquescript/codeBlock.h
+++ b/Engine/source/console/torquescript/codeBlock.h
@@ -61,7 +61,7 @@ private:
 public:
    static bool                      smInFunction;
    static TorqueScriptParser * smCurrentParser;
-   static StringTableEntry smCurrentLineText;
+   static const char* smCurrentLineText;
 
    static CodeBlock *getCodeBlockList()
    {

--- a/Engine/source/console/torquescript/codeBlock.h
+++ b/Engine/source/console/torquescript/codeBlock.h
@@ -61,6 +61,7 @@ private:
 public:
    static bool                      smInFunction;
    static TorqueScriptParser * smCurrentParser;
+   static StringTableEntry smCurrentLineText;
 
    static CodeBlock *getCodeBlockList()
    {

--- a/Engine/source/console/torquescript/compiler.cpp
+++ b/Engine/source/console/torquescript/compiler.cpp
@@ -160,8 +160,16 @@ S32 FuncVars::assign(StringTableEntry var, TypeReq currentType, S32 lineNumber, 
 
       if (found->second.isConstant)
       {
-         const char* lineTxt = CodeBlock::smCurrentLineText;
-         const char* str = avar("Script Warning: Reassigning variable %s when it is a constant. File: %s Line Num: %d \nLine: %s", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineTxt);
+         const char* lineText = CodeBlock::smCurrentLineText;
+
+         String codeString = CodeBlock::smCurrentLineText;
+         Vector<String> splitLines;
+         codeString.split("\n", splitLines);
+
+         if (lineNumber > 0 && splitLines.size() > lineNumber)
+            lineText = splitLines[lineNumber - 1].c_str();
+
+         const char* str = avar("Script Warning: Reassigning variable %s when it is a constant. File: %s\nLine Num: %d\nLine: \"%s\"", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineText);
          scriptErrorHandler(str);
       }
       return found->second.reg;
@@ -180,8 +188,16 @@ S32 FuncVars::lookup(StringTableEntry var, S32 lineNumber)
 
    if (found == vars.end())
    {
-      const char* lineTxt = CodeBlock::smCurrentLineText;
-      const char* str = avar("Script Warning: Variable %s referenced before used when compiling script. File: %s Line Num: %d \nLine: %s", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineTxt);
+      const char* lineText = CodeBlock::smCurrentLineText;
+
+      String codeString = CodeBlock::smCurrentLineText;
+      Vector<String> splitLines;
+      codeString.split("\n", splitLines);
+
+      if (lineNumber > 0 && splitLines.size() > lineNumber)
+         lineText = splitLines[lineNumber - 1].c_str();
+
+      const char* str = avar("Script Warning: Variable %s referenced before used when compiling script. File: %s\nLine Num: %d\nLine: \"%s\"", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineText);
       scriptErrorHandler(str);
 
       return assign(var, TypeReqString, lineNumber, false);
@@ -197,7 +213,15 @@ TypeReq FuncVars::lookupType(StringTableEntry var, S32 lineNumber)
    if (found == vars.end())
    {
       const char* lineText = CodeBlock::smCurrentLineText;
-      const char* str = avar("Script Warning: Variable %s referenced before used when compiling script. File: %s Line Num: %d \nLine: %s", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineText);
+
+      String codeString = CodeBlock::smCurrentLineText;
+      Vector<String> splitLines;
+      codeString.split("\n", splitLines);
+
+      if (lineNumber > 0 && splitLines.size() > lineNumber)
+         lineText = splitLines[lineNumber-1].c_str();
+
+      const char* str = avar("Script Warning: Variable %s referenced before used when compiling script. File: %s\nLine Num: %d\nLine: \"%s\"", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineText);
       scriptErrorHandler(str);
 
       assign(var, TypeReqString, lineNumber, false);

--- a/Engine/source/console/torquescript/compiler.cpp
+++ b/Engine/source/console/torquescript/compiler.cpp
@@ -160,7 +160,8 @@ S32 FuncVars::assign(StringTableEntry var, TypeReq currentType, S32 lineNumber, 
 
       if (found->second.isConstant)
       {
-         const char* str = avar("Script Warning: Reassigning variable %s when it is a constant. File: %s Line : %d", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber);
+         const char* lineTxt = CodeBlock::smCurrentLineText;
+         const char* str = avar("Script Warning: Reassigning variable %s when it is a constant. File: %s Line Num: %d \nLine: %s", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineTxt);
          scriptErrorHandler(str);
       }
       return found->second.reg;
@@ -179,7 +180,8 @@ S32 FuncVars::lookup(StringTableEntry var, S32 lineNumber)
 
    if (found == vars.end())
    {
-      const char* str = avar("Script Warning: Variable %s referenced before used when compiling script. File: %s Line: %d", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber);
+      const char* lineTxt = CodeBlock::smCurrentLineText;
+      const char* str = avar("Script Warning: Variable %s referenced before used when compiling script. File: %s Line Num: %d \nLine: %s", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineTxt);
       scriptErrorHandler(str);
 
       return assign(var, TypeReqString, lineNumber, false);
@@ -194,7 +196,8 @@ TypeReq FuncVars::lookupType(StringTableEntry var, S32 lineNumber)
 
    if (found == vars.end())
    {
-      const char* str = avar("Script Warning: Variable %s referenced before used when compiling script. File: %s Line: %d", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber);
+      const char* lineText = CodeBlock::smCurrentLineText;
+      const char* str = avar("Script Warning: Variable %s referenced before used when compiling script. File: %s Line Num: %d \nLine: %s", var, CodeBlock::smCurrentParser->getCurrentFile(), lineNumber, lineText);
       scriptErrorHandler(str);
 
       assign(var, TypeReqString, lineNumber, false);

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -974,7 +974,9 @@ void GuiGameListMenuCtrl::doScriptCommand(StringTableEntry command)
    if (command && command[0])
    {
       setThisControl();
-      Con::evaluate(command, false, __FILE__);
+      StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
+      String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+      Con::evaluate(command, false, context);
    }
 }
 

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -975,7 +975,7 @@ void GuiGameListMenuCtrl::doScriptCommand(StringTableEntry command)
    {
       setThisControl();
       StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
-      String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+      String context = String::ToString("%s\nObject: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
       Con::evaluate(command, false, context);
    }
 }

--- a/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
@@ -494,7 +494,9 @@ void GuiGameSettingsCtrl::doScriptCommand(StringTableEntry command)
    if (command && command[0])
    {
       setThisControl();
-      Con::evaluate(command, false, __FILE__);
+      StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
+      String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+      Con::evaluate(command, false, context);
    }
 }
 

--- a/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
@@ -495,7 +495,7 @@ void GuiGameSettingsCtrl::doScriptCommand(StringTableEntry command)
    {
       setThisControl();
       StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
-      String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+      String context = String::ToString("%s\nObject: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
       Con::evaluate(command, false, context);
    }
 }

--- a/Engine/source/gui/controls/guiListBoxCtrl.cpp
+++ b/Engine/source/gui/controls/guiListBoxCtrl.cpp
@@ -1539,7 +1539,9 @@ StringTableEntry GuiListBoxCtrl::_makeMirrorItemName( SimObject *inObj )
       Con::setIntVariable( "$ThisControl", getId() );
       Con::setIntVariable( "$ThisObject", inObj->getId() );
 
-      outName = StringTable->insert( Con::evaluate( mMakeNameCallback ).value, true );
+      StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
+      String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+      outName = StringTable->insert( Con::evaluate( mMakeNameCallback, false, context).value, true );
    }
    else if ( inObj->getName() )
       outName = StringTable->insert( inObj->getName() );

--- a/Engine/source/gui/controls/guiMLTextEditCtrl.cpp
+++ b/Engine/source/gui/controls/guiMLTextEditCtrl.cpp
@@ -211,7 +211,9 @@ bool GuiMLTextEditCtrl::onKeyDown(const GuiEvent& event)
          case KEY_ESCAPE:
             if ( mEscapeCommand[0] )
             {
-               Con::evaluate( mEscapeCommand );
+               StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
+               String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+               Con::evaluate( mEscapeCommand, false, context );
                return( true );
             }
             return( Parent::onKeyDown( event ) );

--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -2495,8 +2495,14 @@ void GuiControl::getCursor(GuiCursor *&cursor, bool &showCursor, const GuiEvent 
 const char* GuiControl::evaluate( const char* str )
 {
    smThisControl = this;
-   StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
-   String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+   StringTableEntry objectName = getName();
+   if (getName() == NULL)
+      objectName = getInternalName();
+   StringTableEntry fileName = getFilename();
+   if (fileName != NULL)
+      fileName = Platform::makeRelativePathName(fileName, NULL);
+
+   String context = String::ToString("%s\nObject: %s", fileName, objectName);
    const char* result = Con::evaluate(str, false, context).value;
    smThisControl = NULL;
 

--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -2495,7 +2495,9 @@ void GuiControl::getCursor(GuiCursor *&cursor, bool &showCursor, const GuiEvent 
 const char* GuiControl::evaluate( const char* str )
 {
    smThisControl = this;
-   const char* result = Con::evaluate(str, false).value;
+   StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
+   String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+   const char* result = Con::evaluate(str, false, context).value;
    smThisControl = NULL;
 
    return result;

--- a/Engine/source/sim/actionMap.cpp
+++ b/Engine/source/sim/actionMap.cpp
@@ -1482,8 +1482,12 @@ bool ActionMap::processAction(const InputEventInfo* pEvent)
       if(pNode->flags & Node::BindCmd)
       {
          // it's a bind command
-         if(pNode->makeConsoleCommand)
-            Con::evaluate(pNode->makeConsoleCommand);
+         if (pNode->makeConsoleCommand)
+         {
+            StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
+            String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+            Con::evaluate(pNode->makeConsoleCommand, false, context);
+         }
       }
       else if (pNode->flags & Node::Held)
       {

--- a/Engine/source/sim/actionMap.cpp
+++ b/Engine/source/sim/actionMap.cpp
@@ -1485,7 +1485,7 @@ bool ActionMap::processAction(const InputEventInfo* pEvent)
          if (pNode->makeConsoleCommand)
          {
             StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
-            String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
+            String context = String::ToString("%s\nObject: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
             Con::evaluate(pNode->makeConsoleCommand, false, context);
          }
       }


### PR DESCRIPTION
Caches the processed line in CodeBlock for better assert reporting
Adds additional context on eval and evaluate calls to better isolate script executions that are throwing errors, such as via command fields or eval() calls.