### PR TITLE
Revert "client projectile origin tweak"

### DIFF
--- a/Engine/source/T3D/projectile.cpp
+++ b/Engine/source/T3D/projectile.cpp
@@ -873,11 +873,8 @@ bool Projectile::onAdd()
       }
    }
    if (mSourceObject.isValid())
-   {
       processAfter(mSourceObject);
-      if (isClientObject())
-         mSourceObject->getRenderMuzzlePoint(mSourceObjectSlot, &mCurrPosition);
-   }
+
    // Setup our bounding box
    if (bool(mDataBlock->getProjectileShape()) == true)
       mObjBox = mDataBlock->getProjectileShape()->mBounds;


### PR DESCRIPTION
Reverts TorqueGameEngines/Torque3D#1691

this actually turned out to be in direct conflict with other folks wanting to be able to specify a scripted offset. so we'll need to take a different tack