### PR TITLE
put damagemodel script files in the same pool as resources

### DIFF
--- a/Templates/BaseGame/game/data/DamageModel/DamageModel.tscript
+++ b/Templates/BaseGame/game/data/DamageModel/DamageModel.tscript
@@ -9,20 +9,13 @@ function DamageModel::onDestroy(%this)
 //This is called when the server is initially set up by the game application
 function DamageModel::initServer(%this)
 {
-   %this.queueExec("./scripts/server/player");
-}
-
-//This is called when the server is created for an actual game/map to be played
-function DamageModel::onCreateGameServer(%this)
-{
-   %this.registerDatablock("./scripts/managedData/managedParticleData");
-   %this.registerDatablock("./scripts/managedData/managedParticleEmitterData");
    %this.queueExec("./scripts/server/utility");
    %this.queueExec("./scripts/server/radiusDamage");
    %this.queueExec("./scripts/server/projectile");
    %this.queueExec("./scripts/server/weapon");
    %this.queueExec("./scripts/server/shapeBase");
    %this.queueExec("./scripts/server/vehicle");
+   %this.queueExec("./scripts/server/player");
    %this.queueExec("./scripts/server/commands");
 }
 


### PR DESCRIPTION
initServer callback is run the once
onCreateGameServer callback is run every mission load for queueexec("filename",true); to work, that has to be from the same callback pool being executed.

given resources use the initServer, pool, shifted the damagemodel baseline there as well. may want to revisit this one as time allows for quicker prototyping turnaround