### PR TITLE
context safties

### DIFF
--- a/Engine/source/T3D/SubScene.cpp
+++ b/Engine/source/T3D/SubScene.cpp
@@ -229,12 +229,12 @@ bool SubScene::evaluateCondition()
       if (objectName != NULL)
          objectName = getIdString();
 
-      StringTableEntry groupName = getGroup()->getName();
+      StringTableEntry groupName = getGroup() ? getGroup()->getName() : NULL;
       if (groupName != NULL)
          groupName = getGroup()->getIdString();
 
       String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
-      Con::evaluate(command.c_str(), false, context);
+      Con::evaluate(command.c_str(), false, context.c_str());
       return Con::getBoolVariable(resVar.c_str());
    }
    return true;

--- a/Engine/source/T3D/missionMarker.cpp
+++ b/Engine/source/T3D/missionMarker.cpp
@@ -372,12 +372,12 @@ bool SpawnSphere::testCondition()
    if (objectName != NULL)
       objectName = getIdString();
 
-   StringTableEntry groupName = getGroup()->getName();
+   StringTableEntry groupName = getGroup() ? getGroup()->getName() : NULL;
    if (groupName != NULL)
       groupName = getGroup()->getIdString();
 
    String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
-   Con::evaluate(command.c_str(), false, context);
+   Con::evaluate(command.c_str(), false, context.c_str());
    if (Con::getBoolVariable(resVar.c_str()) == 1)
    {
       return true;

--- a/Engine/source/T3D/trigger.cpp
+++ b/Engine/source/T3D/trigger.cpp
@@ -711,12 +711,12 @@ bool Trigger::testCondition()
    if (objectName != NULL)
       objectName = getIdString();
 
-   StringTableEntry groupName = getGroup()->getName();
+   StringTableEntry groupName = getGroup() ? getGroup()->getName() : NULL;
    if (groupName != NULL)
       groupName = getGroup()->getIdString();
 
    String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
-   Con::evaluate(command.c_str(), false, context);
+   Con::evaluate(command.c_str(), false, context.c_str());
    if (Con::getBoolVariable(resVar.c_str()) == 1)
    {
       return true;
@@ -817,7 +817,7 @@ void Trigger::processTick(const Move* move)
          if (objectName != NULL)
             objectName = getIdString();
 
-         StringTableEntry groupName = getGroup()->getName();
+         StringTableEntry groupName = getGroup() ? getGroup()->getName() : NULL;
          if (groupName != NULL)
             groupName = getGroup()->getIdString();
 

--- a/Engine/source/console/torquescript/codeBlock.cpp
+++ b/Engine/source/console/torquescript/codeBlock.cpp
@@ -611,7 +611,7 @@ Con::EvalResult CodeBlock::compileExec(StringTableEntry fileName, const char *in
    Script::gStatementList = NULL;
 
    // we are an eval compile if we don't have a file name associated (no exec)
-   gIsEvalCompile = fileName == NULL;
+   gIsEvalCompile = fileName == NULL || setFrame == 0;
    gFuncVars = gIsEvalCompile ? &gEvalFuncVars : &gGlobalScopeFuncVars;
 
    // Set up the parser.

--- a/Engine/source/console/torquescript/runtime.cpp
+++ b/Engine/source/console/torquescript/runtime.cpp
@@ -38,8 +38,10 @@ namespace TorqueScript
       if (fileName)
          fileName = StringTable->insert(fileName);
 
+      bool fileExec = Torque::FS::IsFile(fileName);
+
       CodeBlock* newCodeBlock = new CodeBlock();
-      return (newCodeBlock->compileExec(fileName, string, false, fileName ? -1 : 0));
+      return (newCodeBlock->compileExec(fileName, string, false, fileExec ? -1 : 0));
    }
 
    Con::EvalResult TorqueScriptRuntime::evaluate(const char* script, S32 frame, bool echo, const char* fileName)

--- a/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
+++ b/Engine/source/gui/controls/guiGameListMenuCtrl.cpp
@@ -976,7 +976,7 @@ void GuiGameListMenuCtrl::doScriptCommand(StringTableEntry command)
       setThisControl();
       StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
       String context = String::ToString("%s\nObject: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
-      Con::evaluate(command, false, context);
+      Con::evaluate(command, false, context.c_str());
    }
 }
 

--- a/Engine/source/gui/controls/guiListBoxCtrl.cpp
+++ b/Engine/source/gui/controls/guiListBoxCtrl.cpp
@@ -1541,7 +1541,7 @@ StringTableEntry GuiListBoxCtrl::_makeMirrorItemName( SimObject *inObj )
 
       StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
       String context = String::ToString("%s, Object: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);
-      outName = StringTable->insert( Con::evaluate( mMakeNameCallback, false, context).value, true );
+      outName = StringTable->insert( Con::evaluate( mMakeNameCallback, false, context.c_str()).value, true );
    }
    else if ( inObj->getName() )
       outName = StringTable->insert( inObj->getName() );

--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -2496,14 +2496,15 @@ const char* GuiControl::evaluate( const char* str )
 {
    smThisControl = this;
    StringTableEntry objectName = getName();
-   if (getName() == NULL)
-      objectName = getInternalName();
-   StringTableEntry fileName = getFilename();
-   if (fileName != NULL)
-      fileName = Platform::makeRelativePathName(fileName, NULL);
+   if (objectName != NULL)
+      objectName = getIdString();
 
-   String context = String::ToString("%s\nObject: %s", fileName, objectName);
-   const char* result = Con::evaluate(str, false, context).value;
+   StringTableEntry groupName = getGroup() ? getGroup()->getName() : NULL;
+   if (groupName != NULL)
+      groupName = getGroup()->getIdString();
+
+   String context = String::ToString("%s\nGroup: %s, Object: %s", getFilename(), groupName, objectName);
+   const char* result = Con::evaluate(str, false, context.c_str()).value;
    smThisControl = NULL;
 
    return result;


### PR DESCRIPTION
and from Marauder, hardened filename entry for con::evaluate/compileexec. if the string forwarded along is not a real filename, consider it an eval block