### PR TITLE
client projectile origin tweak

### DIFF
--- a/Engine/source/T3D/projectile.cpp
+++ b/Engine/source/T3D/projectile.cpp
@@ -873,8 +873,11 @@ bool Projectile::onAdd()
       }
    }
    if (mSourceObject.isValid())
+   {
       processAfter(mSourceObject);
-
+      if (isClientObject())
+         mSourceObject->getRenderMuzzlePoint(mSourceObjectSlot, &mCurrPosition);
+   }
    // Setup our bounding box
    if (bool(mDataBlock->getProjectileShape()) == true)
       mObjBox = mDataBlock->getProjectileShape()->mBounds;


### PR DESCRIPTION
on the client, start the projectile simulation starting point at the rendered muzzlepoint (reminder server corrective packets will force it to converge as it goes along) origional report/revision suggestion couressy loljester: https://discord.com/channels/358091480004558848/358091480004558849/1476994844005109893