### PR TITLE
adds a pathshape useEase value.-on by default.

### DIFF
--- a/Engine/source/T3D/cameraSpline.cpp
+++ b/Engine/source/T3D/cameraSpline.cpp
@@ -71,6 +71,7 @@ CameraSpline::CameraSpline()
    mFront = NULL;
    mSize = 0;
    mIsMapDirty = true;
+   mUseEase = true;
    VECTOR_SET_ASSOCIATION(mTimeMap);
 }
 
@@ -296,7 +297,7 @@ F32 CameraSpline::getTime(F32 d)
 void CameraSpline::value(F32 t, CameraSpline::Knot *result, bool skip_rotation)
 {
    // Do some easing in and out for t.
-   if(!gBuilding)
+   if(!gBuilding && mUseEase)
    {
       F32 oldT = t;
       if(oldT < 0.5f)

--- a/Engine/source/T3D/cameraSpline.h
+++ b/Engine/source/T3D/cameraSpline.h
@@ -76,8 +76,8 @@ public:
    void push_front(Knot *w) { push_back(w); mFront = w; mIsMapDirty = true; }
 
    Knot* getKnot(S32 i);
-   Knot* next(Knot *k) { return (k && k->next == mFront) ? k : k->next; }
-   Knot* prev(Knot *k) { return (k && k == mFront) ? k : k->prev; }
+   Knot* next(Knot *k) { return (k && k->next != mFront) ? k->next : mFront; }
+   Knot* prev(Knot *k) { return (k && k->prev != mFront) ? k->prev : mFront; }
 
    F32 advanceTime(F32 t, S32 delta_ms);
    F32 advanceDist(F32 t, F32 meters);
@@ -85,7 +85,7 @@ public:
 
    F32 getDistance(F32 t);
    F32 getTime(F32 d);
-
+   void useEase(bool ease = true) { mUseEase = ease; }
    void renderTimeMap();
 
 
@@ -93,7 +93,7 @@ private:
    Knot *mFront;
    S32 mSize;
    bool mIsMapDirty;
-
+   bool mUseEase;
    struct TimeMap {
       F32 mTime;
       F32 mDistance;

--- a/Engine/source/T3D/pathShape.cpp
+++ b/Engine/source/T3D/pathShape.cpp
@@ -46,16 +46,20 @@ void PathShapeData::initPersistFields()
 {
    docsURL;
    Parent::initPersistFields();
+   addField("useEase", TypeBool, Offset(mUseEase, PathShapeData), "Whether to use ease in and out when moving along the path.\n");
+
 }
 
 void PathShapeData::packData(BitStream* stream)
 {
    Parent::packData(stream);
+   stream->writeFlag(mUseEase);
 }
 
 void PathShapeData::unpackData(BitStream* stream)
 {
    Parent::unpackData(stream);
+   mUseEase = stream->readFlag();
 }
 
 
@@ -109,7 +113,7 @@ bool PathShape::onAdd()
          CameraSpline::Knot::NORMAL, CameraSpline::Knot::SPLINE));
       mNodeCount = 1;
    }
-
+   mSpline.useEase(mDataBlock->mUseEase);
    if (isServerObject()) scriptOnAdd();
    return true;
 
@@ -135,6 +139,7 @@ bool PathShape::onNewDataBlock(GameBaseData* dptr, bool reload)
       return false;
 
    scriptOnNewDataBlock(reload);
+   mSpline.useEase(mDataBlock->mUseEase);
    return true;
 }
 
@@ -152,9 +157,7 @@ void PathShape::initPersistFields()
    addField( "Path", TYPEID< SimObjectRef<SimPath::Path> >(), Offset( mSimPath, PathShape ),
          "@brief Name of a Path to follow." );
 
-   addField("Controler", TypeString, Offset(mControl, PathShape), 4, "controlers");
-
-   Parent::initPersistFields();
+   addField("Controler", TypeString, Offset(mControl, PathShape), 4, "controlers");   Parent::initPersistFields();
 
 }
 

--- a/Engine/source/T3D/pathShape.h
+++ b/Engine/source/T3D/pathShape.h
@@ -30,6 +30,7 @@ struct PathShapeData: public StaticShapeData {
    static void initPersistFields();
    void packData(BitStream* stream) override;
    void unpackData(BitStream* stream) override;
+   bool mUseEase;
 };
 
 


### PR DESCRIPTION
camerasplines in general previously assumed you would always want to ease in and out at the first and final node. even when looping. adds an mUsease to it, and to pathshapedata to optionally shut that off. (on by default to behave as legacy)