### PR TITLE
Test for whether configure depends will help with the precompiled header issue

### DIFF
--- a/Engine/source/CMakeLists.txt
+++ b/Engine/source/CMakeLists.txt
@@ -767,21 +767,21 @@ if (TORQUE_TARGET_PROPERTIES)
 endif (TORQUE_TARGET_PROPERTIES)
 target_include_directories(${TORQUE_APP_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_BINARY_DIR}/temp" ${TORQUE_INCLUDE_DIRECTORIES})
 
-# target_precompile_headers(${TORQUE_APP_NAME} PRIVATE
-#     <vector>
-#     <string>
-#     <map>
-#     <memory>
-#     <algorithm>
-#     <type_traits>
-#     <cstring>
-#     <cstdlib>
-#     <cstdio>
-#     <cmath>
-#     <cstdint>
-#     <cmath>
-#     "console/engineObject.h"
-# )
+target_precompile_headers(${TORQUE_APP_NAME} PRIVATE
+    <vector>
+    <string>
+    <map>
+    <memory>
+    <algorithm>
+    <type_traits>
+    <cstring>
+    <cstdlib>
+    <cstdio>
+    <cmath>
+    <cstdint>
+    <cmath>
+    "console/engineObject.h"
+)
 
 if(TORQUE_TESTING)
   if(WIN32)

--- a/Tools/CMake/torque_macros.cmake
+++ b/Tools/CMake/torque_macros.cmake
@@ -54,11 +54,11 @@ ENDMACRO()
 # specified directory then adds them to the TORQUE_SOURCE_FILES variable.
 macro (torqueAddSourceDirectories)
   foreach(ARGUMENT ${ARGV})
-    file(GLOB SCANNED_SOURCE_FILES "${ARGUMENT}/*.cpp")
-    file(GLOB SCANNED_INCLUDE_FILES "${ARGUMENT}/*.h")
+    file(GLOB SCANNED_SOURCE_FILES CONFIGURE_DEPENDS "${ARGUMENT}/*.cpp")
+    file(GLOB SCANNED_INCLUDE_FILES CONFIGURE_DEPENDS "${ARGUMENT}/*.h")
 
     if (APPLE)
-      file(GLOB SCANNED_MAC_FILES "${ARGUMENT}/*.mm")
+      file(GLOB SCANNED_MAC_FILES CONFIGURE_DEPENDS "${ARGUMENT}/*.mm")
     endif (APPLE)
 
     # Set in both current and parent scope so this macro can be used from loaded modules


### PR DESCRIPTION
The issue with adding source and header files to the project while using cmakes precompiled header may have been caused by an improper glob setup. Configure depends ensures that cmake and the generated project stay in sync with one another. 