### PR TITLE
UnitTest build produce seperate EXE 

### DIFF
--- a/.github/workflows/build-linux-gcc.yml
+++ b/.github/workflows/build-linux-gcc.yml
@@ -97,7 +97,7 @@ jobs:
             - name: Unit Tests
               run: |
                 cd "${{github.workspace}}/My Projects/Torque3D/game"
-                ./Torque3D runTests.tscript
+                ./Torque3D_unittests
 
             - name: Test Reporter
               uses: phoenix-actions/test-reporting@v14

--- a/.github/workflows/build-macos-clang.yml
+++ b/.github/workflows/build-macos-clang.yml
@@ -67,7 +67,7 @@ jobs:
             - name: Unit Tests
               run: |
                 cd "${{github.workspace}}/My Projects/Torque3D/game"
-                ./Torque3D.app/Contents/MacOS/Torque3D runTests.tscript
+                ./Torque3D_unittests
 
             - name: Test Reporter
               uses: phoenix-actions/test-reporting@v14

--- a/.github/workflows/build-windows-msvc.yml
+++ b/.github/workflows/build-windows-msvc.yml
@@ -63,7 +63,7 @@ jobs:
             - name: Unit Tests
               run: |
                 cd "${{github.workspace}}/My Projects/Torque3D/game"
-                ./Torque3D.exe runTests.tscript
+                ./Torque3D_unittests.exe
 
             - name: Test Reporter
               uses: phoenix-actions/test-reporting@v14

--- a/Engine/source/CMakeLists.txt
+++ b/Engine/source/CMakeLists.txt
@@ -31,11 +31,6 @@ forwardDef(TORQUE_BASIC_LIGHTING)
 set(TORQUE_SDL ON) # we need sdl to do our platform interop
 forwardDef(TORQUE_SDL)
 
-if(TORQUE_TESTING)
-set(TORQUE_COMPILE_DEFINITIONS ${TORQUE_COMPILE_DEFINITIONS} TORQUE_TESTS_ENABLED)
-set(TORQUE_COMPILE_DEFINITIONS ${TORQUE_COMPILE_DEFINITIONS} "_VARIADIC_MAX=10")
-endif()
-
 # On Windows we disable CRT Security warnings - this comes from recommendations to use non-portable functions.
 if (WIN32)
 	set(TORQUE_COMPILE_DEFINITIONS ${TORQUE_COMPILE_DEFINITIONS} _CRT_SECURE_NO_WARNINGS WIN32)
@@ -253,11 +248,6 @@ if (UNIX AND NOT APPLE)
   torqueAddSourceDirectories("platformX11")
 endif (UNIX AND NOT APPLE)
 
-if(TORQUE_TESTING)
-  torqueAddSourceDirectories("testing")
-  set(TORQUE_COMPILE_DEFINITIONS ${TORQUE_COMPILE_DEFINITIONS} TORQUE_SHARED SDL_MAIN_HANDLED)
-endif(TORQUE_TESTING)
-
 # Add the collected files to our engine group
 source_group(TREE "${CMAKE_SOURCE_DIR}/Engine/source" PREFIX "Engine" FILES ${TORQUE_SOURCE_FILES})
 file(GLOB_RECURSE TORQUE_APP_GAME_SOURCES "${TORQUE_APP_ROOT_DIRECTORY}/source/*.cpp" "${TORQUE_APP_ROOT_DIRECTORY}/source/*.h")
@@ -389,10 +379,6 @@ if (APPLE)
   "${TORQUE_APP_GAME_DIRECTORY}/${TORQUE_APP_NAME}.torsion"
   "${TORQUE_APP_GAME_DIRECTORY}/Template.torsion.exports")
 
