### PR TITLE
Script Fix for Parent call that does not use %this 

### DIFF
--- a/Engine/source/console/torquescript/compiledEval.cpp
+++ b/Engine/source/console/torquescript/compiledEval.cpp
@@ -1981,10 +1981,22 @@ Con::EvalResult CodeBlock::exec(U32 ip, const char* functionName, Namespace* thi
          }
          else // it's a ParentCall
          {
-            ConsoleValue& simObjectLookupValue = callArgv[1];
-            thisObject = getThisObject(simObjectLookupValue);
+            if (callArgc > 1)
+            {
+               ConsoleValue& simObjectLookupValue = callArgv[1];
+               thisObject = getThisObject(simObjectLookupValue);
+            }
 
-            if (thisObject == NULL)
+            //   The grammar does NOT prepend anything. callArgv[1] is either
+            //   a plain script argument (Parent::func(%arg)) or an explicitly
+            //   passed %this (Parent::method(%this, %arg)) — the programmer's
+            //   choice. For plain function parent calls callArgv[1] is never
+            //   an object, so getThisObject returning NULL is expected and
+            //   correct, not an error condition. The old guard was aborting
+            //   these calls with a misleading "unable to find object" error
+            //   using the value of %arg as the object name.
+
+            /*if (thisObject == NULL)
             {
                Con::warnf(
                   ConsoleLogEntry::General,
@@ -1998,7 +2010,7 @@ Con::EvalResult CodeBlock::exec(U32 ip, const char* functionName, Namespace* thi
                stack[_STK + 1].setEmptyString();
                _STK++;
                break;
-            }
+            }*/
 
             if (thisNamespace)
             {


### PR DESCRIPTION
Have explained this in the commented section above the commented out check but callArgv[1] usually refers to %this being passed into a Parent::function, this was creating a state where all parent calls that had arguments but didnt utilize %this it was expecting the first argument to always be an object. Hence if you tried to call a method that took a different argument it incorrectly reported with a misleading error of "unable to find object" 

There may be a better way to enforce this rule without commenting it out entirely but due to the nature of the callArgv handle it is always either an object or it isnt. Forcing a break on null causes an issue that shouldnt have been one in a parent call. 

Bug Reported by Abbey: https://discord.com/channels/358091480004558848/783127087820439582/1509827504402333848