### PR TITLE
Fix for convexShape

### DIFF
--- a/Engine/source/CMakeLists.txt
+++ b/Engine/source/CMakeLists.txt
@@ -782,7 +782,6 @@ target_precompile_headers(${TORQUE_APP_NAME} PRIVATE
     <cstdint>
     <cmath>
     "console/engineObject.h"
-    "scene/sceneObject.h"
 )
 
 if(TORQUE_TESTING)

--- a/Engine/source/CMakeLists.txt
+++ b/Engine/source/CMakeLists.txt
@@ -782,6 +782,7 @@ target_precompile_headers(${TORQUE_APP_NAME} PRIVATE
     <cstdint>
     <cmath>
     "console/engineObject.h"
+    "scene/sceneObject.h"
 )
 
 if(TORQUE_TESTING)

--- a/Engine/source/T3D/convexShape.cpp
+++ b/Engine/source/T3D/convexShape.cpp
@@ -211,7 +211,7 @@ bool ConvexShape::protectedSetSurface( void *object, const char *index, const ch
    Point2F offset;
    Point2F scale;
    F32 rot = 0;
-   S32 horz = 0, vert = 0;
+   S32 horz = 1, vert = 1;
 
 	/*
    dSscanf( data, "%g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g", 

--- a/Engine/source/T3D/convexShape.cpp
+++ b/Engine/source/T3D/convexShape.cpp
@@ -211,7 +211,7 @@ bool ConvexShape::protectedSetSurface( void *object, const char *index, const ch
    Point2F offset;
    Point2F scale;
    F32 rot = 0;
-   bool horz = true, vert = true;
+   S32 horz = 0, vert = 0;
 
 	/*
    dSscanf( data, "%g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g", 


### PR DESCRIPTION
ConvexShape error: reading an int in scanf into a bool causes issues, could be the compile options being more strict about inlining and the precompiled headers

Should consider a review of the compile options at some point to really nail these down