-  if(TORQUE_TESTING)
-    set(MACOSX_RESOURCES ${MACOSX_RESOURCES} "${TORQUE_APP_GAME_DIRECTORY}/runTests.${TORQUE_SCRIPT_EXTENSION}")
-  endif()
-
 	set(TORQUE_SOURCE_FILES ${TORQUE_SOURCE_FILES} ${TORQUE_PLATFORM_MAC_SOURCES} ${MACOSX_RESOURCES})
 
   source_group("Resources" FILES ${MACOSX_RESOURCES})
@@ -426,7 +412,7 @@ if (NOT TORQUE_NET_CURL)
 endif()
 
 ################# Executable Generation ###################
-if (TORQUE_DYNAMIC_LIBRARY AND NOT TORQUE_TESTING)
+if (TORQUE_DYNAMIC_LIBRARY)
   set(TORQUE_COMPILE_DEFINITIONS ${TORQUE_COMPILE_DEFINITIONS} TORQUE_SHARED)
 
   # Build the main engine library
@@ -438,10 +424,8 @@ if (TORQUE_DYNAMIC_LIBRARY AND NOT TORQUE_TESTING)
   set(TORQUE_SOURCE_FILES "main/main.cpp")
   set(TORQUE_LINK_LIBRARIES TorqueEngine)
 else()
-  if(NOT TORQUE_TESTING)
-    set(TORQUE_SOURCE_FILES "main/main.cpp" ${TORQUE_SOURCE_FILES})
-  endif()
-endif (TORQUE_DYNAMIC_LIBRARY AND NOT TORQUE_TESTING)
+  set(TORQUE_SOURCE_FILES "main/main.cpp" ${TORQUE_SOURCE_FILES})
+endif (TORQUE_DYNAMIC_LIBRARY)
 
 if (APPLE)
 	add_executable(${TORQUE_APP_NAME} MACOSX_BUNDLE 
@@ -486,9 +470,9 @@ elseif (WIN32)
 
 	# NOTE: On Windows, /Zc:wchar_t- is necessary otherwise you get unicode errors
 	set_target_properties(${TORQUE_APP_NAME} PROPERTIES COMPILE_FLAGS "${TORQUE_CXX_FLAGS}")
-   if (TORQUE_DYNAMIC_LIBRARY AND NOT TORQUE_TESTING)
+   if (TORQUE_DYNAMIC_LIBRARY)
       set_target_properties(TorqueEngine PROPERTIES COMPILE_FLAGS "${TORQUE_CXX_FLAGS_COMMON_DEFAULT}")
-   endif (TORQUE_DYNAMIC_LIBRARY AND NOT TORQUE_TESTING)
+   endif (TORQUE_DYNAMIC_LIBRARY)
 else()
 	add_executable(${TORQUE_APP_NAME} ${TORQUE_SOURCE_FILES})
 
@@ -539,6 +523,13 @@ if(IS_ARM)
     add_math_backend(neon  MATH_SIMD_NEON)
 endif()
 
+foreach(MATH_BACKEND ${TORQUE_MATH_BACKENDS})
+    target_sources(${TORQUE_APP_NAME}
+        PRIVATE
+        $<TARGET_OBJECTS:${MATH_BACKEND}>
+    )
+endforeach()
+
 if(MSVC)
     # Match projectGenerator naming for executables
     set(OUTPUT_CONFIG DEBUG MINSIZEREL RELWITHDEBINFO)
@@ -547,10 +538,10 @@ if(MSVC)
         list(GET OUTPUT_CONFIG ${INDEX} CONF)
         list(GET OUTPUT_SUFFIX ${INDEX} SUFFIX)
         set_property(TARGET ${TORQUE_APP_NAME} PROPERTY OUTPUT_NAME_${CONF} ${TORQUE_APP_NAME}_${SUFFIX})
-        if (TORQUE_DYNAMIC_LIBRARY AND NOT TORQUE_TESTING)
+        if (TORQUE_DYNAMIC_LIBRARY)
             set_property(TARGET TorqueEngine PROPERTY ${CONF}_POSTFIX "_${SUFFIX}")
             set_property(TARGET TorqueEngine PROPERTY ${CONF}_OUTPUT_NAME ${TORQUE_APP_NAME})
-        endif (TORQUE_DYNAMIC_LIBRARY AND NOT TORQUE_TESTING)
+        endif (TORQUE_DYNAMIC_LIBRARY)
     endforeach()
     # Set Visual Studio startup project
     set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${TORQUE_APP_NAME})
