### PR TITLE
fix for hasaccumulation exception

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -1164,19 +1164,19 @@ void ShapeBase::onRemove()
 {
    mConvexList->nukeList();
 
-   Parent::onRemove();
-
-   // Stop any running sounds on the client
-   if (isGhost())
-      for (S32 i = 0; i < MaxSoundThreads; i++)
-         stopAudio(i);
-
    // Accumulation and environment mapping
    if (isClientObject() && mShapeInstance)
    {
       if (mShapeInstance->hasAccumulation())
          AccumulationVolume::removeObject(this);
    }
+
+   Parent::onRemove();
+
+   // Stop any running sounds on the client
+   if (isGhost())
+      for (S32 i = 0; i < MaxSoundThreads; i++)
+         stopAudio(i);
 
    if ( isClientObject() )   
    {

--- a/Engine/source/ts/tsShapeInstance.cpp
+++ b/Engine/source/ts/tsShapeInstance.cpp
@@ -239,8 +239,11 @@ void TSShapeInstance::initMeshObjects()
 void TSShapeInstance::setMaterialList( TSMaterialList *matList )
 {
    // get rid of old list
-   if ( mOwnMaterialList )
+   if (mOwnMaterialList)
+   {
       delete mMaterialList;
+      mMaterialList = NULL;
+   }
 
    mMaterialList = matList;
    mOwnMaterialList = false;
@@ -891,6 +894,9 @@ void TSShapeInstance::prepCollision()
 // Returns true is the shape contains any materials with accumulation enabled.
 bool TSShapeInstance::hasAccumulation()
 {
+   if (!mOwnMaterialList || mMaterialList == NULL)
+      return false;
+
    bool result = false;
    for ( U32 i = 0; i < mMaterialList->size(); ++i )
    {


### PR DESCRIPTION
There is an exception on teardown usually during a debug build that is caused during shapeBase onRemove calling hasAccumulation.

This fix reorders the hasAccumulation check to be before shapebase calls Parent::onRemove, and also hard sets the mMaterialList to NULL when setMaterialList is called