### PR TITLE
minor cleanups for https://github.com/TorqueGameEngines/Torque3D/pull/1672

### DIFF
--- a/Engine/source/T3D/trigger.cpp
+++ b/Engine/source/T3D/trigger.cpp
@@ -28,6 +28,7 @@
 #include "console/engineAPI.h"
 #include "collision/boxConvex.h"
 #include "console/script.h"
+#include "console/consoleInternal.h"
 
 #include "core/stream/bitStream.h"
 #include "math/mathIO.h"
@@ -172,8 +173,9 @@ Trigger::Trigger()
 
    mPhysicsRep = NULL;
    mTripOnce = false;
+   mTripped = false;
    mTrippedBy = 0xFFFFFFFF;
-   mTripIf = "";
+   mTripIf.clear();
 
    //Default up a basic square
    Point3F vecs[3] = { Point3F(1.0, 0.0, 0.0),
@@ -748,21 +750,11 @@ void Trigger::potentialEnterObject(GameBase* enter)
       mObjects.push_back(enter);
       deleteNotify(enter);
 
-      if(evalCmD(&mEnterCommand))
+      if(isServerObject() && evalCmD(&mEnterCommand))
       {
          String command = String("%obj = ") + enter->getIdString() + ";";
          command = command + String("%this = ") + getIdString() + ";" + mEnterCommand;
-
-         StringTableEntry objectName = getName();
-         if (objectName != NULL)
-            objectName = getIdString();
-
-         StringTableEntry groupName = getGroup()->getName();
-         if (groupName != NULL)
-            groupName = getGroup()->getIdString();
-
-         String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
-         Con::evaluate(command.c_str(), false, context);
+         Con::evaluate(command.c_str(), false, Con::getCurrentScriptModulePath());
       }
 
       if( mDataBlock && testTrippable() && testCondition())
@@ -807,21 +799,11 @@ void Trigger::processTick(const Move* move)
             mObjects.erase(i);
             clearNotify(remove);
             
-            if (evalCmD(&mLeaveCommand))
+            if (isServerObject() && evalCmD(&mLeaveCommand))
             {
                String command = String("%obj = ") + remove->getIdString() + ";";
                command = command + String("%this = ") + getIdString() + ";" + mLeaveCommand;
-
-               StringTableEntry objectName = getName();
-               if (objectName != NULL)
-                  objectName = getIdString();
-
-               StringTableEntry groupName = getGroup()->getName();
-               if (groupName != NULL)
-                  groupName = getGroup()->getIdString();
-
-               String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
-               Con::evaluate(command.c_str(), false, context);
+               Con::evaluate(command.c_str(), false, Con::getCurrentScriptModulePath());
             }
             if (testTrippable() && testCondition())
                mDataBlock->onLeaveTrigger_callback( this, remove );
@@ -829,7 +811,7 @@ void Trigger::processTick(const Move* move)
          }
       }
 
-      if (evalCmD(&mTickCommand))
+      if (isServerObject() && evalCmD(&mTickCommand))
       {
          StringTableEntry objectName = getName();
          if (objectName != NULL)

--- a/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameSettingsCtrl.cpp
@@ -496,7 +496,7 @@ void GuiGameSettingsCtrl::doScriptCommand(StringTableEntry command)
       setThisControl();
       StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
       String context = String::ToString("%s\nObject: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
-      Con::evaluate(command, false, context);
+      Con::evaluate(command, false, context.c_str());
    }
 }
 

--- a/Engine/source/gui/controls/guiMLTextEditCtrl.cpp
+++ b/Engine/source/gui/controls/guiMLTextEditCtrl.cpp
@@ -213,7 +213,7 @@ bool GuiMLTextEditCtrl::onKeyDown(const GuiEvent& event)
             {
                StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
                String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
-               Con::evaluate( mEscapeCommand, false, context );
+               Con::evaluate( mEscapeCommand, false, context.c_str());
                return( true );
             }
             return( Parent::onKeyDown( event ) );

--- a/Engine/source/sim/actionMap.cpp
+++ b/Engine/source/sim/actionMap.cpp
@@ -1486,7 +1486,7 @@ bool ActionMap::processAction(const InputEventInfo* pEvent)
          {
             StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
             String context = String::ToString("%s\nObject: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
-            Con::evaluate(pNode->makeConsoleCommand, false, context);
+            Con::evaluate(pNode->makeConsoleCommand, false, context.c_str());
          }
       }
       else if (pNode->flags & Node::Held)


### PR DESCRIPTION
for context Strings, use c_str(),
for triggers, use Con::getCurrentScriptModulePath() as otherwise, the "%this =" and "%obj=" injections will be treated as within the global scope. which is not allowed.