@@ -590,14 +581,6 @@ if (TORQUE_TARGET_PROPERTIES)
    set_target_properties(${TORQUE_APP_NAME} PROPERTIES ${TORQUE_TARGET_PROPERTIES})
 endif (TORQUE_TARGET_PROPERTIES)
 target_include_directories(${TORQUE_APP_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_BINARY_DIR}/temp" ${TORQUE_INCLUDE_DIRECTORIES})
-
-if(TORQUE_TESTING)
-  if(WIN32)
-        target_link_options(${TORQUE_APP_NAME} PRIVATE "/SUBSYSTEM:CONSOLE")
-        set_target_properties(gtest PROPERTIES COMPILE_FLAGS "/Zc:wchar_t-")
-        set_target_properties(gmock PROPERTIES COMPILE_FLAGS "/Zc:wchar_t-")
-    endif()
-endif(TORQUE_TESTING)
 
 append_defs()
 
@@ -645,3 +628,94 @@ if (UNIX)
 	  endif()
 	endforeach()
 endif (UNIX)
+
+if(TORQUE_TESTING)
+
+    enable_testing()
+
+    # Start with the same sources as the main application
+    set(TORQUE_TEST_SOURCES ${TORQUE_SOURCE_FILES})
+
+    # Add test sources
+    file(GLOB_RECURSE TORQUE_TEST_FILES
+        "${CMAKE_CURRENT_SOURCE_DIR}/testing/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/testing/*.h"
+    )
+
+    list(APPEND TORQUE_TEST_SOURCES ${TORQUE_TEST_FILES})
+
+    list(FILTER TORQUE_TEST_SOURCES EXCLUDE REGEX "main/main\\.cpp$")
+
+    add_executable(${TORQUE_APP_NAME}_unittests
+        ${TORQUE_TEST_SOURCES}
+    )
+
+    foreach(MATH_BACKEND ${TORQUE_MATH_BACKENDS})
+    target_sources(${TORQUE_APP_NAME}_unittests
+        PRIVATE
+        $<TARGET_OBJECTS:${MATH_BACKEND}>
+    )
+    endforeach()
+
+    target_include_directories(${TORQUE_APP_NAME}_unittests
+        PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}
+            "${CMAKE_BINARY_DIR}/temp"
+            ${TORQUE_INCLUDE_DIRECTORIES}
+    )
+
+    target_compile_definitions(${TORQUE_APP_NAME}_unittests
+        PUBLIC
+            ${TORQUE_COMPILE_DEFINITIONS}
+            TORQUE_TESTS_ENABLED
+            "_VARIADIC_MAX=10"
+            TORQUE_SHARED
+            SDL_MAIN_HANDLED
+    )
+
+    target_link_libraries(${TORQUE_APP_NAME}_unittests
+        PRIVATE
+            ${TORQUE_LINK_LIBRARIES}
+            ${TORQUE_LINK_THIRDPARTY}
+            gtest
+            gmock
+    )
+
+    target_link_options(${TORQUE_APP_NAME}_unittests
+        PUBLIC
+            ${TORQUE_LINK_OPTIONS}
+    )
+
+    if(APPLE)
+    target_link_libraries(${TORQUE_APP_NAME}_unittests
+        PRIVATE
+        ${TORQUE_LINK_FRAMEWORKS}
+        )
+    endif()
+
+    if(WIN32)
+        target_link_libraries(${TORQUE_APP_NAME}_unittests
+            PRIVATE
+            ${TORQUE_LINK_WINDOWS}
+        )
+        set_target_properties(${TORQUE_APP_NAME}_unittests 
+            PROPERTIES COMPILE_FLAGS 
+                "${TORQUE_CXX_FLAGS}"
+        )
+
+        target_link_options(${TORQUE_APP_NAME}_unittests PRIVATE "/SUBSYSTEM:CONSOLE")
+        set_target_properties(gtest PROPERTIES COMPILE_FLAGS "/Zc:wchar_t-")
+        set_target_properties(gmock PROPERTIES COMPILE_FLAGS "/Zc:wchar_t-")
+    endif()
+
+    if(UNIX AND NOT APPLE)
+        target_link_libraries(${TORQUE_APP_NAME}_unittests
+            PRIVATE
+            ${TORQUE_LINK_LINUX}
+        )
+    endif()
+
+    include(GoogleTest)
+    gtest_discover_tests(${TORQUE_APP_NAME}_unittests)
+
+endif()

