### PR TITLE
adress https://github.com/TorqueGameEngines/Torque3D/issues/97

### DIFF
--- a/Engine/source/T3D/fx/ribbon.cpp
+++ b/Engine/source/T3D/fx/ribbon.cpp
@@ -608,8 +608,6 @@ void Ribbon::createBuffers(SceneRenderState *state, GFXVertexBufferHandle<GFXVer
          tColor.interpolate(curColor, nextColor, positionDiff);
       }
 
-      if (i < 2 || i > segments - 2) tRadius = POINT_EPSILON * POINT_EPSILON;
-
       Point3F diff;
       F32 length;
       if (i == 0) {

--- a/Engine/source/T3D/fx/ribbon.cpp
+++ b/Engine/source/T3D/fx/ribbon.cpp
@@ -195,6 +195,7 @@ Ribbon::Ribbon()
    mSegmentIdx = 0;
 
    mTravelledDistance = 0;
+   mImmobileTicks = 0;
 }
 
 Ribbon::~Ribbon()
@@ -346,7 +347,7 @@ void Ribbon::addSegmentPoint(Point3F &point, MatrixF &mat) {
    xform.setColumn(3, point);
    setTransform(xform);
 
-   if(mSegmentIdx < mDataBlock->mSegmentSkipAmount)
+   if (mSegmentIdx < mDataBlock->mSegmentSkipAmount)
    {
       mSegmentIdx++;
       return;
@@ -356,7 +357,26 @@ void Ribbon::addSegmentPoint(Point3F &point, MatrixF &mat) {
 
    U32 segmentsToDelete = checkRibbonDistance(mDataBlock->segmentsPerUpdate);
 
-   for (U32 i = 0; i < segmentsToDelete; i++) {
+   U32 i;
+
+   F32 maxSize = mDataBlock->mSizes[0];
+   for (i = 1; i < RibbonData::NumFields; ++i) {
+      if (mDataBlock->mSizes[i] > 0.0f && mDataBlock->mSizes[i] > maxSize)
+         maxSize = mDataBlock->mSizes[i];
+   }
+   F32 movementThreshold = maxSize * 0.1f;
+   if (mSegmentPoints.size() && ((point - mSegmentPoints[0]).lenSquared() < movementThreshold * movementThreshold))
+   {
+      mImmobileTicks++;
+      if (mImmobileTicks > TickMs)
+      {
+         segmentsToDelete = mMax(segmentsToDelete, 1);
+         mImmobileTicks = 0;
+      }
+   }
+   else mImmobileTicks = 0;
+
+   for (i = 0; i < segmentsToDelete; i++) {
       S32 last = mSegmentPoints.size() - 1;
       if (last < 0)
          break;
@@ -374,10 +394,13 @@ void Ribbon::addSegmentPoint(Point3F &point, MatrixF &mat) {
       return;
    }
 
+   if (mImmobileTicks > 0)
+      return;
+
    Point3F startPoint = mSegmentPoints[0];
 
    //add X points based on how many segments Per Update from last point to current point
-   for (U32 i = 0; i < mDataBlock->segmentsPerUpdate; i++) {
+   for (i = 0; i < mDataBlock->segmentsPerUpdate; i++) {
 
       F32 interp = (F32(i+1) / (F32)mDataBlock->segmentsPerUpdate);
       //(end - start) * percentage) + start
@@ -450,7 +473,7 @@ U32 Ribbon::checkRibbonDistance(S32 segments) {
    if (difference < 0)
       return mAbs(difference);
 
-   return 0;  //do not delete any points
+   return 0;
 }
 
 void Ribbon::setShaderParams() {
@@ -584,6 +607,8 @@ void Ribbon::createBuffers(SceneRenderState *state, GFXVertexBufferHandle<GFXVer
          tRadius = curRadius + (nextRadius - curRadius) * positionDiff;
          tColor.interpolate(curColor, nextColor, positionDiff);
       }
+
+      if (i < 2 || i > segments - 2) tRadius = POINT_EPSILON * POINT_EPSILON;
 
       Point3F diff;
       F32 length;

--- a/Engine/source/T3D/fx/ribbon.h
+++ b/Engine/source/T3D/fx/ribbon.h
@@ -90,7 +90,7 @@ class Ribbon : public GameBase
    F32 mFadeAwayStep;   ///< How quickly the ribbons is faded away after deletion.
    F32 mFadeOut;
    F32 mTravelledDistance; ///< How far the ribbon has travelled in it's lifetime.
-
+   U32 mImmobileTicks;
    Vector<Point3F> mSegmentPoints; ///< The points in space where the ribbon has spawned segments.
    U32 mSegmentOffset;
    U32 mSegmentIdx;


### PR DESCRIPTION
this laregly occured due to adding ribbon nodes in smaller increments than the size of a given quad. we therefore skip adding new ribbon nodes if velocity, as determined by the point deltas, would be below 10% of the largest scale a given quad for that link in the ribbon would be. as this will result in lower than a max length ribbon, also adds a timeout mechanism of removing a link every TickMS (32 ticks/second, or roughly how often one would also be aded when in a growth state) for full finalization do still need to circle back and adress why there remains 1 quad spawned after motion.