### PR TITLE
Tweaks the logic to how the editor handles toggling and setting of camera modes to behave more consistently,

### DIFF
--- a/Templates/BaseGame/game/core/core.tscript
+++ b/Templates/BaseGame/game/core/core.tscript
@@ -88,6 +88,8 @@ function CoreModule::onCreate(%this)
    
    //This is used to build the remap keybind sets for the different actionMaps.
    $RemapCount = 0;
+   
+   $editorCameraMode = "1st Person"; //largely just used for camera mode toggling
 }
 
 function CoreModule::onDestroy(%this)

--- a/Templates/BaseGame/game/tools/VPathEditor/Scripts/Plugin.tscript
+++ b/Templates/BaseGame/game/tools/VPathEditor/Scripts/Plugin.tscript
@@ -12,6 +12,7 @@ new ScriptObject( VPathEditorPlugin )
 
 function VPathEditorPlugin::onWorldEditorStartup( %this )
 {
+   return; //disabled for now
     //----------------------------------------------------------------------
     //
     // Editor Init

--- a/Templates/BaseGame/game/tools/VerveEditor/Scripts/Plugin.tscript
+++ b/Templates/BaseGame/game/tools/VerveEditor/Scripts/Plugin.tscript
@@ -13,6 +13,7 @@ new ScriptObject( VerveEditorPlugin )
 
 function VerveEditorPlugin::onWorldEditorStartup( %this )
 {
+   return; //disabled for now
     //----------------------------------------------------------------------
     //
     // Editor Toggles

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/EditorGui.ed.tscript
@@ -924,7 +924,7 @@ function EditorGui::syncCameraGui( %this )
       EditorFreeCameraTypeOptions.checkRadioItem( 0, 4, %flyModeRadioItem);
       EditorPlayerCameraTypeOptions.checkRadioItem( 0, 4, -1);
    }
-   else if (!$isFirstPersonVar) // if 3rd person
+   else if ($editorCameraMode $= "3rd Person")
    {
       EditorGui-->trdPersonCamera.setStateOn(true);
       EWorldEditorToggleCamera.setBitmap("ToolsModule:3rd_person_camera_n_image");
@@ -934,7 +934,7 @@ function EditorGui::syncCameraGui( %this )
       EditorPlayerCameraTypeOptions.checkRadioItem( 0, 2, %flyModeRadioItem);
       EditorGuiStatusBar.setCamera("3rd Person Camera");
    }
-   else if ($isFirstPersonVar) // if 1st Person
+   else if ($editorCameraMode $= "1st Person")
    {
       EditorGui-->PlayerCamera.setStateOn(true);
       EWorldEditorToggleCamera.setBitmap("ToolsModule:player_n_image");
@@ -944,7 +944,12 @@ function EditorGui::syncCameraGui( %this )
       EditorPlayerCameraTypeOptions.checkRadioItem( 0, 2, %flyModeRadioItem);
       EditorFreeCameraTypeOptions.checkRadioItem( 0, 4, -1);
       EditorGuiStatusBar.setCamera("1st Person Camera");
-   }      
+   } 
+   else if ($editorCameraMode !$= "")
+   {
+      //Unclear what the status is, but presumably it was set elsewhere, so we'll just make sure we adhere  
+      EditorGuiStatusBar.setCamera($editorCameraMode);
+   }
  }
  
  //------------------------------------------------------------------------------
@@ -2449,7 +2454,6 @@ function Editor::open(%this)
 
    %this.editorEnabled();
    Canvas.setContent(EditorGui);   
-   $isFirstPersonVar = true;
    EditorGui.syncCameraGui();
    
    if(EditorSettings.value("WorldEditor/Layout/LayoutMode", "Classic") $= "Modern")
@@ -3228,6 +3232,8 @@ function EWorldEditorStatusBarCamera::onWake( %this )
    %this.add( "Isometric View" );
    %this.add( "Smooth Camera" );
    %this.add( "Smooth Rot Camera" );
+   
+   callOnModules("onCameraModesListWake", "", %this);
 }
 
 function EWorldEditorStatusBarCamera::onSelect( %this, %id, %text )