--- a/Engine/source/CMakeLists.txt
+++ b/Engine/source/CMakeLists.txt
@@ -645,6 +645,8 @@ if(TORQUE_TESTING)
     list(APPEND TORQUE_TEST_SOURCES ${TORQUE_TEST_FILES})
 
     list(FILTER TORQUE_TEST_SOURCES EXCLUDE REGEX "main/main\\.cpp$")
+    list(FILTER TORQUE_TEST_SOURCES EXCLUDE REGEX "gfx/D3D11/")
+    list(FILTER TORQUE_TEST_SOURCES EXCLUDE REGEX "gfx/gl/")
 
     add_executable(${TORQUE_APP_NAME}_unittests
         ${TORQUE_TEST_SOURCES}
@@ -667,8 +669,6 @@ if(TORQUE_TESTING)
     target_compile_definitions(${TORQUE_APP_NAME}_unittests
         PUBLIC
             ${TORQUE_COMPILE_DEFINITIONS}
-            TORQUE_TESTS_ENABLED
-            "_VARIADIC_MAX=10"
             TORQUE_SHARED
             SDL_MAIN_HANDLED
     )

--- a/Engine/source/core/frameAllocator.h
+++ b/Engine/source/core/frameAllocator.h
@@ -291,8 +291,11 @@ public:
    FrameTemp(const U32 numElements = 0)
    {
       mPosition = FrameAllocator::getWaterMark();
-      mData = (T*)FrameAllocator::alloc(sizeof(T) * numElements);
+      mData = reinterpret_cast<T*>(FrameAllocator::alloc(sizeof(T) * numElements));
       mSize = numElements;
+
+      for (S32 i = 0; i < numElements; i++)
+         constructInPlace<T>(&mData[i]);
    }
 
    ~FrameTemp()
@@ -303,6 +306,8 @@ public:
    }
 
    // Operators
+   inline TORQUE_FORCEINLINE T* operator~() { return mData; }
+   inline TORQUE_FORCEINLINE const T* operator~() const { return mData; }
 
    inline TORQUE_FORCEINLINE T&       operator*() { return *mData; }
    inline TORQUE_FORCEINLINE const T& operator*() const { return *mData; }
@@ -329,5 +334,34 @@ public:
    inline TORQUE_FORCEINLINE const U32 getObjectCount() const { return mSize; }
 };
 
