### PR TITLE
Damage model fix

### DIFF
--- a/Templates/BaseGame/game/data/DamageModel/DamageModel.tscript
+++ b/Templates/BaseGame/game/data/DamageModel/DamageModel.tscript
@@ -9,6 +9,7 @@ function DamageModel::onDestroy(%this)
 //This is called when the server is initially set up by the game application
 function DamageModel::initServer(%this)
 {
+   %this.queueExec("./scripts/server/player");
 }
 
 //This is called when the server is created for an actual game/map to be played
@@ -22,7 +23,6 @@ function DamageModel::onCreateGameServer(%this)
    %this.queueExec("./scripts/server/weapon");
    %this.queueExec("./scripts/server/shapeBase");
    %this.queueExec("./scripts/server/vehicle");
-   %this.queueExec("./scripts/server/player");
    %this.queueExec("./scripts/server/commands");
 }
 

--- a/Templates/BaseGame/game/data/DamageModel/scripts/server/player.tscript
+++ b/Templates/BaseGame/game/data/DamageModel/scripts/server/player.tscript
@@ -2,27 +2,31 @@ function PlayerData::damage(%this, %obj, %sourceObject, %position, %damage, %dam
 {
    if (!isObject(%obj) || %obj.getDamageState() !$= "Enabled" || !%damage)
       return;
-      
+
    %rootObj = %obj;
    if (%obj.healthFromMount)
       %rootObj = findRootObject(%obj);
-      
+
+   %this.setDamageDirection(%rootObj, %sourceObject, %position);
+
+   if (%damageType !$= "Suicide") {
+      %getDamageLoc = %rootObj.getDamageLocation(%position);
+      %damageLoc = firstWord(%getDamageLoc);
+   }
+
    %rootObj.applyDamage(%damage);
    %this.onDamage(%rootObj, %damage);
-   
-   %this.setDamageDirection(%rootObj, %sourceObject, %position);
-   
+
    // Deal with client callbacks here because we don't have this
    // information in the onDamage or onDisable methods
    %client = %rootObj.client;
    %sourceClient = %sourceObject ? %sourceObject.client : 0;
 
-   %location = "Body";
    if (isObject(%client))
    {
       if (%rootObj.getDamageState() !$= "Enabled")
       {
-         callGamemodeFunction("onDeath", %client, %sourceObject, %sourceClient, %damageType, %location);
+         callGamemodeFunction("onDeath", %client, %sourceObject, %sourceClient, %damageType, %damageLoc);
       }
    }
 }
@@ -30,7 +34,7 @@ function PlayerData::damage(%this, %obj, %sourceObject, %position, %damage, %dam
 function PlayerData::onDamage(%this, %obj, %delta)
 {
    Parent::onDamage(%this, %obj, %delta);
-   
+
    // This method is invoked by the ShapeBase code whenever the
    // object's damage level changes.
    if (%delta > 0 && %obj.getDamageState() !$= "Destroyed")


### PR DESCRIPTION
1.moved execution of  %this.queueExec("./scripts/server/player"); to not override fpsPlayer module
2.added simple barebones implementation of getDamageLocation to playerData::damage, more sophisticated version in fpsPlayer module playerData::damage