### PR TITLE
correct element gui resizing drift

### DIFF
--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -1382,6 +1382,8 @@ void GuiControl::parentResized(const RectI &oldParentRect, const RectI &newParen
 
 	S32 deltaX = newParentRect.extent.x - oldParentRect.extent.x;
  	S32 deltaY = newParentRect.extent.y - oldParentRect.extent.y;
+   F32 nudgeX = (deltaX > 0) ? -0.001f : 0.001f;
+   F32 nudgeY = (deltaY > 0) ? -0.001f : 0.001f;
 
 	if (mHorizSizing == horizResizeCenter)
 	   newPosition.x = (newParentRect.extent.x - getWidth()) >> 1;
@@ -1391,40 +1393,34 @@ void GuiControl::parentResized(const RectI &oldParentRect, const RectI &newParen
       newPosition.x += deltaX;
    else if (mHorizSizing == horizResizeRelative && oldParentRect.extent.x != 0)
    {
-      S32 newLeft = mRoundToNearest( ( F32( newPosition.x ) / F32( oldParentRect.extent.x ) ) * F32( newParentRect.extent.x ) );
-      S32 newWidth = mRoundToNearest( ( F32( newExtent.x ) / F32( oldParentRect.extent.x ) ) * F32( newParentRect.extent.x ) );
+      S32 newLeft = mRoundToNearest( ( F32( newPosition.x ) / F32( oldParentRect.extent.x ) ) * F32( newParentRect.extent.x ) + nudgeX);
+      S32 newWidth = mRoundToNearest( ( F32( newExtent.x ) / F32( oldParentRect.extent.x ) ) * F32( newParentRect.extent.x ) + nudgeX);
 
       newPosition.x = newLeft;
       newExtent.x = newWidth;
    }
    else if (mHorizSizing == horizResizeAspectLeft && oldParentRect.extent.x != 0)
    {
-      S32 newLeft = mRoundToNearest((F32(newPosition.x) / F32(oldParentRect.extent.x)) * F32(newParentRect.extent.x));
-      S32 newWidth = mRoundToNearest((F32(newExtent.x) / F32(oldParentRect.extent.y)) * F32(newParentRect.extent.y));
+      F32 heightRatio = F32(newParentRect.extent.y) / F32(oldParentRect.extent.y);
+      S32 newWidth = mRoundToNearest(F32(newExtent.x) * heightRatio + nudgeX);
 
-      newPosition.x = newLeft;
+      S32 newRight = newPosition.x + newExtent.x + deltaX;
+      newPosition.x = newRight - newWidth;
       newExtent.x = newWidth;
    }
    else if (mHorizSizing == horizResizeAspectRight && oldParentRect.extent.x != 0)
    {
-      S32 newLeft = mRoundToNearest((F32(newPosition.x) / F32(oldParentRect.extent.x)) * F32(newParentRect.extent.x));
-      S32 newWidth = mRoundToNearest((F32(newExtent.x) / F32(oldParentRect.extent.y)) * F32(newParentRect.extent.y)); //origional aspect ratio corrected width
-      S32 rWidth = mRoundToNearest((F32(newExtent.x) / F32(oldParentRect.extent.x)) * F32(newParentRect.extent.x)); //parent aspect ratio relative width
-
-      S32 offset = rWidth - newWidth; // account for change in relative width
-      newLeft += offset;
-      newPosition.x = newLeft;
+      F32 heightRatio = F32(newParentRect.extent.y) / F32(oldParentRect.extent.y);
+      S32 newWidth = mRoundToNearest(F32(newExtent.x) * heightRatio + nudgeX);
       newExtent.x = newWidth;
    }
    else if (mHorizSizing == horizResizeAspectCenter && oldParentRect.extent.x != 0)
    {
-      S32 newLeft = mRoundToNearest((F32(newPosition.x) / F32(oldParentRect.extent.x)) * F32(newParentRect.extent.x));
-      S32 newWidth = mRoundToNearest((F32(newExtent.x) / F32(oldParentRect.extent.y)) * F32(newParentRect.extent.y)); //origional aspect ratio corrected width
-      S32 rWidth = mRoundToNearest((F32(newExtent.x) / F32(oldParentRect.extent.x)) * F32(newParentRect.extent.x)); //parent aspect ratio relative width
-
-      S32 offset = rWidth - newWidth; // account for change in relative width
-      newLeft += offset/2;
-      newPosition.x = newLeft;
+      F32 heightRatio = F32(newParentRect.extent.y) / F32(oldParentRect.extent.y);
+      S32 newWidth = mRoundToNearest(F32(newExtent.x) * heightRatio + nudgeX);
+      S32 center = newPosition.x + (newExtent.x >> 1);
+      center += deltaX >> 1;
+      newPosition.x = center - (newWidth >> 1);
       newExtent.x = newWidth;
    }
 
@@ -1436,40 +1432,32 @@ void GuiControl::parentResized(const RectI &oldParentRect, const RectI &newParen
       newPosition.y += deltaY;
    else if(mVertSizing == vertResizeRelative && oldParentRect.extent.y != 0)
    {
-      S32 newTop = mRoundToNearest( ( F32( newPosition.y ) / F32( oldParentRect.extent.y ) ) * F32( newParentRect.extent.y ) );
-      S32 newHeight = mRoundToNearest( ( F32( newExtent.y ) / F32( oldParentRect.extent.y ) ) * F32( newParentRect.extent.y ) );
+      S32 newHeight = mRoundToNearest( ( F32( newExtent.y ) / F32( oldParentRect.extent.y ) ) * F32( newParentRect.extent.y ) + nudgeY );
+      S32 newTop = mRoundToNearest( ( F32( newPosition.y ) / F32( oldParentRect.extent.y ) ) * F32( newParentRect.extent.y ) + nudgeY );
 
       newPosition.y = newTop;
       newExtent.y = newHeight;
    }
    else if (mVertSizing == vertResizeAspectTop && oldParentRect.extent.y != 0)
    {
-      S32 newTop = mRoundToNearest((F32(newPosition.y) / F32(oldParentRect.extent.y)) * F32(newParentRect.extent.y));
-      S32 newHeight = mRoundToNearest((F32(newExtent.y) / F32(oldParentRect.extent.x)) * F32(newParentRect.extent.x));
-
-      newPosition.y = newTop;
+      F32 widthRatio = F32(newParentRect.extent.x) / F32(oldParentRect.extent.x);
+      S32 newHeight = mRoundToNearest(F32(newExtent.y) * widthRatio + nudgeY);
+      newPosition.y += deltaY;
       newExtent.y = newHeight;
    }
    else if (mVertSizing == vertResizeAspectBottom && oldParentRect.extent.y != 0)
    {
-      S32 newTop = mRoundToNearest((F32(newPosition.y) / F32(oldParentRect.extent.y)) * F32(newParentRect.extent.y));
-      S32 newHeight = mRoundToNearest((F32(newExtent.y) / F32(oldParentRect.extent.x)) * F32(newParentRect.extent.x)); //origional aspect ratio corrected hieght
-      S32 rHeight = mRoundToNearest((F32(newExtent.y) / F32(oldParentRect.extent.y)) * F32(newParentRect.extent.y)); //parent aspect ratio relative hieght
-
-      S32 offset = rHeight - newHeight; // account for change in relative hieght
-      newTop += offset;
-      newPosition.y = newTop;
+      F32 widthRatio = F32(newParentRect.extent.x) / F32(oldParentRect.extent.x);
+      S32 newHeight = mRoundToNearest(F32(newExtent.y) * widthRatio + nudgeY);
       newExtent.y = newHeight;
    }
    else if (mVertSizing == vertResizeAspectCenter && oldParentRect.extent.y != 0)
    {
-      S32 newTop = mRoundToNearest((F32(newPosition.y) / F32(oldParentRect.extent.y)) * F32(newParentRect.extent.y));
-      S32 newHeight = mRoundToNearest((F32(newExtent.y) / F32(oldParentRect.extent.x)) * F32(newParentRect.extent.x)); //origional aspect ratio corrected hieght
-      S32 rHeight = mRoundToNearest((F32(newExtent.y) / F32(oldParentRect.extent.y)) * F32(newParentRect.extent.y)); //parent aspect ratio relative hieght
-
-      S32 offset = rHeight - newHeight; // account for change in relative hieght
-      newTop += offset / 2;
-      newPosition.y = newTop;
+      F32 widthRatio = F32(newParentRect.extent.x) / F32(oldParentRect.extent.x);
+      S32 newHeight = mRoundToNearest(F32(newExtent.y) * widthRatio + nudgeY);
+      S32 center = newPosition.y + (newExtent.y >> 1);
+      center += deltaY >> 1;
+      newPosition.y = center - (newHeight >> 1);
       newExtent.y = newHeight;
    }
 


### PR DESCRIPTION
add minimal padding to counteract floating point flutter when rounding due to changes in parent element scale. revisit the aspect maintining resizer math to correct a few failures with live editing the values.