+//-----------------------------------------------------------------------------
+// FrameTemp specializations for types with no constructor/destructor
+#define FRAME_TEMP_NC_SPEC(type) \
+   template<> \
+   inline FrameTemp<type>::FrameTemp( const U32 count ) \
+   { \
+      AssertFatal( count > 0, "Allocating a FrameTemp with less than one instance" ); \
+      mPosition = FrameAllocator::getWaterMark(); \
+      mSize = count;\
+      mData = reinterpret_cast<type *>( FrameAllocator::alloc( sizeof( type ) * count ) ); \
+   } \
+   template<>\
+   inline FrameTemp<type>::~FrameTemp() \
+   { \
+      FrameAllocator::setWaterMark( mPosition ); \
+   } \
+
+FRAME_TEMP_NC_SPEC(char);
+FRAME_TEMP_NC_SPEC(float);
+FRAME_TEMP_NC_SPEC(double);
+FRAME_TEMP_NC_SPEC(bool);
+FRAME_TEMP_NC_SPEC(int);
+FRAME_TEMP_NC_SPEC(short);
+
+FRAME_TEMP_NC_SPEC(unsigned char);
+FRAME_TEMP_NC_SPEC(unsigned int);
+FRAME_TEMP_NC_SPEC(unsigned short);
+
+#undef FRAME_TEMP_NC_SPEC
 
 #endif  // _H_FRAMEALLOCATOR_

