### PR TITLE
fix advanced model editor slider blocker

### DIFF
--- a/Templates/BaseGame/game/tools/shapeEditor/gui/shapeEdAdvancedWindow.ed.gui
+++ b/Templates/BaseGame/game/tools/shapeEditor/gui/shapeEdAdvancedWindow.ed.gui
@@ -879,6 +879,7 @@ $guiContent = new GuiWindowCollapseCtrl(ShapeEdAdvancedWindow,EditorGuiGroup) {
                tooltipProfile = "GuiToolTipProfile";
                tooltip = "Select the method used to auto-generate the collision geometry";
                internalName = "colType";
+               command = "ShapeEdColWindow.onColTypeSelected();";
             };
             new GuiTextCtrl() {
                text = "Fit Target";
@@ -1127,7 +1128,7 @@ $guiContent = new GuiWindowCollapseCtrl(ShapeEdAdvancedWindow,EditorGuiGroup) {
             new GuiBitmapCtrl() {
                BitmapAsset = "ToolsModule:inactive_overlay_image";
                position = "0 47";
-               extent = "199 178";
+               extent = "342 178";
                profile = "ToolsGuiDefaultProfile";
                visible = "0";
                tooltipProfile = "GuiToolTipProfile";

--- a/Templates/BaseGame/game/tools/shapeEditor/scripts/shapeEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/shapeEditor/scripts/shapeEditor.ed.tscript
@@ -3112,7 +3112,6 @@ function ShapeEdColWindow::update_onCollisionChanged( %this )
 
    if ( %this-->colType.getText() $= "Convex Hulls" )
    {
-      %this-->hullInactive.setVisible( false );
       %this-->hullDepth.setValue( getField( %colData, 2 ) );
       %this-->hullDepthText.setText( mFloor( %this-->hullDepth.getValue() ) );
       %this-->hullMergeThreshold.setValue( getField( %colData, 3 ) );
@@ -3129,6 +3128,15 @@ function ShapeEdColWindow::update_onCollisionChanged( %this )
       %this-->hullMaxCapsuleErrorText.setText( mFloor( %this-->hullMaxCapsuleError.getValue() ) );
       %fillModeID = %this-->fillMode.findText( getField( %colData, 9 ) );
       %this-->fillMode.setSelected( %fillModeID, false );
+   }
+}
+
+function ShapeEdColWindow::onColTypeSelected(%this)
+{
+   
+   if ( %this-->colType.getText() $= "Convex Hulls" )
+   {
+      %this-->hullInactive.setVisible( false );
    }
    else
    {


### PR DESCRIPTION
correct size of hullInactive filter and logic for it by adding a function ShapeEdColWindow::onColTypeSelected that goes off on any selection from the dropdown