### PR TITLE
fix optional skin param for ShapeBase::setImage

### DIFF
--- a/Engine/source/T3D/shapeImage.cpp
+++ b/Engine/source/T3D/shapeImage.cpp
@@ -2343,6 +2343,7 @@ void ShapeBase::setImage(  U32 imageSlot,
    image.dataBlock = imageData;
    image.state = &image.dataBlock->state[0];
    image.skinNameHandle = skinNameHandle;
+   image.appliedSkinName = "Base";
    image.updateDoAnimateAllShapes(this);
 
    for (U32 i=0; i<ShapeBaseImageData::MaxShapes; ++i)


### PR DESCRIPTION
using the %obj.mountImage(image,slot,loaded,skin)  skin option was not always properly applying.

reported by steve_yorksire, fixed by sir_skurpsalot: https://discord.com/channels/358091480004558848/580242040730943509/1510795740199260252