--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -258,10 +258,6 @@ DXGI_SWAP_CHAIN_DESC GFXD3D11Device::setupPresentParams(const GFXVideoMode &mode
 
 void GFXD3D11Device::enumerateAdapters(Vector<GFXAdapter*> &adapterList)
 {
-#ifdef TORQUE_TESTS_ENABLED
-      return;
-#endif
-
    IDXGIAdapter1* EnumAdapter;
    IDXGIFactory1* DXGIFactory;
 

--- a/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
+++ b/Engine/source/gfx/gl/sdl/gfxGLDevice.sdl.cpp
@@ -77,10 +77,6 @@ void EnumerateVideoModes(Vector<GFXVideoMode>& outModes)
 
 void GFXGLDevice::enumerateAdapters( Vector<GFXAdapter*> &adapterList )
 {
-#ifdef TORQUE_TESTS_ENABLED
-      return;
-#endif
-
    AssertFatal( SDL_WasInit(SDL_INIT_VIDEO), "");
 
    PlatformGL::init(); // for hints about context creation

--- a/Engine/source/testing/dataChunkerTest.cpp
+++ b/Engine/source/testing/dataChunkerTest.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: MIT
 //-----------------------------------------------------------------------------
 
-#ifdef TORQUE_TESTS_ENABLED
 #include "testing/unitTesting.h"
 #include "core/dataChunker.h"
 
@@ -343,5 +342,3 @@ TEST(ThreeTieredChunkerTest,ThreeTieredChunker_Should_Function_Correctly)
    EXPECT_TRUE(threeChunker.getT3Chunker().getFreeListHead().isEmpty());
 }
 
-
-#endif

--- a/Engine/source/testing/frameAllocatorTest.cpp
+++ b/Engine/source/testing/frameAllocatorTest.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: MIT
 //-----------------------------------------------------------------------------
 
-#ifdef TORQUE_TESTS_ENABLED
 #include "testing/unitTesting.h"
 #include "core/frameAllocator.h"
 
@@ -192,4 +191,3 @@ TEST(FrameTempTest, FrameTempShould_Function_Correctly)
 }
 
 
-#endif

--- a/Engine/source/testing/inspectorFieldTest.cpp
+++ b/Engine/source/testing/inspectorFieldTest.cpp
@@ -1,33 +1,132 @@
-﻿#include <gtest/gtest.h>
+#include <gtest/gtest.h>
 
+#include "gui/editor/guiInspector.h"
 #include "gui/editor/inspector/group.h"
+#include "gui/editor/inspector/field.h"
 #include "console/script.h"
-#include "T3D/fx/particle.h"
+#include "console/simDatablock.h"
 
-TEST(InspectorFieldTest, SetData_Should_Update_The_Field)
+class InspectorTestData : public SimDataBlock
 {
-   GuiInspector* inspector = new GuiInspector();
-   ASSERT_TRUE(inspector->registerObject());
+   typedef SimDataBlock Parent;
 
-   ParticleData* exampleObj = new ParticleData();
-   ASSERT_TRUE(exampleObj->registerObject());
-   // Add it to inspector so inspector field can find it
-   inspector->addInspectObject(exampleObj);
+public:
+   S32 testInt = 0;
+   F32 testFloat = 0.f;
+   bool testBool = false;
+   StringTableEntry testString;
 
-   AbstractClassRep::Field* field = const_cast<AbstractClassRep::Field*>(exampleObj->findField(StringTable->insert("lifetimeMS")));
+   DECLARE_CONOBJECT(InspectorTestData);
 
-   GuiInspectorGroup* group = new GuiInspectorGroup("testing", NULL);
-   ASSERT_TRUE(group->registerObject());
+   static void initPersistFields()
+   {
+      addField("testInt", TypeS32,        Offset(testInt, InspectorTestData));
+      addField("testFloat", TypeF32,      Offset(testFloat, InspectorTestData));
+      addField("testBool", TypeBool,      Offset(testBool, InspectorTestData));
+      addField("testString", TypeString,  Offset(testString, InspectorTestData));
 
-   GuiInspectorField* inspectorField = new GuiInspectorField(inspector, group, field);
-   ASSERT_TRUE(inspectorField->registerObject());
+      Parent::initPersistFields();
+   }
+};
 
-   inspectorField->setData("12345");
-   EXPECT_EQ(exampleObj->lifetimeMS, 12345);
+IMPLEMENT_CO_DATABLOCK_V1(InspectorTestData);
 
-   // Cleanup
-   inspectorField->deleteObject();
-   group->deleteObject();
-   inspector->deleteObject();
-   exampleObj->deleteObject();
+class GuiInspectorFieldFixture : public ::testing::Test
+{
+protected:
+   GuiInspector* inspector{};
+   GuiInspectorGroup* group{};
+
+   void SetUp() override
+   {
+      inspector = new GuiInspector();
+      ASSERT_TRUE(inspector->registerObject());
+
+      group = new GuiInspectorGroup("testing", nullptr);
+      ASSERT_TRUE(group->registerObject());
+   }
+
+   void TearDown() override
+   {
+      group->deleteObject();
+      inspector->deleteObject();
+   }
+
+   GuiInspectorField* createField(
+      SimObject* object,
+      const char* fieldName)
+   {
+      inspector->addInspectObject(object);
+
+      AbstractClassRep::Field* field =
+         const_cast<AbstractClassRep::Field*>(
+            object->findField(StringTable->insert(fieldName)));
+
+      EXPECT_NE(field, nullptr);
+
+      GuiInspectorField* inspectorField =  new GuiInspectorField(inspector, group, field);
+      EXPECT_TRUE(inspectorField->registerObject());
+
+      return inspectorField;
+   }
+};
+
+TEST_F(GuiInspectorFieldFixture, SetData_IntField)
+{
+   InspectorTestData* object = new InspectorTestData();
+   ASSERT_TRUE(object->registerObject());
+
+   GuiInspectorField* field = createField(object, "testInt");
+
+   field->setData("12345");
+
+   EXPECT_EQ(object->testInt, 12345);
+
+   field->deleteObject();
+   object->deleteObject();
+}
+
+TEST_F(GuiInspectorFieldFixture, SetData_FloatField)
+{
+   InspectorTestData* object = new InspectorTestData();
+   ASSERT_TRUE(object->registerObject());
+
+   GuiInspectorField* field = createField(object, "testFloat");
+
+   field->setData("123.5");
+
+   EXPECT_FLOAT_EQ(object->testFloat, 123.5f);
+
+   field->deleteObject();
+   object->deleteObject();
+}
+
+TEST_F(GuiInspectorFieldFixture, SetData_BoolField)
+{
+   InspectorTestData* object = new InspectorTestData();
+   ASSERT_TRUE(object->registerObject());
+
+   GuiInspectorField* field = createField(object, "testBool");
+
+   field->setData("1");
+
+   EXPECT_TRUE(object->testBool);
+
+   field->deleteObject();
+   object->deleteObject();
+}
+
+TEST_F(GuiInspectorFieldFixture, SetData_StringField)
+{
+   InspectorTestData* object = new InspectorTestData();
+   ASSERT_TRUE(object->registerObject());
+
+   GuiInspectorField* field = createField(object, "testString");
+
+   field->setData("Hello World");
+
+   EXPECT_STREQ(object->testString, "Hello World");
+
+   field->deleteObject();
+   object->deleteObject();
 }

--- a/Engine/source/testing/mutexTest.cpp
+++ b/Engine/source/testing/mutexTest.cpp
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#ifdef TORQUE_TESTS_ENABLED
 #include "testing/unitTesting.h"
 #include "platform/threads/mutex.h"
 #include "platform/threads/thread.h"
@@ -66,5 +65,3 @@ TEST(Mutex, BasicSynchronization)
    // Kill mutex2, which was never touched.
    Mutex::destroyMutex(mutex2);
 }
