### PR TITLE
Fix wrong variable in physics collision loop

### DIFF
--- a/Engine/source/T3D/player.cpp
+++ b/Engine/source/T3D/player.cpp
@@ -5169,7 +5169,7 @@ bool Player::updatePos(const F32 travelTime)
             Collision& colCheck = collisionList[i];
             if (colCheck.object)
             {
-               SceneObject* obj = static_cast<SceneObject*>(col.object);
+               SceneObject* obj = static_cast<SceneObject*>(colCheck.object);
                if (obj->getTypeMask() & PlayerObjectType)
                {
                   _handleCollision( colCheck );


### PR DESCRIPTION
  ---
  ## Summary

  Fixes a bug in `Player::updatePos()` where the wrong variable was used when iterating through physics collision results.

  ## The Bug

  In the physics-enabled collision handling loop at line 5172:

  ```cpp
  for (U32 i=0; i<collisionList.getCount(); ++i)
  {
     Collision& colCheck = collisionList[i];
     if (colCheck.object)
     {
        SceneObject* obj = static_cast<SceneObject*>(col.object);  // BUG: should be colCheck.object
        if (obj->getTypeMask() & PlayerObjectType)
        ...

  The code was checking col.object instead of colCheck.object.

  Impact

  - First iteration: col is uninitialized (zeroed), so col.object is null
  - Subsequent iterations: col contains the previous iteration's value, checking wrong object type

  The Fix

  Changed col.object to colCheck.object to check the correct collision object.

  Testing

  This fix has been tested in a T3D-based project and resolves player collision issues.

Co-Authored by GLM-5
