### PR TITLE
fix decal editor bounds and decalmanager raycast

### DIFF
--- a/Engine/source/T3D/decal/decalManager.cpp
+++ b/Engine/source/T3D/decal/decalManager.cpp
@@ -660,12 +660,14 @@ DecalInstance* DecalManager::raycast( const Point3F &start, const Point3F &end, 
          RayInfo ri;
          bool containsPoint = false;
          if ( gServerContainer.castRayRendered( start, end, STATIC_COLLISION_TYPEMASK, &ri ) )
-         {        
+         {
+            RectF rect = inst->mDataBlock->texRect[inst->mTextureRectIdx];
+            rect.extent *= inst->mSize * 0.5f;
             Point2F poly[4];
-            poly[0].set( inst->mPosition.x - (inst->mSize / 2), inst->mPosition.y + (inst->mSize / 2));
-            poly[1].set( inst->mPosition.x - (inst->mSize / 2), inst->mPosition.y - (inst->mSize / 2));
-            poly[2].set( inst->mPosition.x + (inst->mSize / 2), inst->mPosition.y - (inst->mSize / 2));
-            poly[3].set( inst->mPosition.x + (inst->mSize / 2), inst->mPosition.y + (inst->mSize / 2));
+            poly[0].set(inst->mPosition.x - rect.extent.x, inst->mPosition.y + rect.extent.y);
+            poly[1].set( inst->mPosition.x - rect.extent.x, inst->mPosition.y - rect.extent.y);
+            poly[2].set( inst->mPosition.x + rect.extent.x, inst->mPosition.y - rect.extent.y);
+            poly[3].set( inst->mPosition.x + rect.extent.x, inst->mPosition.y + rect.extent.y);
             
             if ( MathUtils::pointInPolygon( poly, 4, Point2F(ri.point.x, ri.point.y) ) )
                containsPoint = true;

--- a/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiDecalEditorCtrl.cpp
@@ -516,11 +516,12 @@ void GuiDecalEditorCtrl::renderScene(const RectI & updateRect)
       if ( gDecalManager->clipDecal( mSELDecal, &mSELEdgeVerts ) )
          _renderDecalEdge( mSELEdgeVerts, ColorI( 255, 255, 255, 255 ) );
 
-      const F32 &decalSize = mSELDecal->mSize;
+      const F32 &decalSize = mSELDecal->mSize * 0.5;
       Point3F boxSize( decalSize, decalSize, decalSize );
-
       MatrixF worldMat( true );
-      mSELDecal->getWorldMatrix( &worldMat, true );   
+      mSELDecal->getWorldMatrix( &worldMat, true );
+      RectF rect = mSELDecal->mDataBlock->texRect[mSELDecal->mTextureRectIdx];
+      worldMat.scale(Point3F(rect.extent.x, rect.extent.y, 0.25f));
 
       drawUtil->drawObjectBox( desc, boxSize, mSELDecal->mPosition, worldMat, ColorI( 255, 255, 255, 255 ) );
    }
@@ -531,11 +532,13 @@ void GuiDecalEditorCtrl::renderScene(const RectI & updateRect)
       if ( gDecalManager->clipDecal( mHLDecal, &mHLEdgeVerts ) )
          _renderDecalEdge( mHLEdgeVerts, ColorI( 255, 255, 255, 255 ) );
 
-      const F32 &decalSize = mHLDecal->mSize;
+      const F32 &decalSize = mHLDecal->mSize * 0.5;
       Point3F boxSize( decalSize, decalSize, decalSize );
 
       MatrixF worldMat( true );
       mHLDecal->getWorldMatrix( &worldMat, true );  
+      RectF rect = mHLDecal->mDataBlock->texRect[mHLDecal->mTextureRectIdx];
+      worldMat.scale(Point3F(rect.extent.x, rect.extent.y, 0.25f));
 
       drawUtil->drawObjectBox( desc, boxSize, mHLDecal->mPosition, worldMat, ColorI( 255, 255, 255, 255 ) );
    }


### PR DESCRIPTION
we weren't accounting for texRects for decal atlases