### PR TITLE
simplify menu navigation button setup

### DIFF
--- a/Templates/BaseGame/game/data/UI/guis/ChooseLevelMenu.gui
+++ b/Templates/BaseGame/game/data/UI/guis/ChooseLevelMenu.gui
@@ -82,25 +82,27 @@ $guiContent = new GuiControl(ChooseLevelMenu) {
    };
    new GuiControl(ChooseLevelMenuNavButtonOverlay) {
       position = "0 61";
-      extent = "1281 60";
-      horizSizing = "width";
+      extent = "1280 60";
+      horizSizing = "center";
       profile = "GuiNonModalDefaultProfile";
       tooltipProfile = "GuiToolTipProfile";
       isContainer = "1";
 
       new GuiBitmapCtrl(ChooseLevelMenuPrevNavIcon) {
          BitmapAsset = "UI:Keyboard_Black_Q_image";
-         position = "485 24";
+         position = "188 24";
          extent = "40 40";
          vertSizing = "top";
+         horizSizing = "right";
          profile = "GuiNonModalDefaultProfile";
          tooltipProfile = "GuiToolTipProfile";
       };
       new GuiBitmapCtrl(ChooseLevelMenuNextNavIcon) {
          BitmapAsset = "UI:Keyboard_Black_E_image";
-         position = "595 24";
+         position = "1050 24";
          extent = "40 40";
          vertSizing = "top";
+         horizSizing = "left";
          profile = "GuiNonModalDefaultProfile";
          tooltipProfile = "GuiToolTipProfile";
       };

--- a/Templates/BaseGame/game/data/UI/guis/ChooseLevelMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/ChooseLevelMenu.tscript
@@ -285,10 +285,7 @@ function ChooseLevelMenu::syncGUI(%this)
    %btn.setHighlighted(true);
    
    %buttonPosX = %btn.position.x + ChooseLevelMenuTabList.position.x;
-   
-   ChooseLevelMenuPrevNavIcon.position.x = %buttonPosX;
-   ChooseLevelMenuNextNavIcon.position.x = %buttonPosX + %btn.extent.x - 40;
-     
+        
    ChooseLevelBackBtn.setBitmap(BaseUIActionMap.getCommandButtonBitmap(%device, "BaseUIBackOut"));
    
    if(ChooseLevelMenu.currentMenuIdx == 0)

--- a/Templates/BaseGame/game/data/UI/guis/GameMenu.gui
+++ b/Templates/BaseGame/game/data/UI/guis/GameMenu.gui
@@ -43,25 +43,27 @@ $guiContent = new GuiControl(GameMenu) {
          };
          
          new GuiControl(GameMenuNavButtonOverlay) {
-            extent = "1281 60";
-            horizSizing = "width";
+            extent = "1280 60";
+            horizSizing = "center";
             vertSizing = "height";
             profile = GuiNonModalDefaultProfile;
             
             new GuiBitmapCtrl(GameMenuPrevNavIcon) {
                BitmapAsset = "UI:Keyboard_Black_Q_image";
-               position = "0 24";
+               position = "188 24";
                extent = "40 40";
                profile = GuiNonModalDefaultProfile;
                vertSizing = "top";
+               horizSizing = "right";
             };
             
             new GuiBitmapCtrl(GameMenuNextNavIcon) {
                BitmapAsset = "UI:Keyboard_Black_E_image";
-               position = "0 24";
+               position = "1050 24";
                extent = "40 40";
                profile = GuiNonModalDefaultProfile;
                vertSizing = "top";
+               horizSizing = "left";
             };
          };
       };


### PR DESCRIPTION
remove position lookup logic for the choose level and choose game modes nav button icons in favor of the built in source side ones. The elements they relate to are centered as is, so set the encapsulating element for them to horizontal=centered as well, and the sub elements to thier respective left-and right as prepwork if someone *did* want to make the elements they reference scale hoizontally.