### PR TITLE
Adjusts the logic for collision and physics setup functions in TSStatic

### DIFF
--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -484,7 +484,7 @@ void TSStatic::prepCollision()
    mLOSDetails.clear();
    mConvexList->nukeList();
 
-   Resource<TSShape> shape = mShapeAssetRef.assetPtr->getShapeResource();
+   TSShape* shape = mShapeInstance->getShape();
 
    if (mCollisionType == CollisionMesh || mCollisionType == VisibleMesh)
    {
@@ -515,7 +515,7 @@ void TSStatic::_updatePhysics()
    if (!PHYSICSMGR || mCollisionType == None)
       return;
 
-   Resource<TSShape> shape = mShapeAssetRef.assetPtr->getShapeResource();
+   TSShape* shape = mShapeInstance->getShape();
 
    PhysicsCollision* colShape = NULL;
    if (mCollisionType == Bounds)


### PR DESCRIPTION
Adjusts the logic for collision and physics setup functions in TSStatic because we utilize/allow for the fallback shape and so need to contend for if we have a shapeInstance but our shapeAsset ptr is invalid.