-
-#endif

--- a/Engine/source/testing/pathTest.cpp
+++ b/Engine/source/testing/pathTest.cpp
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#ifdef TORQUE_TESTS_ENABLED
 #include "testing/unitTesting.h"
 #include "core/util/path.h"
 
@@ -36,5 +35,3 @@ TEST(MakeRelativePath, MakeRelativePath)
    EXPECT_EQ(Torque::Path::MakeRelativePath("levels/den/file.png", "art/interiors/burg/"), "../../../levels/den/file.png");
    EXPECT_EQ(Torque::Path::MakeRelativePath("art/interiors/burg/file.png", "art/dts/burg/"), "../../interiors/burg/file.png");
 };
-
-#endif

--- a/Engine/source/testing/strTest.cpp
+++ b/Engine/source/testing/strTest.cpp
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#ifdef TORQUE_TESTS_ENABLED
 #include "testing/unitTesting.h"
 #include "core/util/str.h"
 #include "core/util/tVector.h"
@@ -347,5 +346,3 @@ TEST(StringBuilder, StringBuilder)
 
    EXPECT_TRUE( str.end() == String( "foobarbarfoo" ) );
 }
-
-#endif

--- a/Engine/source/testing/strTest.cpp
+++ b/Engine/source/testing/strTest.cpp
@@ -218,9 +218,28 @@ TEST(String, Order)
    }
 }
 
-/// TODO
 TEST(String, Find)
 {
+   String str("foobarbarfoo");
+
+   // Character searches.
+   EXPECT_EQ(str.find('f'), 0);
+   EXPECT_EQ(str.find('o'), 1);
+   EXPECT_EQ(str.find('b'), 3);
+   EXPECT_EQ(str.find('r'), 5);
+
+   // Substring searches.
+   EXPECT_EQ(str.find("foo"), 0);
+   EXPECT_EQ(str.find("bar"), 3);
+   EXPECT_EQ(str.find("barfoo"), 6);
+
+   // Not found.
+   EXPECT_EQ(str.find("baz"), String::NPos);
+   EXPECT_EQ(str.find('x'), String::NPos);
+
+   // Empty string.
+   EXPECT_EQ(String("").find("foo"), String::NPos);
+   EXPECT_EQ(String("").find('f'), String::NPos);
 }
 
 TEST(String, Insert)

--- a/Engine/source/testing/swizzleTest.cpp
+++ b/Engine/source/testing/swizzleTest.cpp
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#ifdef TORQUE_TESTS_ENABLED
 #include "platform/platform.h"
 #include "testing/unitTesting.h"
 #include "core/util/swizzle.h"
@@ -106,7 +105,7 @@ TEST(Swizzle, Swizzle)
       EXPECT_TRUE( same )
          << "Test object failed to be competent";
 
