### PR TITLE
crashfix: make sure mShapeInstance is always assigned valid or NULL

### DIFF
--- a/Engine/source/T3D/missionMarker.cpp
+++ b/Engine/source/T3D/missionMarker.cpp
@@ -471,7 +471,7 @@ void SpawnSphere::unpackUpdate(NetConnection * con, BitStream * stream)
       stream->read(&mSpawnDataBlock);
       if (oldSDB != mSpawnDataBlock)
       {
-         delete mShapeInstance;
+         SAFE_DELETE(mShapeInstance);
          ShapeBaseData *spawnedDatablock = dynamic_cast<ShapeBaseData *>(Sim::findObject(mSpawnDataBlock.c_str()));
          if (spawnedDatablock)
          {


### PR DESCRIPTION
there were a couple code routes that could lead to mShapeInstance holding on to the old ram loc. used SAFE_DELETE preemptively to ensure that never happens.