@@ -3285,6 +3291,9 @@ function EWorldEditorStatusBarCamera::onSelect( %this, %id, %text )
       case "Smooth Rot Camera":
          commandToServer( 'SetEditorCameraNewtonDamped' );
          EditorGui.setDisplayType( $EditTsCtrl::DisplayTypePerspective );
+         
+      default:
+         callOnModules("onCameraModesListSelect", "", %text);
    }
 }
 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/cameraCommands.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/cameraCommands.ed.tscript
@@ -57,14 +57,30 @@ function serverCmdToggleCamera(%client)
       }
       
       %client.camera.setVelocity("0 0 0");
+      
+      %client.lastControlObject = %client.getControlObject();
+      %client.lastCameraObject = %client.getCameraObject();
+      
       %control = %client.camera;
+      %camera = %client.camera;
    }
    else
    {
       %client.player.setVelocity("0 0 0");
-      %control = %client.player;
+      
+      //Toggle back onto whatever we had been last
+      %control = %client.lastControlObject;
+      %camera = %client.lastCameraObject;
    }
-   %client.setControlObject(%control);
+   
+   
+   //%client.lastCameraObject = %client.getCameraObject();
+   //%client.lastControlObject = %client.getControlObject();
+   if(%control != %client.getControlObject() && %camera != %client.getCameraObject())
+   {
+      %client.setControlObject(%control);
+      %client.setCameraObject(%camera);
+   }
    clientCmdSyncEditorGui();
 }
 
@@ -72,9 +88,18 @@ function serverCmdSetEditorCameraPlayer(%client)
 {
    // Switch to Player Mode
    %client.player.setVelocity("0 0 0");
-   %client.setControlObject(%client.player);
-   ServerConnection.setFirstPerson(1);
-   $isFirstPersonVar = 1;
+   
+   if(%client.player != %client.getControlObject())
+   {
+      %client.lastCameraObject = %client.getCameraObject();
+      %client.lastControlObject = %client.getControlObject();
+      
+      %client.setControlObject(%client.player);
+      %client.setCameraObject(%client.player);
+   }
+   
+   $editorCameraMode = "1st Person";
+   ServerConnection.setFirstPerson(true);
 
    clientCmdSyncEditorGui();
 }
@@ -83,9 +108,18 @@ function serverCmdSetEditorCameraPlayerThird(%client)
 {
    // Swith to Player Mode
    %client.player.setVelocity("0 0 0");
-   %client.setControlObject(%client.player);
-   ServerConnection.setFirstPerson(0);
-   $isFirstPersonVar = 0;
+   
+   if(%client.player != %client.getControlObject())
+   {
+      %client.lastCameraObject = %client.getCameraObject();
+      %client.lastControlObject = %client.getControlObject();
+      
+      %client.setControlObject(%client.player);
+      %client.setCameraObject(%client.player);
+   }
+   
+   $editorCameraMode = "3rd Person";
+   ServerConnection.setFirstPerson(false);
 
    clientCmdSyncEditorGui();
 }
@@ -101,7 +135,11 @@ function serverCmdDropPlayerAtCamera(%client)
    %obj.setTransform(%client.camera.getTransform());
    %obj.setVelocity("0 0 0");
 
+   %client.lastCameraObject = %client.getCameraObject();
+   %client.lastControlObject = %client.getControlObject();
+   
    %client.setControlObject(%client.player);
+   %client.setCameraObject(%client.player);
    clientCmdSyncEditorGui();
 }
 
@@ -109,7 +147,12 @@ function serverCmdDropCameraAtPlayer(%client)
 {
    %client.camera.setTransform(%client.player.getEyeTransform());
    %client.camera.setVelocity("0 0 0");
+   
+   %client.lastCameraObject = %client.getCameraObject();
+   %client.lastControlObject = %client.getControlObject();
+      
    %client.setControlObject(%client.camera);
+   %client.setCameraObject(%client.camera);
    clientCmdSyncEditorGui();
 }
 
@@ -137,7 +180,12 @@ function serverCmdCycleCameraFlyType(%client)
 			%client.camera.newtonMode = "0";
 			%client.camera.newtonRotation = "0";
 		}
+		
+		%client.lastCameraObject = %client.getCameraObject();
+        %client.lastControlObject = %client.getControlObject();
+   
 		%client.setControlObject(%client.camera);
