### PR TITLE
fix F32 Camera::getDamageFlash() recursion

### DIFF
--- a/Engine/source/T3D/camera.cpp
+++ b/Engine/source/T3D/camera.cpp
@@ -1603,7 +1603,7 @@ F32 Camera::getDamageFlash() const
    {
       const GameBase *castObj = mOrbitObject;
       const ShapeBase* psb = dynamic_cast<const ShapeBase*>(castObj);
-      if (psb)
+      if (psb && !(dynamic_cast<const Camera*>(psb)))
          return psb->getDamageFlash();
    }
 

--- a/Engine/source/afx/afxCamera.cpp
+++ b/Engine/source/afx/afxCamera.cpp
@@ -1144,7 +1144,7 @@ F32 afxCamera::getDamageFlash() const
   {
     const GameBase *castObj = mOrbitObject;
     const ShapeBase* psb = dynamic_cast<const ShapeBase*>(castObj);
-    if (psb)
+    if (psb && !(dynamic_cast<const Camera*>(psb) || dynamic_cast<const afxCamera*>(psb)) )
       return psb->getDamageFlash();
   }
 


### PR DESCRIPTION
if for some reason a camera ends up orbiting itself or another camera, make sure we don't look to the camera orbiting the camera orbiting the....