### PR TITLE
Update ImageAsset.cpp

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -669,8 +669,8 @@ void ImageAsset::populateImage(void)
             mImageHeight = tempFile->mHeight;
          }
 
-         ddsFs->close();
          delete tempFile;
+         delete ddsFs;
       }
       else
       {


### PR DESCRIPTION
the opened ddsfs file for pulling metadata was leaking. The FileStream function close does not delete the pointer to the original file only FileObject does this. It might be worthwhile instead to switch to using fileObject anywhere we use a filestream that way we can be at least somewhat safe in using the object and once it goes out of scope the raw pointer will be freed