### PR TITLE
crashfix for SFXEmitter

### DIFF
--- a/Engine/source/T3D/sfx/sfxEmitter.cpp
+++ b/Engine/source/T3D/sfx/sfxEmitter.cpp
@@ -820,7 +820,7 @@ void SFXEmitter::_update()
    // is toggled on a local profile sound.  It makes the
    // editor feel responsive and that things are working.
    if(  gEditingMission &&
-        (SoundAsset::getAssetErrCode(mSoundAsset) || !mSoundAsset->getSFXTrack()) &&
+        (SoundAsset::getAssetErrCode(mSoundAsset) || (mSoundAsset.isValid() && !mSoundAsset->getSFXTrack())) &&
         mPlayOnAdd && 
         mDirty.test( IsLooping ) )
       prevState = SFXStatusPlaying;


### PR DESCRIPTION
the last refactor broke spawning sfxemitters with blank entries. this will fix that, though we'll need to circle back and correct other issues, like looping override