### PR TITLE
Proper constructor for PathShapeData

### DIFF
--- a/Engine/source/T3D/pathShape.cpp
+++ b/Engine/source/T3D/pathShape.cpp
@@ -27,6 +27,11 @@
 
 IMPLEMENT_CO_DATABLOCK_V1(PathShapeData);
 
+PathShapeData::PathShapeData()
+{
+   mUseEase = false;
+}
+
 void PathShapeData::consoleInit()
 {
 }
@@ -141,11 +146,6 @@ bool PathShape::onNewDataBlock(GameBaseData* dptr, bool reload)
    scriptOnNewDataBlock(reload);
    mSpline.useEase(mDataBlock->mUseEase);
    return true;
-}
-
-PathShapeData::PathShapeData()
-{
-
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Has the PathShapeData constructor proper initialize the mUseEase var which prevents the datablock CRC cache from failing to match.