### PR TITLE
AssetImportConfig::loadImportConfig safety

### DIFF
--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -238,6 +238,11 @@ void AssetImportConfig::initPersistFields()
 
 void AssetImportConfig::loadImportConfig(Settings* configSettings, String configName)
 {
+   if (!configSettings)
+   {
+      Con::errorf("AssetImportConfig::loadImportConfig - No config settings!");
+      return;
+   }
    //General
    DuplicateAutoResolution = configSettings->value(String(configName + "/General/DuplicateAutoResolution").c_str());
    WarningsAsErrors = dAtob(configSettings->value(String(configName + "/General/WarningsAsErrors").c_str()));


### PR DESCRIPTION
if no Settings* passed, report and skip trying to apply them to a nonexisent object