-      bgraObjSwizzle.InPlace( ~objTest, sizeof( TestStruct ) * ( sizeof( objIdx ) / sizeof( U32 ) ) );
+      bgraObjSwizzle.InPlace( objTest.address(), sizeof(TestStruct) * (sizeof(objIdx) / sizeof(U32)));
       same = true;
 
       for( U32 i = 0; i < sizeof( objIdx ) / sizeof( U32 ); i++ )
@@ -115,7 +114,7 @@ TEST(Swizzle, Swizzle)
       EXPECT_TRUE( same )
          << "Object RGBA->BGRA test failed.";
 
-      bgraObjSwizzle.InPlace( ~objTest, sizeof( TestStruct ) * ( sizeof( objIdx ) / sizeof( U32 ) ) );
+      bgraObjSwizzle.InPlace( objTest.address(), sizeof(TestStruct) * (sizeof(objIdx) / sizeof(U32)));
       same = true;
 
       for( U32 i = 0; i < sizeof( objIdx ) / sizeof( U32 ); i++ )
@@ -125,5 +124,3 @@ TEST(Swizzle, Swizzle)
          << "Object RGBA->BGRA reverse test failed.";
    }
 };
-
-#endif

--- a/Engine/source/testing/tFixedSizeDequeTest.cpp
+++ b/Engine/source/testing/tFixedSizeDequeTest.cpp
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#ifdef TORQUE_TESTS_ENABLED
 #include "testing/unitTesting.h"
 #include "core/util/tFixedSizeDeque.h"
 
@@ -45,5 +44,3 @@ TEST(FixedSizeDeque, FixedSizeDeque)
    EXPECT_EQ( deque.popFront(), 2 );
    EXPECT_TRUE( deque.isEmpty() );
 };
-
-#endif

--- a/Engine/source/testing/tVectorTest.cpp
+++ b/Engine/source/testing/tVectorTest.cpp
@@ -20,7 +20,6 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#ifdef TORQUE_TESTS_ENABLED
 #include "testing/unitTesting.h"
 #include "core/util/tVector.h"
 
@@ -121,5 +120,3 @@ TEST_FIX(Vector, Sorting)
       EXPECT_TRUE(v[i] <= v[i + 1])
          << "Element " << i << " was not in sorted order";
 }
-
-#endif

--- a/Tools/CMake/torque_configs.cmake
+++ b/Tools/CMake/torque_configs.cmake
@@ -99,10 +99,6 @@ set(TORQUE_COMPILE_DEFINITIONS ICE_NO_DLL PCRE_STATIC TORQUE_ADVANCED_LIGHTING T
 # All link libraries. Modules should append to this the path to specify additional link libraries (.a, .lib, .dylib, .so)
 set(TORQUE_LINK_LIBRARIES png_static tinyxml2 collada squish opcode assimp SDL2 glad pcre convexMath zlib)
 
-if(TORQUE_TESTING)
-set(TORQUE_LINK_LIBRARIES ${TORQUE_LINK_LIBRARIES} gtest gmock)
-endif()
-
 if(NOT WIN32)
    set(WIN32 OFF CACHE BOOL "" FORCE)
 endif()

--- a/Tools/CMake/torque_macros.cmake
+++ b/Tools/CMake/torque_macros.cmake
@@ -201,6 +201,7 @@ function(add_math_backend name compile_defs)
     endif()
 
     # Inject objects into engine
-    target_sources(${TORQUE_APP_NAME} PRIVATE $<TARGET_OBJECTS:math_${name}>)
+    list(APPEND TORQUE_MATH_BACKENDS math_${name})
+    set(TORQUE_MATH_BACKENDS ${TORQUE_MATH_BACKENDS} PARENT_SCOPE)
     set_target_properties(math_${name} PROPERTIES FOLDER "Libraries/Math")
 endfunction()


### PR DESCRIPTION
should be longer build time on this pr as it is rebuilding the engine twice, will begin removing unnecessary files and possibly removing the preproc so the unit tests could use the same result as the engine build.