### PR TITLE
Fixes for shape importing/taml writing

### DIFF
--- a/Engine/source/T3D/assets/assetImporter.cpp
+++ b/Engine/source/T3D/assets/assetImporter.cpp
@@ -3044,9 +3044,11 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
 
    StringTableEntry assetName = StringTable->insert(assetItem->assetName.c_str());
 
-   String shapeFileName = "@" + assetItem->filePath.getFileName() + "." + assetItem->filePath.getExtension();
-   String constructorFileName = assetItem->filePath.getFileName() + "." TORQUE_SCRIPT_EXTENSION;
+   String shapeFileName =assetItem->filePath.getFileName() + "." + assetItem->filePath.getExtension();
    String assetPath = targetPath + "/" + shapeFileName;
+   shapeFileName = "@" + shapeFileName;
+
+   String constructorFileName = assetItem->filePath.getFileName() + "." TORQUE_SCRIPT_EXTENSION;
    String constructorPath = targetPath + "/" + constructorFileName;
    constructorFileName = "@" + constructorFileName;
    String tamlPath = targetPath + "/" + assetName + ".asset.taml";
@@ -3128,6 +3130,29 @@ Torque::Path AssetImporter::importShapeAsset(AssetImportObject* assetItem)
       dSprintf(importLogBuffer, sizeof(importLogBuffer), "Error! Unable to write asset taml file %s", tamlPath.c_str());
       activityLog.push_back(importLogBuffer);
       return "";
+   }
+
+   if (!isReimport)
+   {
+      char qualifiedFromFile[2048];
+      char qualifiedToFile[2048];
+
+#ifndef TORQUE_SECURE_VFS
+      Platform::makeFullPathName(originalPath.c_str(), qualifiedFromFile, sizeof(qualifiedFromFile));
+      Platform::makeFullPathName(assetPath.c_str(), qualifiedToFile, sizeof(qualifiedToFile));
+#else
+      dStrcpy(qualifiedFromFile, originalPath.c_str(), sizeof(qualifiedFromFile));
+      dStrcpy(qualifiedToFile, assetPath.c_str(), sizeof(qualifiedToFile));
+#endif
+
+      bool isInPlace = !String::compare(qualifiedFromFile, qualifiedToFile);
+
+      if (!isInPlace && !Torque::FS::CopyFile(qualifiedFromFile, qualifiedToFile, !isReimport))
+      {
+         dSprintf(importLogBuffer, sizeof(importLogBuffer), "Error! Unable to copy file %s", qualifiedFromFile);
+         activityLog.push_back(importLogBuffer);
+         return "";
+      }
    }
 
    bool makeNewConstructor = true;

--- a/Engine/source/persistence/taml/taml.cpp
+++ b/Engine/source/persistence/taml/taml.cpp
@@ -252,8 +252,9 @@ bool Taml::write(SimObject* pSimObject, const char* pFilename)
    stream.close();
 
    // Reset the compilation.
-   resetCompilation();
    mWriteLocked = false;
+   resetCompilation();
+
    return status;
 }
 


### PR DESCRIPTION
- Flips the order of the taml object compilation and flag for locking the write so we can properly clear and reprocess objects if they're accessed/written again

- Re-adds the filecopy check so if dragging-and-dropping an external shape file for importing(Secure VFS flag allowing) it properly copies the source file to the destination directory on import