### PR TITLE
Fix for extension registrations for different Resource types

### DIFF
--- a/Engine/source/gfx/bitmap/gBitmap.cpp
+++ b/Engine/source/gfx/bitmap/gBitmap.cpp
@@ -38,8 +38,13 @@ using namespace Torque;
 
 const U32 GBitmap::csFileVersion   = 3;
 
-Vector<GBitmap::Registration>   GBitmap::sRegistrations( __FILE__, __LINE__ );
+Vector<GBitmap::Registration>& GBitmap::getBitmapRegistrations()
+{
+   static Vector<GBitmap::Registration> * regs =
+      new Vector<GBitmap::Registration>(__FILE__, __LINE__);
 
+   return *regs;
+}
 
 GBitmap::GBitmap()
  : mInternalFormat(GFXFormatR8G8B8),
@@ -198,24 +203,24 @@ U32 GBitmap::getFormatBytesPerPixel(GFXFormat fmt)
 
 void GBitmap::sRegisterFormat( const GBitmap::Registration &reg )
 {
-   U32 insert = sRegistrations.size();
-   for ( U32 i = 0; i < sRegistrations.size(); i++ )
+   U32 insert = GBitmap::getBitmapRegistrations().size();
+   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
    {
-      if ( sRegistrations[i].priority <= reg.priority )
+      if ( GBitmap::getBitmapRegistrations()[i].priority <= reg.priority )
       {
          insert = i;
          break;
       }
    }
 
-   sRegistrations.insert( insert, reg );
+   GBitmap::getBitmapRegistrations().insert( insert, reg );
 }
 
 const GBitmap::Registration   *GBitmap::sFindRegInfo( const String &extension )
 {
-   for ( U32 i = 0; i < GBitmap::sRegistrations.size(); i++ )
+   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
    {
-      const GBitmap::Registration   &reg = GBitmap::sRegistrations[i];
+      const GBitmap::Registration   &reg = GBitmap::getBitmapRegistrations()[i];
       const Vector<String>          &extensions = reg.extensions;
 
       for ( U32 j = 0; j < extensions.size(); ++j )
@@ -236,9 +241,9 @@ bool GBitmap::sFindFile( const Path &path, Path *outPath )
 
    Path tryPath( path );
 
-   for ( U32 i = 0; i < sRegistrations.size(); i++ )
+   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
    {
-      const Registration &reg = sRegistrations[i];
+      const Registration &reg = GBitmap::getBitmapRegistrations()[i];
       const Vector<String> &extensions = reg.extensions;
 
       for ( U32 j = 0; j < extensions.size(); ++j )
@@ -266,9 +271,9 @@ bool GBitmap::sFindFiles( const Path &path, Vector<Path> *outFoundPaths )
    
    Path  tryPath( path );
 
-   for ( U32 i = 0; i < GBitmap::sRegistrations.size(); i++ )
+   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
    {
-      const GBitmap::Registration   &reg = GBitmap::sRegistrations[i];
+      const GBitmap::Registration   &reg = GBitmap::getBitmapRegistrations()[i];
       const Vector<String>          &extensions = reg.extensions;
 
       for ( U32 j = 0; j < extensions.size(); ++j )
@@ -292,9 +297,9 @@ String GBitmap::sGetExtensionList()
 {
    String list;
 
-   for ( U32 i = 0; i < sRegistrations.size(); i++ )
+   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
    {
-      const Registration &reg = sRegistrations[i];
+      const Registration &reg = GBitmap::getBitmapRegistrations()[i];
       for ( U32 j = 0; j < reg.extensions.size(); j++ )
       {
          list += reg.extensions[j];

--- a/Engine/source/gfx/bitmap/gBitmap.cpp
+++ b/Engine/source/gfx/bitmap/gBitmap.cpp
@@ -38,7 +38,7 @@ using namespace Torque;
 
 const U32 GBitmap::csFileVersion   = 3;
 
-Vector<GBitmap::Registration>& GBitmap::getBitmapRegistrations()
+Vector<GBitmap::Registration>& GBitmap::getRegistrations()
 {
    static Vector<GBitmap::Registration> * regs =
       new Vector<GBitmap::Registration>(__FILE__, __LINE__);
@@ -203,24 +203,24 @@ U32 GBitmap::getFormatBytesPerPixel(GFXFormat fmt)
 
 void GBitmap::sRegisterFormat( const GBitmap::Registration &reg )
 {
-   U32 insert = GBitmap::getBitmapRegistrations().size();
-   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
+   U32 insert = GBitmap::getRegistrations().size();
+   for ( U32 i = 0; i < GBitmap::getRegistrations().size(); i++ )
    {
-      if ( GBitmap::getBitmapRegistrations()[i].priority <= reg.priority )
+      if ( GBitmap::getRegistrations()[i].priority <= reg.priority )
       {
          insert = i;
          break;
       }
    }
 
-   GBitmap::getBitmapRegistrations().insert( insert, reg );
+   GBitmap::getRegistrations().insert( insert, reg );
 }
 
 const GBitmap::Registration   *GBitmap::sFindRegInfo( const String &extension )
 {
-   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
+   for ( U32 i = 0; i < GBitmap::getRegistrations().size(); i++ )
    {
-      const GBitmap::Registration   &reg = GBitmap::getBitmapRegistrations()[i];
+      const GBitmap::Registration   &reg = GBitmap::getRegistrations()[i];
       const Vector<String>          &extensions = reg.extensions;
 
       for ( U32 j = 0; j < extensions.size(); ++j )
@@ -241,9 +241,9 @@ bool GBitmap::sFindFile( const Path &path, Path *outPath )
 
    Path tryPath( path );
 
-   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
+   for ( U32 i = 0; i < GBitmap::getRegistrations().size(); i++ )
    {
-      const Registration &reg = GBitmap::getBitmapRegistrations()[i];
+      const Registration &reg = GBitmap::getRegistrations()[i];
       const Vector<String> &extensions = reg.extensions;
 
       for ( U32 j = 0; j < extensions.size(); ++j )
@@ -271,9 +271,9 @@ bool GBitmap::sFindFiles( const Path &path, Vector<Path> *outFoundPaths )
    
    Path  tryPath( path );
 
-   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
+   for ( U32 i = 0; i < GBitmap::getRegistrations().size(); i++ )
    {
-      const GBitmap::Registration   &reg = GBitmap::getBitmapRegistrations()[i];
+      const GBitmap::Registration   &reg = GBitmap::getRegistrations()[i];
       const Vector<String>          &extensions = reg.extensions;
 
       for ( U32 j = 0; j < extensions.size(); ++j )
@@ -297,9 +297,9 @@ String GBitmap::sGetExtensionList()
 {
    String list;
 
-   for ( U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++ )
+   for ( U32 i = 0; i < GBitmap::getRegistrations().size(); i++ )
    {
-      const Registration &reg = GBitmap::getBitmapRegistrations()[i];
+      const Registration &reg = GBitmap::getRegistrations()[i];
       for ( U32 j = 0; j < reg.extensions.size(); j++ )
       {
          list += reg.extensions[j];

--- a/Engine/source/gfx/bitmap/gBitmap.h
+++ b/Engine/source/gfx/bitmap/gBitmap.h
@@ -278,7 +278,7 @@ public:
    template<class T, dsize_t mapLength>
    void swizzle(const Swizzle<T,mapLength> *s);
 
-   static Vector<Registration>   sRegistrations;
+   static Vector<Registration>& getBitmapRegistrations();
 
 private:
    GFXFormat mInternalFormat;

--- a/Engine/source/gfx/bitmap/gBitmap.h
+++ b/Engine/source/gfx/bitmap/gBitmap.h
@@ -278,7 +278,7 @@ public:
    template<class T, dsize_t mapLength>
    void swizzle(const Swizzle<T,mapLength> *s);
 
-   static Vector<Registration>& getBitmapRegistrations();
+   static Vector<Registration>& getRegistrations();
 
 private:
    GFXFormat mInternalFormat;

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -858,14 +858,14 @@ Torque::Path GFXTextureManager::validatePath(const Torque::Path &path)
 
    // Now loop through the rest of the GBitmap extensions
    // to see if we have any matches
-   for (U32 i = 0; i < GBitmap::sRegistrations.size(); i++)
+   for (U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++)
    {
       // If we have gotten a match (either in this loop or before)
       // then we can exit
       if (textureExt)
          break;
 
-      const GBitmap::Registration   &reg = GBitmap::sRegistrations[i];
+      const GBitmap::Registration   &reg = GBitmap::getBitmapRegistrations()[i];
       const Vector<String>          &extensions = reg.extensions;
 
       for (U32 j = 0; j < extensions.size(); ++j)

--- a/Engine/source/gfx/gfxTextureManager.cpp
+++ b/Engine/source/gfx/gfxTextureManager.cpp
@@ -858,14 +858,14 @@ Torque::Path GFXTextureManager::validatePath(const Torque::Path &path)
 
    // Now loop through the rest of the GBitmap extensions
    // to see if we have any matches
-   for (U32 i = 0; i < GBitmap::getBitmapRegistrations().size(); i++)
+   for (U32 i = 0; i < GBitmap::getRegistrations().size(); i++)
    {
       // If we have gotten a match (either in this loop or before)
       // then we can exit
       if (textureExt)
          break;
 
-      const GBitmap::Registration   &reg = GBitmap::getBitmapRegistrations()[i];
+      const GBitmap::Registration   &reg = GBitmap::getRegistrations()[i];
       const Vector<String>          &extensions = reg.extensions;
 
       for (U32 j = 0; j < extensions.size(); ++j)

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -407,9 +407,9 @@ void ColladaShapeLoader::computeBounds(Box3F& bounds)
 String findTextureExtension(const Torque::Path &texPath)
 {
    Torque::Path path(texPath);
-   for(S32 i = 0;i < GBitmap::sRegistrations.size();++i)
+   for(S32 i = 0;i < GBitmap::getBitmapRegistrations().size();++i)
    {
-      GBitmap::Registration &reg = GBitmap::sRegistrations[i];
+      GBitmap::Registration &reg = GBitmap::getBitmapRegistrations()[i];
       for(S32 j = 0;j < reg.extensions.size();++j)
       {
          path.setExtension(reg.extensions[j]);

--- a/Engine/source/ts/collada/colladaShapeLoader.cpp
+++ b/Engine/source/ts/collada/colladaShapeLoader.cpp
@@ -407,9 +407,9 @@ void ColladaShapeLoader::computeBounds(Box3F& bounds)
 String findTextureExtension(const Torque::Path &texPath)
 {
    Torque::Path path(texPath);
-   for(S32 i = 0;i < GBitmap::getBitmapRegistrations().size();++i)
+   for(S32 i = 0;i < GBitmap::getRegistrations().size();++i)
    {
-      GBitmap::Registration &reg = GBitmap::getBitmapRegistrations()[i];
+      GBitmap::Registration &reg = GBitmap::getRegistrations()[i];
       for(S32 j = 0;j < reg.extensions.size();++j)
       {
          path.setExtension(reg.extensions[j]);

--- a/Engine/source/ts/loader/tsShapeLoader.cpp
+++ b/Engine/source/ts/loader/tsShapeLoader.cpp
@@ -1302,9 +1302,9 @@ String TSShapeLoader::getFormatExtensions()
 {
    // "*.dsq TAB *.dae TAB
    StringBuilder output;
-   for(U32 n = 0; n < TSShape::sRegistrations.size(); ++n)
+   for(U32 n = 0; n < TSShape::getShapeRegistrations().size(); ++n)
    {
-      TSShape::ShapeRegistration reg = TSShape::sRegistrations[n];
+      TSShape::ShapeRegistration reg = TSShape::getShapeRegistrations()[n];
       for (U32 i = 0; i < reg.extensions.size(); i++)
       {
          TSShape::ShapeFormat format = reg.extensions[i];
@@ -1320,9 +1320,9 @@ String TSShapeLoader::getFormatFilters()
 {
    // "DSQ Files|*.dsq|COLLADA Files|*.dae|"
    StringBuilder output;
-   for (U32 n = 0; n < TSShape::sRegistrations.size(); ++n)
+   for (U32 n = 0; n < TSShape::getShapeRegistrations().size(); ++n)
    {
-      TSShape::ShapeRegistration reg = TSShape::sRegistrations[n];
+      TSShape::ShapeRegistration reg = TSShape::getShapeRegistrations()[n];
       for (U32 i = 0; i < reg.extensions.size(); i++)
       {
          TSShape::ShapeFormat format = reg.extensions[i];

--- a/Engine/source/ts/loader/tsShapeLoader.cpp
+++ b/Engine/source/ts/loader/tsShapeLoader.cpp
@@ -1302,9 +1302,9 @@ String TSShapeLoader::getFormatExtensions()
 {
    // "*.dsq TAB *.dae TAB
    StringBuilder output;
-   for(U32 n = 0; n < TSShape::getShapeRegistrations().size(); ++n)
+   for(U32 n = 0; n < TSShape::getRegistrations().size(); ++n)
    {
-      TSShape::ShapeRegistration reg = TSShape::getShapeRegistrations()[n];
+      TSShape::ShapeRegistration reg = TSShape::getRegistrations()[n];
       for (U32 i = 0; i < reg.extensions.size(); i++)
       {
          TSShape::ShapeFormat format = reg.extensions[i];
@@ -1320,9 +1320,9 @@ String TSShapeLoader::getFormatFilters()
 {
    // "DSQ Files|*.dsq|COLLADA Files|*.dae|"
    StringBuilder output;
-   for (U32 n = 0; n < TSShape::getShapeRegistrations().size(); ++n)
+   for (U32 n = 0; n < TSShape::getRegistrations().size(); ++n)
    {
-      TSShape::ShapeRegistration reg = TSShape::getShapeRegistrations()[n];
+      TSShape::ShapeRegistration reg = TSShape::getRegistrations()[n];
       for (U32 i = 0; i < reg.extensions.size(); i++)
       {
          TSShape::ShapeFormat format = reg.extensions[i];

--- a/Engine/source/ts/tsShape.cpp
+++ b/Engine/source/ts/tsShape.cpp
@@ -41,25 +41,25 @@
 // Vector<TSShape::ShapeRegistration>   TSShape::sShapeRegistrations(__FILE__, __LINE__);
 
 Vector<TSShape::ShapeRegistration>& TSShape::getShapeRegistrations()
-   {
-      static Vector<TSShape::ShapeRegistration>* regs =
-         new Vector<TSShape::ShapeRegistration>(__FILE__, __LINE__);
+{
+   static Vector<TSShape::ShapeRegistration>* regs =
+      new Vector<TSShape::ShapeRegistration>(__FILE__, __LINE__);
 
-      return *regs;
-   }
+   return *regs;
+}
 
 void TSShape::sRegisterFormat(const ShapeRegistration& reg)
 {
-   U32 insert = getShapeRegistrations().size();
-   getShapeRegistrations().insert(insert, reg);
+   U32 insert = TSShape::getShapeRegistrations().size();
+   TSShape::getShapeRegistrations().insert(insert, reg);
 }
 
 
 const TSShape::ShapeRegistration* TSShape::sFindShapeRegInfo(const String& extension, bool exporting)
 {
-   for (U32 i = 0; i < getShapeRegistrations().size(); i++)
+   for (U32 i = 0; i < TSShape::getShapeRegistrations().size(); i++)
    {
-      const TSShape::ShapeRegistration& reg = getShapeRegistrations()[i];
+      const TSShape::ShapeRegistration& reg = TSShape::getShapeRegistrations()[i];
       const Vector<ShapeFormat>& extensions = exporting ? reg.export_extensions : reg.extensions;
 
       for (U32 j = 0; j < extensions.size(); j++)

--- a/Engine/source/ts/tsShape.cpp
+++ b/Engine/source/ts/tsShape.cpp
@@ -40,7 +40,7 @@
 
 // Vector<TSShape::ShapeRegistration>   TSShape::sShapeRegistrations(__FILE__, __LINE__);
 
-Vector<TSShape::ShapeRegistration>& TSShape::getShapeRegistrations()
+Vector<TSShape::ShapeRegistration>& TSShape::getRegistrations()
 {
    static Vector<TSShape::ShapeRegistration>* regs =
       new Vector<TSShape::ShapeRegistration>(__FILE__, __LINE__);
@@ -50,16 +50,16 @@ Vector<TSShape::ShapeRegistration>& TSShape::getShapeRegistrations()
 
 void TSShape::sRegisterFormat(const ShapeRegistration& reg)
 {
-   U32 insert = TSShape::getShapeRegistrations().size();
-   TSShape::getShapeRegistrations().insert(insert, reg);
+   U32 insert = TSShape::getRegistrations().size();
+   TSShape::getRegistrations().insert(insert, reg);
 }
 
 
 const TSShape::ShapeRegistration* TSShape::sFindShapeRegInfo(const String& extension, bool exporting)
 {
-   for (U32 i = 0; i < TSShape::getShapeRegistrations().size(); i++)
+   for (U32 i = 0; i < TSShape::getRegistrations().size(); i++)
    {
-      const TSShape::ShapeRegistration& reg = TSShape::getShapeRegistrations()[i];
+      const TSShape::ShapeRegistration& reg = TSShape::getRegistrations()[i];
       const Vector<ShapeFormat>& extensions = exporting ? reg.export_extensions : reg.extensions;
 
       for (U32 j = 0; j < extensions.size(); j++)

--- a/Engine/source/ts/tsShape.cpp
+++ b/Engine/source/ts/tsShape.cpp
@@ -38,19 +38,28 @@
 #include "core/stream/fileStream.h"
 #include "core/fileObject.h"
 
-Vector<TSShape::ShapeRegistration>   TSShape::sRegistrations(__FILE__, __LINE__);
+// Vector<TSShape::ShapeRegistration>   TSShape::sShapeRegistrations(__FILE__, __LINE__);
+
+Vector<TSShape::ShapeRegistration>& TSShape::getShapeRegistrations()
+   {
+      static Vector<TSShape::ShapeRegistration>* regs =
+         new Vector<TSShape::ShapeRegistration>(__FILE__, __LINE__);
+
+      return *regs;
+   }
 
 void TSShape::sRegisterFormat(const ShapeRegistration& reg)
 {
-   U32 insert = sRegistrations.size();
-   sRegistrations.insert(insert, reg);
+   U32 insert = getShapeRegistrations().size();
+   getShapeRegistrations().insert(insert, reg);
 }
 
-const TSShape::ShapeRegistration* TSShape::sFindRegInfo(const String& extension, bool exporting)
+
+const TSShape::ShapeRegistration* TSShape::sFindShapeRegInfo(const String& extension, bool exporting)
 {
-   for (U32 i = 0; i < TSShape::sRegistrations.size(); i++)
+   for (U32 i = 0; i < getShapeRegistrations().size(); i++)
    {
-      const TSShape::ShapeRegistration& reg = TSShape::sRegistrations[i];
+      const TSShape::ShapeRegistration& reg = getShapeRegistrations()[i];
       const Vector<ShapeFormat>& extensions = exporting ? reg.export_extensions : reg.extensions;
 
       for (U32 j = 0; j < extensions.size(); j++)
@@ -2358,7 +2367,7 @@ template<> void *Resource<TSShape>::create(const Torque::Path &path)
    }
    else
    {
-      const TSShape::ShapeRegistration* regInfo = TSShape::sFindRegInfo(extension);
+      const TSShape::ShapeRegistration* regInfo = TSShape::sFindShapeRegInfo(extension);
       if (regInfo == NULL)
       {
          readSuccess = false;

--- a/Engine/source/ts/tsShape.h
+++ b/Engine/source/ts/tsShape.h
@@ -122,8 +122,8 @@ public:
    };
 
    static void sRegisterFormat(const ShapeRegistration& reg);
-   static const ShapeRegistration* sFindRegInfo(const String& extension, bool exporting = false);
-   static Vector<ShapeRegistration>   sRegistrations;
+   static const ShapeRegistration* sFindShapeRegInfo(const String& extension, bool exporting = false);
+   static Vector<ShapeRegistration>&  getShapeRegistrations();
 
    /// Nodes hold the transforms in the shape's tree.  They are the bones of the skeleton.
    struct Node

--- a/Engine/source/ts/tsShape.h
+++ b/Engine/source/ts/tsShape.h
@@ -123,7 +123,7 @@ public:
 
    static void sRegisterFormat(const ShapeRegistration& reg);
    static const ShapeRegistration* sFindShapeRegInfo(const String& extension, bool exporting = false);
-   static Vector<ShapeRegistration>&  getShapeRegistrations();
+   static Vector<ShapeRegistration>&  getRegistrations();
 
    /// Nodes hold the transforms in the shape's tree.  They are the bones of the skeleton.
    struct Node

--- a/Engine/source/ts/tsShapeEdit.cpp
+++ b/Engine/source/ts/tsShapeEdit.cpp
@@ -1361,7 +1361,7 @@ bool TSShape::isShapeFileType(Torque::Path filePath)
 {
    String fileExt = filePath.getExtension();
 
-   if (TSShape::sFindRegInfo(fileExt))
+   if (TSShape::sFindShapeRegInfo(fileExt))
       return true;
 
    return false;


### PR DESCRIPTION
The automatic global static was hitting a destructor on xcode, this seemed like it was being pedantic about name at first but then between runs the same issue would come back. With this change it is wrapped in a function to get the vector instead.