### PR TITLE
Fix heap-buffer-overflow in vendored assimp Quick3D importer (CVE-2025-11277)

### DIFF
--- a/Engine/lib/assimp/code/AssetLib/Q3D/Q3DLoader.cpp
+++ b/Engine/lib/assimp/code/AssetLib/Q3D/Q3DLoader.cpp
@@ -54,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/scene.h>
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/IOSystem.hpp>
+#include <limits>
 
 namespace Assimp {
 
@@ -307,6 +308,11 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
 
                 if (!tex->mWidth || !tex->mHeight) {
                     throw DeadlyImportError("Quick3D: Invalid texture. Width or height is zero");
+                }
+
+                const unsigned int uint_max = std::numeric_limits<unsigned int>::max();
+                if (tex->mWidth > (uint_max / tex->mHeight)) {
+                    throw DeadlyImportError("Quick3D: Texture dimensions are too large, resulting in overflow.");
                 }
 
                 unsigned int mul = tex->mWidth * tex->mHeight;


### PR DESCRIPTION
## Summary

Fixes a heap-buffer-overflow (out-of-bounds heap **write**) in the vendored assimp 5.4.3 Quick3D (`.q3o`/`.q3s`) importer. Tracked as **CVE-2025-11277**; reported in #1765.

## Root cause

`Engine/lib/assimp/code/AssetLib/Q3D/Q3DLoader.cpp`, `Q3DImporter::InternReadFile`:

```cpp
tex->mWidth  = (unsigned int)stream.GetI4();   // attacker-controlled
tex->mHeight = (unsigned int)stream.GetI4();   // attacker-controlled
if (!tex->mWidth || !tex->mHeight) { throw ...; }   // only rejects zero

unsigned int mul = tex->mWidth * tex->mHeight;      // 32-bit overflow -> wraps
aiTexel *begin = tex->pcData = new aiTexel[mul];    // undersized allocation
aiTexel *const end = &begin[mul - 1] + 1;           // mul-1 underflows when mul wraps
for (; begin != end; ++begin) { ...; begin->a = 0xff; }  // OOB heap WRITE
```

`mWidth * mHeight` is computed in 32-bit `unsigned int`, so crafted texture dimensions (e.g. `0x10000 x 0x10000`) overflow and wrap to a small value (0 in the PoC). The allocation `new aiTexel[mul]` is then far too small, and the fill loop — bounded by `&begin[mul - 1] + 1`, where `mul - 1` underflows to `0xFFFFFFFF` when `mul == 0` — writes well past the buffer.

This importer is reachable from the engine's untrusted-asset path: `Engine/source/ts/assimp/assimpShapeLoader.cpp` calls `Assimp::Importer::ReadFile(...)`, and `q3o`/`q3s` are registered loadable shape formats, so a malicious model asset (mod / downloaded content) can trigger the corruption.

## Fix

Adopt the upstream assimp integer-overflow guard verbatim — the fix that closed [assimp/assimp#6358](https://github.com/assimp/assimp/pull/6358) (CVE-2025-11277). After the existing zero check, reject dimensions whose product would overflow before performing the multiplication:

```cpp
const unsigned int uint_max = std::numeric_limits<unsigned int>::max();
if (tex->mWidth > (uint_max / tex->mHeight)) {
    throw DeadlyImportError("Quick3D: Texture dimensions are too large, resulting in overflow.");
}
```

(plus `#include <limits>`). Surgical, minimal change matching upstream; no behavioral change for valid files.

## Verification

Built assimp 5.4.3 with this exact patched file under `-fsanitize=address` and ran the PoC from #1765 through an engine-style `Assimp::Importer::ReadFile` harness:

- vulnerable 5.4.3: `AddressSanitizer: heap-buffer-overflow WRITE` at `Q3DLoader.cpp:317`, exit 134
- **patched (this PR): no crash** — importer throws `DeadlyImportError("Quick3D: Texture dimensions are too large, resulting in overflow.")`, import returns null, exit 2

Refs #1765