+		%client.setCameraObject(%client.camera);
 		clientCmdSyncEditorGui();
 	}
 }
@@ -148,7 +196,16 @@ function serverCmdSetEditorCameraStandard(%client)
    %client.camera.setFlyMode();
    %client.camera.newtonMode = "0";
    %client.camera.newtonRotation = "0";
-   %client.setControlObject(%client.camera);
+   
+   if(%client.camera != %client.getControlObject() && %client.camera != %client.getCameraObject())
+   {
+      %client.lastCameraObject = %client.getCameraObject();
+      %client.lastControlObject = %client.getControlObject();
+      
+      %client.setControlObject(%client.camera);
+      %client.setCameraObject(%client.camera);
+   }
+   
    clientCmdSyncEditorGui();
 }
 
@@ -159,7 +216,12 @@ function serverCmdSetEditorCameraNewton(%client)
    %client.camera.newtonMode = "1";
    %client.camera.newtonRotation = "0";
    %client.camera.setVelocity("0 0 0");
+   
+   %client.lastCameraObject = %client.getCameraObject();
+   %client.lastControlObject = %client.getControlObject();
+   
    %client.setControlObject(%client.camera);
+   %client.setCameraObject(%client.camera);
    clientCmdSyncEditorGui();
 }
 
@@ -170,21 +232,36 @@ function serverCmdSetEditorCameraNewtonDamped(%client)
    %client.camera.newtonMode = "1";
    %client.camera.newtonRotation = "1";
    %client.camera.setAngularVelocity("0 0 0");
+   
+   %client.lastCameraObject = %client.getCameraObject();
+   %client.lastControlObject = %client.getControlObject();
+   
    %client.setControlObject(%client.camera);
+   %client.setCameraObject(%client.camera);
    clientCmdSyncEditorGui();
 }
 
 function serverCmdSetEditorOrbitCamera(%client)
 {
    %client.camera.setEditOrbitMode();
+   
+   %client.lastCameraObject = %client.getCameraObject();
+   %client.lastControlObject = %client.getControlObject();
+   
    %client.setControlObject(%client.camera);
+   %client.setCameraObject(%client.camera);
    clientCmdSyncEditorGui();
 }
 
 function serverCmdSetEditorFlyCamera(%client)
 {
    %client.camera.setFlyMode();
+   
+   %client.lastCameraObject = %client.getCameraObject();
+   %client.lastControlObject = %client.getControlObject();
+   
    %client.setControlObject(%client.camera);
+   %client.setCameraObject(%client.camera);
    clientCmdSyncEditorGui();
 }
 
@@ -204,6 +281,11 @@ function serverCmdEditorOrbitCameraSelectChange(%client, %size, %center)
 function serverCmdEditorCameraAutoFit(%client, %radius)
 {
    %client.camera.autoFitRadius(%radius);
+   
+   %client.lastCameraObject = %client.getCameraObject();
+   %client.lastControlObject = %client.getControlObject();
+   
    %client.setControlObject(%client.camera);
-  clientCmdSyncEditorGui();
-}
+   %client.setCameraObject(%client.camera);
+   clientCmdSyncEditorGui();
+} 

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/editor.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/editor.ed.tscript
@@ -87,11 +87,18 @@ function Editor::onAdd(%this)
 
 function Editor::checkActiveLoadDone()
 {
-   if(isObject(EditorGui) && EditorGui.loadingMission)
+   if(isObject(EditorGui))
    {
-      Canvas.setContent(EditorGui);
-      EditorGui.loadingMission = false;
-      return true;
+      if(EditorGui.loadingMission)
+      {
+         Canvas.setContent(EditorGui);
+         EditorGui.loadingMission = false;
+         return true;
+      }
+      if(EditorGui.isAwake())
+      {
+         return true;  
+      }
    }
    return false;
 }


### PR DESCRIPTION
Allow for initializing the camera into another mode(like 3rd person), and properly toggling back and forth between the standard cam and whatever the other last camera mode was.

Also adds callbacks so gamemodes/modules can provide custom camera modes. This gives more control and integration of specialty camera types so it doesn't have to fight the editor's handling of camera modes/toggles.