### PR TITLE
Update MaterialAsset and TerrainAsset to AssetRef standardization

### DIFF
--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -459,25 +459,6 @@ void ImageAsset::initializeAsset(void)
       Torque::FS::AddChangeNotification(mImageFile, this, &ImageAsset::_onResourceChanged);
 
    populateImage();
-
-   //Make sure our fallbacks are valid
-   if (smNoImageAssetFallbackAssetPtr.isNull())
-   {
-      smNoImageAssetFallbackAssetPtr = smNoImageAssetFallback;
-      if (smNoImageAssetFallbackAssetPtr.isNull())
-         Con::errorf("ImageAsset::initializeAsset could not find fallback asset %s!", smNoImageAssetFallback);
-      else
-         smNoImageAssetFallbackAssetPtr->load();
-   }
-
-   if (smNamedTargetAssetFallbackAssetPtr.isNull())
-   {
-      smNamedTargetAssetFallbackAssetPtr = smNamedTargetAssetFallback;
-      if (smNamedTargetAssetFallbackAssetPtr.isNull())
-         Con::errorf("ImageAsset::initializeAsset could not find named target fallback asset %s!", smNamedTargetAssetFallback);
-      else
-         smNamedTargetAssetFallbackAssetPtr->load();
-   }
 }
 
 void ImageAsset::onAssetRefresh(void)
@@ -860,6 +841,45 @@ DefineEngineMethod(ImageAsset, isNamedTarget, bool, (), ,
    return object->isNamedTarget();
 }
 
+DefineEngineFunction(loadImageAssetFallback, S32, (), ,
+   "Forces the loading of the ImageAsset fallback asset.\n"
+   "@return Load status code.")
+{
+   if (ImageAsset::smNoImageAssetFallbackAssetPtr.isNull())
+   {
+      ImageAsset::smNoImageAssetFallbackAssetPtr = ImageAsset::smNoImageAssetFallback;
+      if (ImageAsset::smNoImageAssetFallbackAssetPtr.isNull())
+         Con::errorf("loadImageAssetFallback could not find fallback asset %s!", ImageAsset::smNoImageAssetFallback);
+      else
+         return (S32)ImageAsset::smNoImageAssetFallbackAssetPtr->load();
+   }
+   else
+   {
+      return (S32)ImageAsset::smNoImageAssetFallbackAssetPtr->getStatus();
+   }
+
+   return AssetBase::Failed;
+}
+
+DefineEngineFunction(loadNamedTargetFallback, S32, (), ,
+   "Forces the loading of the ImageAsset Named Target fallback asset.\n"
+   "@return Load status code.")
+{
+   if (ImageAsset::smNamedTargetAssetFallbackAssetPtr.isNull())
+   {
+      ImageAsset::smNamedTargetAssetFallbackAssetPtr = ImageAsset::smNamedTargetAssetFallback;
+      if (ImageAsset::smNamedTargetAssetFallbackAssetPtr.isNull())
+         Con::errorf("loadNamedTargetFallback could not find fallback asset %s!", ImageAsset::smNamedTargetAssetFallback);
+      else
+         return (S32)ImageAsset::smNamedTargetAssetFallbackAssetPtr->load();
+   }
+   else
+   {
+      return (S32)ImageAsset::smNamedTargetAssetFallbackAssetPtr->getStatus();
+   }
+
+   return AssetBase::Failed;
+}
 
 #ifdef TORQUE_TOOLS
 DefineEngineStaticMethod(ImageAsset, getAssetIdByFilename, const char*, (const char* filePath), (""),

--- a/Engine/source/T3D/assets/MaterialAsset.cpp
+++ b/Engine/source/T3D/assets/MaterialAsset.cpp
@@ -44,6 +44,7 @@
 #include "T3D/assets/assetImporter.h"
 
 StringTableEntry MaterialAsset::smNoMaterialAssetFallback = NULL;
+AssetPtr<MaterialAsset> MaterialAsset::smNoMaterialAssetFallbackAssetPtr = NULL;
 
 const String MaterialAsset::mErrCodeStrings[] =
 {
@@ -55,6 +56,9 @@ const String MaterialAsset::mErrCodeStrings[] =
 //-----------------------------------------------------------------------------
 
 IMPLEMENT_CONOBJECT(MaterialAsset);
+
+IMPLEMENT_STRUCT(AssetRef<MaterialAsset>, AssetRefMaterialAsset, , "")
+END_IMPLEMENT_STRUCT
 
 ConsoleType(MaterialAssetPtr, TypeMaterialAssetPtr, MaterialAsset, ASSET_ID_FIELD_PREFIX)
 
@@ -126,6 +130,43 @@ ConsoleSetType(TypeMaterialAssetId)
    // Warn.
    Con::warnf("(TypeMaterialAssetId) - Cannot set multiple args to a single asset.");
 }
+
+//-----------------------------------------------------------------------------
+
+ConsoleType(MaterialAssetRef, TypeMaterialAssetRef, AssetRef<MaterialAsset>, ASSET_ID_FIELD_PREFIX)
+
+ConsoleGetType(TypeMaterialAssetRef)
+{
+   AssetRef<MaterialAsset>& ref = *((AssetRef<MaterialAsset>*)dptr);
+
+   if (ref.assetPtr.isNull())
+      return ref.assetId;
+   else
+      return ref.assetPtr.getAssetId();
+}
+
+ConsoleSetType(TypeMaterialAssetRef)
+{
+   if (argc == 1)
+   {
+      const char* pFieldValue = argv[0];
+
+      AssetRef<MaterialAsset>* pAssetRef = (AssetRef<MaterialAsset>*)(dptr);
+
+      if (pAssetRef == NULL)
+      {
+         Con::warnf("(TypeMaterialAssetRef) - Failed to set asset Id '%d'.", pFieldValue);
+         return;
+      }
+
+      *pAssetRef = pFieldValue;
+
+      return;
+   }
+
+   Con::warnf("(TypeMaterialAssetRef) - Cannot set multiple args to a single asset.");
+}
+
 //-----------------------------------------------------------------------------
 
 MaterialAsset::MaterialAsset()
@@ -245,12 +286,34 @@ void MaterialAsset::setScriptFile(const char* pScriptFile)
 
 //------------------------------------------------------------------------------
 
-U32 MaterialAsset::load()
+StringTableEntry MaterialAsset::getMaterialName()
 {
    if (mMaterialDefinition)
-   {
-      mMaterialDefinition->safeDeleteObject();
-   }
+      return mMatDefinitionName;
+
+   if (smNoMaterialAssetFallbackAssetPtr.notNull())
+      return smNoMaterialAssetFallbackAssetPtr->getMaterialName();
+
+   return StringTable->EmptyString();
+}
+
+SimObjectPtr<Material> MaterialAsset::getMaterial()
+{
+   if (mMaterialDefinition)
+      return mMaterialDefinition;
+
+   if (smNoMaterialAssetFallbackAssetPtr.notNull())
+      return smNoMaterialAssetFallbackAssetPtr->getMaterial();
+
+   return NULL;
+}
+
+//------------------------------------------------------------------------------
+
+U32 MaterialAsset::load()
+{
+   if (mLoadedState == AssetErrCode::Ok)
+      return mLoadedState;
 
    if (mLoadedState == EmbeddedDefinition)
    {
@@ -333,7 +396,7 @@ U32 MaterialAsset::getAssetByMaterialName(StringTableEntry matName, AssetPtr<Mat
       for (U32 i = 0; i < foundAssetcount; i++)
       {
          MaterialAsset* tMatAsset = AssetDatabase.acquireAsset<MaterialAsset>(query.mAssetList[i]);
-         if (tMatAsset && tMatAsset->getMaterialDefinitionName() == matName)
+         if (tMatAsset && tMatAsset->getMaterialName() == matName)
          {
             matAsset->setAssetId(query.mAssetList[i]);
             AssetDatabase.releaseAsset(query.mAssetList[i]);
@@ -366,7 +429,7 @@ StringTableEntry MaterialAsset::getAssetIdByMaterialName(StringTableEntry matNam
          MaterialAsset* matAsset = AssetDatabase.acquireAsset<MaterialAsset>(query.mAssetList[i]);
          if (matAsset)
          {
-            if (matAsset->getMaterialDefinitionName() == matName)
+            if (matAsset->getMaterialName() == matName)
                materialAssetId = matAsset->getAssetId();
 
             AssetDatabase.releaseAsset(query.mAssetList[i]);
@@ -420,6 +483,26 @@ SimObjectPtr<Material> MaterialAsset::findMaterialDefinitionByAssetId(StringTabl
       return matDef;
    }
    return NULL;
+}
+
+DefineEngineFunction(loadMaterialAssetFallback, S32, (), ,
+   "Forces the loading of the MaterialAsset fallback asset.\n"
+   "@return Load status code.")
+{
+   if (MaterialAsset::smNoMaterialAssetFallbackAssetPtr.isNull())
+   {
+      MaterialAsset::smNoMaterialAssetFallbackAssetPtr = MaterialAsset::smNoMaterialAssetFallback;
+      if (MaterialAsset::smNoMaterialAssetFallbackAssetPtr.isNull())
+         Con::errorf("loadMaterialAssetFallback could not find fallback asset %s!", MaterialAsset::smNoMaterialAssetFallback);
+      else
+         return (S32)MaterialAsset::smNoMaterialAssetFallbackAssetPtr->load();
+   }
+   else
+   {
+      return (S32)MaterialAsset::smNoMaterialAssetFallbackAssetPtr->getStatus();
+   }
+
+   return AssetBase::Failed;
 }
 
 #ifdef TORQUE_TOOLS
@@ -623,14 +706,14 @@ void GuiInspectorTypeMaterialAssetPtr::updatePreviewImage()
 
    AssetPtr<MaterialAsset> matAssetDef = matAssetId;
    if (matAssetDef.isNull() || matAssetDef->getStatus() != AssetBase::AssetErrCode::Ok ||
-      matAssetDef->getMaterialDefinitionName() == StringTable->EmptyString())
+      matAssetDef->getMaterialName() == StringTable->EmptyString())
    {
       mPreviewImage->_setBitmap(StringTable->insert("Core_Rendering:WarningMaterial"));
       return;
    }
 
    Material* matDef;
-   if (!Sim::findObject(matAssetDef->getMaterialDefinitionName(), matDef))
+   if (!Sim::findObject(matAssetDef->getMaterialName(), matDef))
    {
       mPreviewImage->_setBitmap(StringTable->insert("Core_Rendering:WarningMaterial"));
       return;
@@ -683,9 +766,9 @@ void GuiInspectorTypeMaterialAssetPtr::setPreviewImage(StringTableEntry assetId)
       if (AssetDatabase.isDeclaredAsset(assetId))
       {
          MaterialAsset* matAsset = AssetDatabase.acquireAsset<MaterialAsset>(assetId);
-         if (matAsset && matAsset->getMaterialDefinition())
+         if (matAsset && matAsset->getMaterial())
          {
-            mPreviewImage->_setBitmap(matAsset->getMaterialDefinition()->getDiffuseMapAssetId(0));
+            mPreviewImage->_setBitmap(matAsset->getMaterial()->getDiffuseMapAssetId(0));
          }
       }
    }
@@ -707,5 +790,22 @@ void GuiInspectorTypeMaterialAssetId::consoleInit()
    Parent::consoleInit();
 
    ConsoleBaseType::getType(TypeMaterialAssetId)->setInspectorFieldType("GuiInspectorTypeMaterialAssetId");
+}
+
+//-----------------------------------------------------------------------------
+
+IMPLEMENT_CONOBJECT(GuiInspectorTypeMaterialAssetRef);
+
+ConsoleDocClass(GuiInspectorTypeMaterialAssetRef,
+   "@brief Inspector field type for AssetRef<MaterialAsset> fields\n\n"
+   "Editor use only.\n\n"
+   "@internal"
+);
+
+void GuiInspectorTypeMaterialAssetRef::consoleInit()
+{
+   Parent::consoleInit();
+
+   ConsoleBaseType::getType(TypeMaterialAssetRef)->setInspectorFieldType("GuiInspectorTypeMaterialAssetRef");
 }
 #endif

--- a/Engine/source/T3D/assets/MaterialAsset.h
+++ b/Engine/source/T3D/assets/MaterialAsset.h
@@ -74,6 +74,7 @@ class MaterialAsset : public AssetBase
 
 public:
    static StringTableEntry smNoMaterialAssetFallback;
+   static AssetPtr<MaterialAsset> smNoMaterialAssetFallbackAssetPtr;
 
    enum MaterialAssetErrCode
    {
@@ -106,8 +107,8 @@ public:
 
    U32 load() override;
 
-   StringTableEntry getMaterialDefinitionName() { return mMatDefinitionName; }
-   SimObjectPtr<Material> getMaterialDefinition() { return mMaterialDefinition; }
+   StringTableEntry getMaterialName();
+   SimObjectPtr<Material> getMaterial();
 
    void                    setScriptFile(const char* pScriptFile);
    inline StringTableEntry getScriptFile(void) const { return mScriptFile; };
@@ -143,6 +144,8 @@ protected:
 
 DefineConsoleType(TypeMaterialAssetPtr, MaterialAsset)
 DefineConsoleType(TypeMaterialAssetId, String)
+DECLARE_STRUCT(AssetRef<MaterialAsset>)
+DefineConsoleType(TypeMaterialAssetRef, AssetRef<MaterialAsset>)
 #ifdef TORQUE_TOOLS
 //-----------------------------------------------------------------------------
 // TypeAssetId GuiInspectorField Class
@@ -177,142 +180,16 @@ public:
    DECLARE_CONOBJECT(GuiInspectorTypeMaterialAssetId);
    static void consoleInit();
 };
+
+class GuiInspectorTypeMaterialAssetRef : public GuiInspectorTypeMaterialAssetPtr
+{
+   typedef GuiInspectorTypeMaterialAssetPtr Parent;
+public:
+
+   DECLARE_CONOBJECT(GuiInspectorTypeMaterialAssetRef);
+   static void consoleInit();
+};
 #endif
-#pragma region Singular Asset Macros
-
-//Singular assets
-/// <Summary>
-/// Declares an material asset
-/// This establishes the assetId, asset and legacy filepath fields, along with supplemental getter and setter functions
-/// </Summary>
-#define DECLARE_MATERIALASSET(className, name) public: \
-   StringTableEntry m##name##Name;\
-   StringTableEntry m##name##AssetId;\
-   AssetPtr<MaterialAsset>  m##name##Asset;\
-   SimObjectPtr<Material> m##name;\
-public: \
-   const StringTableEntry get##name##File() const { return m##name##Name; }\
-   void set##name##Name(const FileName &_in) { m##name##Name = StringTable->insert(_in.c_str());}\
-   const AssetPtr<MaterialAsset> & get##name##Asset() const { return m##name##Asset; }\
-   void set##name##Asset(const AssetPtr<MaterialAsset> &_in) { m##name##Asset = _in;}\
-   \
-   bool _set##name(StringTableEntry _in)\
-   {\
-      if(m##name##AssetId != _in || m##name##Name != _in)\
-      {\
-         if (_in == NULL || _in == StringTable->EmptyString())\
-         {\
-            m##name##Name = StringTable->EmptyString();\
-            m##name##AssetId = StringTable->EmptyString();\
-            m##name##Asset = NULL;\
-            m##name = NULL;\
-            return true;\
-         }\
-         \
-         if (AssetDatabase.isDeclaredAsset(_in))\
-         {\
-            m##name##AssetId = _in;\
-            \
-            U32 assetState = MaterialAsset::getAssetById(m##name##AssetId, &m##name##Asset);\
-            \
-            if (MaterialAsset::Ok == assetState)\
-            {\
-               m##name##Name = StringTable->EmptyString();\
-            }\
-         }\
-         else\
-         {\
-            StringTableEntry assetId = MaterialAsset::getAssetIdByMaterialName(_in);\
-            if (assetId != StringTable->EmptyString())\
-            {\
-               m##name##AssetId = assetId;\
-               if (MaterialAsset::getAssetById(m##name##AssetId, &m##name##Asset) == MaterialAsset::Ok)\
-               {\
-                  m##name##Name = StringTable->EmptyString();\
-               }\
-            }\
-            else\
-            {\
-               m##name##Name = _in;\
-               m##name##AssetId = StringTable->EmptyString();\
-               m##name##Asset = NULL;\
-            }\
-         }\
-      }\
-      if (get##name() != StringTable->EmptyString() && m##name##Asset.notNull())\
-      {\
-         if (m##name && String(m##name##Asset->getMaterialDefinitionName()).equal(m##name->getName(), String::NoCase))\
-            return false;\
-         \
-         Material* tempMat = NULL;\
-         \
-         if (!Sim::findObject(m##name##Asset->getMaterialDefinitionName(), tempMat))\
-            Con::errorf("%s::_set%s() - Material %s was not found.", macroText(className), macroText(name), m##name##Asset->getMaterialDefinitionName());\
-         m##name = tempMat;\
-      }\
-      else\
-      {\
-         m##name = NULL;\
-      }\
-      \
-      if(get##name() == StringTable->EmptyString())\
-         return true;\
-      \
-      if (m##name##Asset.notNull() && m##name##Asset->getStatus() != MaterialAsset::Ok)\
-      {\
-         Con::errorf("%s::_set%s() - material asset failure\"%s\" due to [%s]", macroText(className), macroText(name), _in, MaterialAsset::getAssetErrstrn(m##name##Asset->getStatus()).c_str());\
-         return false; \
-      }\
-      else if (!m##name)\
-      {\
-         Con::errorf("%s::_set%s() - Couldn't load material \"%s\"", macroText(className), macroText(name), _in);\
-         return false;\
-      }\
-      return true;\
-   }\
-   \
-   const StringTableEntry get##name() const\
-   {\
-      if (m##name##Asset && (m##name##Asset->getMaterialDefinitionName() != StringTable->EmptyString()))\
-         return m##name##Asset->getMaterialDefinitionName();\
-      else if (m##name##AssetId != StringTable->EmptyString())\
-         return m##name##AssetId;\
-      else if (m##name##Name != StringTable->EmptyString())\
-         return m##name##Name;\
-      else\
-         return StringTable->EmptyString();\
-   }\
-   SimObjectPtr<Material> get##name##Resource() \
-   {\
-      return m##name;\
-   }\
-   bool is##name##Valid() {return (get##name() != StringTable->EmptyString() && m##name##Asset->getStatus() == AssetBase::Ok); }
-
-#ifdef TORQUE_SHOW_LEGACY_FILE_FIELDS
-
-#define INITPERSISTFIELD_MATERIALASSET(name, consoleClass, docs) \
-   addProtectedField(#name, TypeMaterialName, Offset(m##name##Name, consoleClass), _set##name##Data, &defaultProtectedGetFn,assetDoc(name, docs)); \
-   addProtectedField(assetText(name, Asset), TypeMaterialAssetId, Offset(m##name##AssetId, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, asset docs.));
-
-#else
-
-#define INITPERSISTFIELD_MATERIALASSET(name, consoleClass, docs) \
-   addProtectedField(#name, TypeMaterialName, Offset(m##name##Name, consoleClass), _set##name##Data, &defaultProtectedGetFn,assetDoc(name, docs), AbstractClassRep::FIELD_HideInInspectors); \
-   addProtectedField(assetText(name, Asset), TypeMaterialAssetId, Offset(m##name##AssetId, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, asset docs.));
-
-#endif // SHOW_LEGACY_FILE_FIELDS
-
-#define LOAD_MATERIALASSET(name)\
-if (m##name##AssetId != StringTable->EmptyString())\
-{\
-   S32 assetState = MaterialAsset::getAssetById(m##name##AssetId, &m##name##Asset);\
-   if (assetState == MaterialAsset::Ok )\
-   {\
-      m##name##Name = StringTable->EmptyString();\
-   }\
-   else Con::warnf("Warning: %s::LOAD_MATERIALASSET(%s)-%s", mClassName, m##name##AssetId, MaterialAsset::getAssetErrstrn(assetState).c_str());\
-}
-#pragma endregion
 
 #endif // _ASSET_BASE_H_
 

--- a/Engine/source/T3D/assets/ShapeAsset.cpp
+++ b/Engine/source/T3D/assets/ShapeAsset.cpp
@@ -263,16 +263,6 @@ void ShapeAsset::initializeAsset()
       String normalPath = String(mShapeFile) + "_imposter_normals.dds";
       mNormalImposterFileName = StringTable->insert(normalPath.c_str());
    }
-
-   //Make sure our fallback is valid
-   if (smNoShapeAssetFallbackAssetPtr.isNull())
-   {
-      smNoShapeAssetFallbackAssetPtr = smNoShapeAssetFallback;
-      if (smNoShapeAssetFallbackAssetPtr.isNull())
-         Con::errorf("ShapeAsset::initializeAsset could not find fallback asset %s!", smNoShapeAssetFallback);
-      else
-         smNoShapeAssetFallbackAssetPtr->load();
-   }
 }
 
 void ShapeAsset::setShapeFile(const char* pShapeFile)
@@ -773,6 +763,26 @@ DefineEngineMethod(ShapeAsset, getShapeConstructorFilePath, const char*, (), ,
 DefineEngineMethod(ShapeAsset, getStatusString, String, (), , "get status string")\
 {
    return ShapeAsset::getAssetErrstrn(object->getStatus());
+}
+
+DefineEngineFunction(loadShapeAssetFallback, S32, (), ,
+   "Forces the loading of the ShapeAsset fallback asset.\n"
+   "@return Load status code.")
+{
+   if (ShapeAsset::smNoShapeAssetFallbackAssetPtr.isNull())
+   {
+      ShapeAsset::smNoShapeAssetFallbackAssetPtr = ShapeAsset::smNoShapeAssetFallback;
+      if (ShapeAsset::smNoShapeAssetFallbackAssetPtr.isNull())
+         Con::errorf("loadShapeAssetFallback could not find fallback asset %s!", ShapeAsset::smNoShapeAssetFallback);
+      else
+         return (S32)ShapeAsset::smNoShapeAssetFallbackAssetPtr->load();
+   }
+   else
+   {
+      return (S32)ShapeAsset::smNoShapeAssetFallbackAssetPtr->getStatus();
+   }
+
+   return AssetBase::Failed;
 }
 
 #ifdef TORQUE_TOOLS

--- a/Engine/source/T3D/assets/TerrainMaterialAsset.cpp
+++ b/Engine/source/T3D/assets/TerrainMaterialAsset.cpp
@@ -44,12 +44,16 @@
 #include "T3D/assets/assetImporter.h"
 
 StringTableEntry TerrainMaterialAsset::smNoTerrainMaterialAssetFallback = NULL;
+AssetPtr<TerrainMaterialAsset> TerrainMaterialAsset::smNoTerrainMaterialAssetFallbackAssetPtr = NULL;
 
 //-----------------------------------------------------------------------------
 
 IMPLEMENT_CONOBJECT(TerrainMaterialAsset);
 
 IMPLEMENT_STRUCT(AssetPtr<TerrainMaterialAsset>, AssetPtrTerrainMaterialAsset, , "")
+END_IMPLEMENT_STRUCT
+
+IMPLEMENT_STRUCT(AssetRef<TerrainMaterialAsset>, AssetRefTerrainMaterialAsset, , "")
 END_IMPLEMENT_STRUCT
 
 ConsoleType(TerrainMaterialAssetPtr, TypeTerrainMaterialAssetPtr, AssetPtr<TerrainMaterialAsset>, ASSET_ID_FIELD_PREFIX)
@@ -122,6 +126,43 @@ ConsoleSetType(TypeTerrainMaterialAssetId)
    // Warn.
    Con::warnf("(TypeTerrainMaterialAssetId) - Cannot set multiple args to a single asset.");
 }
+
+//-----------------------------------------------------------------------------
+
+ConsoleType(TerrainMaterialAssetRef, TypeTerrainMaterialAssetRef, AssetRef<TerrainMaterialAsset>, ASSET_ID_FIELD_PREFIX)
+
+ConsoleGetType(TypeTerrainMaterialAssetRef)
+{
+   AssetRef<TerrainMaterialAsset>& ref = *((AssetRef<TerrainMaterialAsset>*)dptr);
+
+   if (ref.assetPtr.isNull())
+      return ref.assetId;
+   else
+      return ref.assetPtr.getAssetId();
+}
+
+ConsoleSetType(TypeTerrainMaterialAssetRef)
+{
+   if (argc == 1)
+   {
+      const char* pFieldValue = argv[0];
+
+      AssetRef<TerrainMaterialAsset>* pAssetRef = (AssetRef<TerrainMaterialAsset>*)(dptr);
+
+      if (pAssetRef == NULL)
+      {
+         Con::warnf("(TypeTerrainMaterialAssetRef) - Failed to set asset Id '%d'.", pFieldValue);
+         return;
+      }
+
+      *pAssetRef = pFieldValue;
+
+      return;
+   }
+
+   Con::warnf("(TypeTerrainMaterialAssetRef) - Cannot set multiple args to a single asset.");
+}
+
 //-----------------------------------------------------------------------------
 
 TerrainMaterialAsset::TerrainMaterialAsset()
@@ -254,12 +295,34 @@ void TerrainMaterialAsset::setScriptFile(const char* pScriptFile)
 
 //------------------------------------------------------------------------------
 
-U32 TerrainMaterialAsset::load()
+StringTableEntry TerrainMaterialAsset::getMaterialName()
 {
    if (mMaterialDefinition)
-      mMaterialDefinition->safeDeleteObject();
-   if (mFXMaterialDefinition)
-      mFXMaterialDefinition->safeDeleteObject();
+      return mMatDefinitionName;
+
+   if (smNoTerrainMaterialAssetFallbackAssetPtr.notNull())
+      return smNoTerrainMaterialAssetFallbackAssetPtr->getMaterialName();
+
+   return StringTable->EmptyString();
+}
+
+SimObjectPtr<TerrainMaterial> TerrainMaterialAsset::getMaterial()
+{
+   if (mMaterialDefinition)
+      return mMaterialDefinition;
+
+   if (smNoTerrainMaterialAssetFallbackAssetPtr.notNull())
+      return smNoTerrainMaterialAssetFallbackAssetPtr->getMaterial();
+
+   return NULL;
+}
+
+//------------------------------------------------------------------------------
+
+U32 TerrainMaterialAsset::load()
+{
+   if (mLoadedState == AssetErrCode::Ok)
+      return mLoadedState;
 
    if (mLoadedState == EmbeddedDefinition)
    {
@@ -355,7 +418,7 @@ U32 TerrainMaterialAsset::getAssetByMaterialName(StringTableEntry matName, Asset
       for (U32 i = 0; i < foundAssetcount; i++)
       {
          TerrainMaterialAsset* tMatAsset = AssetDatabase.acquireAsset<TerrainMaterialAsset>(query.mAssetList[i]);
-         if (tMatAsset && tMatAsset->getMaterialDefinitionName() == matName)
+         if (tMatAsset && tMatAsset->getMaterialName() == matName)
          {
             matAsset->setAssetId(query.mAssetList[i]);
             AssetDatabase.releaseAsset(query.mAssetList[i]);
@@ -388,7 +451,7 @@ StringTableEntry TerrainMaterialAsset::getAssetIdByMaterialName(StringTableEntry
          TerrainMaterialAsset* matAsset = AssetDatabase.acquireAsset<TerrainMaterialAsset>(query.mAssetList[i]);
          if (matAsset)
          {
-            if (matAsset->getMaterialDefinitionName() == matName)
+            if (matAsset->getMaterialName() == matName)
                materialAssetId = matAsset->getAssetId();
 
             AssetDatabase.releaseAsset(query.mAssetList[i]);
@@ -467,11 +530,11 @@ DefineEngineMethod(TerrainMaterialAsset, getScriptPath, const char*, (), ,
    return object->getScriptPath();
 }
 
-DefineEngineMethod(TerrainMaterialAsset, getMaterialDefinition, S32, (), ,
+DefineEngineMethod(TerrainMaterialAsset, getMaterial, S32, (), ,
    "Queries the Asset Database to see if any asset exists that is associated with the provided material name.\n"
    "@return The AssetId of the associated asset, if any.")
 {
-   SimObjectPtr<TerrainMaterial> mat = object->getMaterialDefinition();
+   SimObjectPtr<TerrainMaterial> mat = object->getMaterial();
    if (mat.isValid())
       return mat->getId();
    else
@@ -487,6 +550,26 @@ DefineEngineMethod(TerrainMaterialAsset, getFXMaterialDefinition, S32, (), ,
       return mat->getId();
    else
       return 0;
+}
+
+DefineEngineFunction(loadTerrainMaterialAssetFallback, S32, (), ,
+   "Forces the loading of the TerrainMaterialAsset fallback asset.\n"
+   "@return Load status code.")
+{
+   if (TerrainMaterialAsset::smNoTerrainMaterialAssetFallbackAssetPtr.isNull())
+   {
+      TerrainMaterialAsset::smNoTerrainMaterialAssetFallbackAssetPtr = TerrainMaterialAsset::smNoTerrainMaterialAssetFallback;
+      if (TerrainMaterialAsset::smNoTerrainMaterialAssetFallbackAssetPtr.isNull())
+         Con::errorf("loadTerrainMaterialAssetFallback could not find fallback asset %s!", TerrainMaterialAsset::smNoTerrainMaterialAssetFallback);
+      else
+         return (S32)TerrainMaterialAsset::smNoTerrainMaterialAssetFallbackAssetPtr->load();
+   }
+   else
+   {
+      return (S32)TerrainMaterialAsset::smNoTerrainMaterialAssetFallbackAssetPtr->getStatus();
+   }
+
+   return AssetBase::Failed;
 }
 //-----------------------------------------------------------------------------
 // GuiInspectorTypeAssetId
@@ -590,5 +673,19 @@ void GuiInspectorTypeTerrainMaterialAssetId::consoleInit()
    Parent::consoleInit();
 
    ConsoleBaseType::getType(TypeTerrainMaterialAssetId)->setInspectorFieldType("GuiInspectorTypeTerrainMaterialAssetId");
+}
+
+IMPLEMENT_CONOBJECT(GuiInspectorTypeTerrainMaterialAssetRef);
+
+ConsoleDocClass(GuiInspectorTypeTerrainMaterialAssetRef,
+   "@brief Inspector field type for AssetRef<TerrainMaterialAsset> fields\n\n"
+   "Editor use only.\n\n"
+   "@internal"
+);
+
+void GuiInspectorTypeTerrainMaterialAssetRef::consoleInit()
+{
+   Parent::consoleInit();
+   ConsoleBaseType::getType(TypeTerrainMaterialAssetRef)->setInspectorFieldType("GuiInspectorTypeTerrainMaterialAssetRef");
 }
 #endif

--- a/Engine/source/T3D/assets/TerrainMaterialAsset.h
+++ b/Engine/source/T3D/assets/TerrainMaterialAsset.h
@@ -70,7 +70,8 @@ class TerrainMaterialAsset : public AssetBase
 
 public:
    static StringTableEntry smNoTerrainMaterialAssetFallback;
-   
+   static AssetPtr<TerrainMaterialAsset> smNoTerrainMaterialAssetFallbackAssetPtr;
+
    enum TerrainMaterialAssetErrCode
    {
       ScriptLoaded = AssetErrCode::Extended,
@@ -91,8 +92,8 @@ public:
 
    U32 load() override;
 
-   StringTableEntry getMaterialDefinitionName() { return mMatDefinitionName; }
-   SimObjectPtr<TerrainMaterial> getMaterialDefinition() { return mMaterialDefinition; }
+   StringTableEntry getMaterialName();
+   SimObjectPtr<TerrainMaterial> getMaterial();
 
    SimObjectPtr<Material> getFXMaterialDefinition() { return mFXMaterialDefinition; }
 
@@ -131,181 +132,11 @@ protected:
 DECLARE_STRUCT(AssetPtr<TerrainMaterialAsset>)
 DefineConsoleType(TypeTerrainMaterialAssetPtr, AssetPtr<TerrainMaterialAsset>)
 
-#define DECLARE_TERRAINMATERIALASSET(className, name)                                                                                                               \
-private:                                                                                                                                                                      \
-   AssetPtr<TerrainMaterialAsset> m##name##Asset;                                                                                                                                  \
-   StringTableEntry     m##name##File = {StringTable->EmptyString() };                                                                                                   \
-public:                                                                                                                                                                       \
-   void _set##name(StringTableEntry _in){                                                                                                                   \
-      if (m##name##Asset.getAssetId() == _in)                                                                                                                          \
-         return;                                                                                                                                                              \
-      if(_in == NULL || !String::compare(_in,StringTable->EmptyString()))                                                                                                       \
-      {                                                                                                                                                                       \
-         m##name##Asset = NULL;                                                                                                                                        \
-         m##name##File = "";                                                                                                                                           \
-         return;                                                                                                                                                              \
-      }                                                                                                                                                                       \
-      if (!AssetDatabase.isDeclaredAsset(_in))                                                                                                                                \
-      {                                                                                                                                                                       \
-         StringTableEntry terMatAssetId = StringTable->EmptyString();                                                                                                          \
-         AssetQuery query;                                                                                                                                                    \
-         S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in);                                                                                                 \
-         if (foundAssetcount != 0)                                                                                                                                            \
-         {                                                                                                                                                                    \
-            terMatAssetId = query.mAssetList[0];                                                                                                                               \
-         }                                                                                                                                                                    \
-         m##name##Asset = terMatAssetId;                                                                                                                                \
-         m##name##File = _in;                                                                                                                                          \
-      }                                                                                                                                                                       \
-      else                                                                                                                                                                    \
-      {                                                                                                                                                                       \
-         m##name##Asset = _in;                                                                                                                                         \
-         m##name##File = get##name##File();                                                                                                                       \
-      }                                                                                                                                                                       \
-   };                                                                                                                                                                         \
-                                                                                                                                                                              \
-   inline StringTableEntry _get##name##AssetId() const { return m##name##Asset.getAssetId(); }                                                         \
-   TerrainMaterial* get##name() { if (m##name##Asset.notNull()) return m##name##Asset->getMaterialDefinition(); else return NULL; }                                  \
-   AssetPtr<TerrainMaterialAsset> get##name##Asset() { return m##name##Asset; }                                                                                  \
-   static bool _set##name##Data(void* obj, const char* index, const char* data) { static_cast<className*>(obj)->_set##name(_getStringTable()->insert(data)); return false;}\
-   StringTableEntry get##name##File() { return m##name##Asset.notNull() ? m##name##Asset->getScriptFile() : ""; }
-
-#define DECLARE_TERRAINMATERIALASSET_NET(className, name, mask)                                                                                                               \
-private:                                                                                                                                                                      \
-   AssetPtr<TerrainMaterialAsset> m##name##Asset;                                                                                                                                  \
-   StringTableEntry     m##name##File = {StringTable->EmptyString() };                                                                                                   \
-public:                                                                                                                                                                       \
-   void _set##name(StringTableEntry _in){                                                                                                                   \
-      if (m##name##Asset.getAssetId() == _in)                                                                                                                          \
-         return;                                                                                                                                                              \
-      if(_in == NULL || !String::compare(_in,StringTable->EmptyString()))                                                                                                       \
-      {                                                                                                                                                                       \
-         m##name##Asset = NULL;                                                                                                                                        \
-         m##name##File = "";                                                                                                                                           \
-         return;                                                                                                                                                              \
-      }                                                                                                                                                                       \
-      if (!AssetDatabase.isDeclaredAsset(_in))                                                                                                                                \
-      {                                                                                                                                                                       \
-         StringTableEntry terMatAssetId = StringTable->EmptyString();                                                                                                          \
-         AssetQuery query;                                                                                                                                                    \
-         S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in);                                                                                                 \
-         if (foundAssetcount != 0)                                                                                                                                            \
-         {                                                                                                                                                                    \
-            terMatAssetId = query.mAssetList[0];                                                                                                                               \
-         }                                                                                                                                                                    \
-         m##name##Asset = terMatAssetId;                                                                                                                                \
-         m##name##File = _in;                                                                                                                                          \
-      }                                                                                                                                                                       \
-      else                                                                                                                                                                    \
-      {                                                                                                                                                                       \
-         m##name##Asset = _in;                                                                                                                                         \
-         m##name##File = get##name##File();                                                                                                                       \
-      }                                                                                                                                                                       \
-   };                                                                                                                                                                         \
-                                                                                                                                                                              \
-   inline StringTableEntry _get##name##AssetId() const { return m##name##Asset.getAssetId(); }                                                         \
-   TerrainMaterial* get##name() { if (m##name##Asset.notNull()) return m##name##Asset->getMaterialDefinition(); else return NULL; }                                  \
-   AssetPtr<TerrainMaterialAsset> get##name##Asset() { return m##name##Asset; }                                                                                  \
-   static bool _set##name##Data(void* obj, const char* index, const char* data)\
-   {\
-       static_cast<className*>(obj)->_set##name(_getStringTable()->insert(data));\
-       static_cast<className*>(obj)->setMaskBits(mask); \
-       return false;\
-   }\
-   StringTableEntry get##name##File() { return m##name##Asset.notNull() ? m##name##Asset->getScriptFile() : ""; }
-
-#define INITPERSISTFIELD_TERRAINMATERIALASSET(name, consoleClass, docs)                                                                                       \
-   addProtectedField(assetText(name, Asset), TypeTerrainMaterialAssetPtr, Offset(m##name##Asset, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, asset docs.));\
-   addProtectedField(assetText(name, File), TypeFilename, Offset(m##name##File, consoleClass), _set##name##Data, &defaultProtectedGetFn, assetDoc(name, asset docs.), AbstractClassRep::FIELD_HideInInspectors);
-
-#define DECLARE_TERRAINMATERIALASSET_ARRAY(className, name, max)                                                                                                               \
-private:                                                                                                                                                                      \
-   AssetPtr<TerrainMaterialAsset> m##name##Asset[max];                                                                                                                                  \
-   StringTableEntry     m##name##File[max] = {StringTable->EmptyString() };                                                                                                   \
-public:                                                                                                                                                                       \
-   void _set##name(StringTableEntry _in, const U32& index){                                                                                                                   \
-      if (m##name##Asset[index].getAssetId() == _in)                                                                                                                          \
-         return;                                                                                                                                                              \
-      if(_in == NULL || !String::compare(_in,StringTable->EmptyString()))                                                                                                       \
-      {                                                                                                                                                                       \
-         m##name##Asset[index] = NULL;                                                                                                                                        \
-         m##name##File[index] = "";                                                                                                                                           \
-         return;                                                                                                                                                              \
-      }                                                                                                                                                                       \
-      if (!AssetDatabase.isDeclaredAsset(_in))                                                                                                                                \
-      {                                                                                                                                                                       \
-         StringTableEntry terMatAssetId = StringTable->EmptyString();                                                                                                          \
-         AssetQuery query;                                                                                                                                                    \
-         S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in);                                                                                                 \
-         if (foundAssetcount != 0)                                                                                                                                            \
-         {                                                                                                                                                                    \
-            terMatAssetId = query.mAssetList[0];                                                                                                                               \
-         }                                                                                                                                                                    \
-         m##name##Asset[index] = terMatAssetId;                                                                                                                                \
-         m##name##File[index] = _in;                                                                                                                                          \
-      }                                                                                                                                                                       \
-      else                                                                                                                                                                    \
-      {                                                                                                                                                                       \
-         m##name##Asset[index] = _in;                                                                                                                                         \
-         m##name##File[index] = get##name##File(index);                                                                                                                       \
-      }                                                                                                                                                                       \
-   };                                                                                                                                                                         \
-                                                                                                                                                                              \
-   inline StringTableEntry _get##name##AssetId(const U32& index) const { return m##name##Asset[index].getAssetId(); }                                                         \
-   TerrainMaterial* get##name(const U32& index) { if (m##name##Asset[index].notNull()) return m##name##Asset[index]->getMaterialDefinition(); else return NULL; }                                  \
-   AssetPtr<TerrainMaterialAsset> get##name##Asset(const U32& index) { return m##name##Asset[index]; }                                                                                  \
-   static bool _set##name##Data(void* obj, const char* index, const char* data) { static_cast<className*>(obj)->_set##name(_getStringTable()->insert(data), dAtoi(index)); return false;}\
-   StringTableEntry get##name##File(const U32& idx) { return m##name##Asset[idx].notNull() ? m##name##Asset[idx]->getScriptFile() : ""; }
-
-#define DECLARE_TERRAINMATERIALASSET_NET_ARRAY(className, name, max, mask)                                                                                                               \
-private:                                                                                                                                                                      \
-   AssetPtr<TerrainMaterialAsset> m##name##Asset[max];                                                                                                                                  \
-   StringTableEntry     m##name##File[max] = {StringTable->EmptyString() };                                                                                                   \
-public:                                                                                                                                                                       \
-   void _set##name(StringTableEntry _in, const U32& index){                                                                                                                   \
-      if (m##name##Asset[index].getAssetId() == _in)                                                                                                                          \
-         return;                                                                                                                                                              \
-      if(_in == NULL || !String::compare(_in,StringTable->EmptyString()))                                                                                                       \
-      {                                                                                                                                                                       \
-         m##name##Asset[index] = NULL;                                                                                                                                        \
-         m##name##File[index] = "";                                                                                                                                           \
-         return;                                                                                                                                                              \
-      }                                                                                                                                                                       \
-      if (!AssetDatabase.isDeclaredAsset(_in))                                                                                                                                \
-      {                                                                                                                                                                       \
-         StringTableEntry terMatAssetId = StringTable->EmptyString();                                                                                                          \
-         AssetQuery query;                                                                                                                                                    \
-         S32 foundAssetcount = AssetDatabase.findAssetLooseFile(&query, _in);                                                                                                 \
-         if (foundAssetcount != 0)                                                                                                                                            \
-         {                                                                                                                                                                    \
-            terMatAssetId = query.mAssetList[0];                                                                                                                               \
-         }                                                                                                                                                                    \
-         m##name##Asset[index] = terMatAssetId;                                                                                                                                \
-         m##name##File[index] = _in;                                                                                                                                          \
-      }                                                                                                                                                                       \
-      else                                                                                                                                                                    \
-      {                                                                                                                                                                       \
-         m##name##Asset[index] = _in;                                                                                                                                         \
-         m##name##File[index] = get##name##File(index);                                                                                                                       \
-      }                                                                                                                                                                       \
-   };                                                                                                                                                                         \
-                                                                                                                                                                              \
-   inline StringTableEntry _get##name##AssetId(const U32& index) const { return m##name##Asset[index].getAssetId(); }                                                         \
-   TerrainMaterial* get##name(const U32& index) { if (m##name##Asset[index].notNull()) return m##name##Asset[index]->getMaterialDefinition(); else return NULL; }                                  \
-   AssetPtr<TerrainMaterialAsset> get##name##Asset(const U32& index) { return m##name##Asset[index]; }                                                                                  \
-   static bool _set##name##Data(void* obj, const char* index, const char* data)\
-   {\
-       static_cast<className*>(obj)->_set##name(_getStringTable()->insert(data), dAtoi(index));\
-       static_cast<className*>(obj)->setMaskBits(mask); \
-       return false;\
-   }\
-   StringTableEntry get##name##File(const U32& idx) { return m##name##Asset[idx].notNull() ? m##name##Asset[idx]->getScriptFile() : ""; }
-
-#define INITPERSISTFIELD_TERRAINMATERIALASSET_ARRAY(name, arraySize, consoleClass, docs)                                                                                       \
-   addProtectedField(assetText(name, Asset), TypeTerrainMaterialAssetPtr, Offset(m##name##Asset, consoleClass), _set##name##Data, &defaultProtectedGetFn, arraySize, assetDoc(name, asset docs.));\
-   addProtectedField(assetText(name, File), TypeFilename, Offset(m##name##File, consoleClass), _set##name##Data, &defaultProtectedGetFn, arraySize, assetDoc(name, asset docs.), AbstractClassRep::FIELD_HideInInspectors);
-
 DefineConsoleType(TypeTerrainMaterialAssetId, String)
+
+DECLARE_STRUCT(AssetRef<TerrainMaterialAsset>)
+DefineConsoleType(TypeTerrainMaterialAssetRef, AssetRef<TerrainMaterialAsset>)
+
 #ifdef TORQUE_TOOLS
 //-----------------------------------------------------------------------------
 // TypeAssetId GuiInspectorField Class
@@ -329,6 +160,13 @@ class GuiInspectorTypeTerrainMaterialAssetId : public GuiInspectorTypeTerrainMat
 public:
 
    DECLARE_CONOBJECT(GuiInspectorTypeTerrainMaterialAssetId);
+   static void consoleInit();
+};
+class GuiInspectorTypeTerrainMaterialAssetRef : public GuiInspectorTypeTerrainMaterialAssetPtr
+{
+   typedef GuiInspectorTypeTerrainMaterialAssetPtr Parent;
+public:
+   DECLARE_CONOBJECT(GuiInspectorTypeTerrainMaterialAssetRef);
    static void consoleInit();
 };
 #endif

--- a/Engine/source/T3D/convexShape.cpp
+++ b/Engine/source/T3D/convexShape.cpp
@@ -261,9 +261,11 @@ bool ConvexShape::protectedSetSurfaceTexture(void *object, const char *index, co
 
    surfaceMaterial surface;
 
-   surface._setMaterial(StringTable->insert(data));
+   surface.mMaterialAssetRef = StringTable->insert( data );
 
    shape->mSurfaceTextures.push_back(surface);
+   
+   shape->setMaskBits(UpdateMask);
 
    return false;
 }
@@ -287,7 +289,6 @@ ConvexShape::ConvexShape()
    mSurfaceUVs.clear();
    mSurfaceTextures.clear();
 
-   INIT_ASSET(Material);
 }
 
 ConvexShape::~ConvexShape()
@@ -310,7 +311,9 @@ void ConvexShape::initPersistFields()
    docsURL;
    addGroup( "Rendering" );
 
-      INITPERSISTFIELD_MATERIALASSET(Material, ConvexShape, "Default material used to render the ConvexShape surface.");
+      ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, ConvexShape ) )
+         .network( UpdateMask )
+         .doc( "Default material asset used to render the ConvexShape surface." );
 
    endGroup( "Rendering" );
 
@@ -461,9 +464,9 @@ void ConvexShape::writeFields( Stream &stream, U32 tabStop )
       char buffer[1024];
       dMemset(buffer, 0, 1024);
 
-      dSprintf(buffer, 1024, "surfaceTexture = \"%s\";", mSurfaceTextures[i].getMaterial());
+      dSprintf( buffer, 1024, "surfaceTexture = \"%s\";", mSurfaceTextures[i].mMaterialAssetRef.getAssetId() );
 
-      stream.writeLine((const U8*)buffer);
+      stream.writeLine( (const U8*)buffer );
    }
 
    for ( U32 i = 0; i < count; i++ )
@@ -541,9 +544,9 @@ const char* ConvexShape::getSpecialFieldOut(StringTableEntry fieldName, const U3
       char buffer[1024];
       dMemset(buffer, 0, 1024);
 
-      dSprintf(buffer, 1024, "surfaceTexture = \"%s\";", mSurfaceTextures[index].getMaterial());
+      dSprintf( buffer, 1024, "surfaceTexture = \"%s\";", mSurfaceTextures[index].mMaterialAssetRef.getAssetId() );
 
-      return StringTable->insert(buffer);
+      return StringTable->insert( buffer );
    }
 
    return NULL;
@@ -577,7 +580,7 @@ U32 ConvexShape::packUpdate( NetConnection *conn, U32 mask, BitStream *stream )
 
    if ( stream->writeFlag( mask & UpdateMask ) )
    {
-      PACK_ASSET(conn, Material);
+      AssetDatabase.packDataAsset( stream, mMaterialAssetRef.getAssetId() );
       
       U32 surfCount = mSurfaces.size();
       stream->writeInt( surfCount, 32 );
@@ -604,14 +607,8 @@ U32 ConvexShape::packUpdate( NetConnection *conn, U32 mask, BitStream *stream )
 	  stream->writeInt( surfaceTex, 32 );
 	  //next check for any texture coord or scale mods
 	  for(U32 i=0; i < surfaceTex; i++)
-     {
-         if (stream->writeFlag(mSurfaceTextures[i].mMaterialAsset.notNull()))
-         {
-            NetStringHandle assetIdStr = mSurfaceTextures[i].mMaterialAsset.getAssetId();
-            conn->packNetStringHandleU(stream, assetIdStr);
-         }
-         else
-            stream->writeString(mSurfaceTextures[i].mMaterialName);
+      {
+		AssetDatabase.packDataAsset( stream, mSurfaceTextures[i].mMaterialAssetRef.getAssetId() );
 	  }
    }
 
@@ -633,7 +630,7 @@ void ConvexShape::unpackUpdate( NetConnection *conn, BitStream *stream )
 
    if ( stream->readFlag() ) // UpdateMask
    {
-      UNPACK_ASSET(conn, Material);
+      mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
 
       mSurfaces.clear();
       mSurfaceUVs.clear();
@@ -673,13 +670,7 @@ void ConvexShape::unpackUpdate( NetConnection *conn, BitStream *stream )
      {
         mSurfaceTextures.increment();
 
-        if (stream->readFlag())
-        {
-           mSurfaceTextures[i].mMaterialAssetId = StringTable->insert(conn->unpackNetStringHandleU(stream).getString());
-           mSurfaceTextures[i]._setMaterial(mSurfaceTextures[i].mMaterialAssetId);
-         }
-         else
-           mSurfaceTextures[i].mMaterialName = stream->readSTString();
+        mSurfaceTextures[i].mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
 	  }
 
      if (isProperlyAdded())
@@ -1255,43 +1246,49 @@ void ConvexShape::_updateMaterial()
    //update our custom surface materials
    for (U32 i = 0; i<mSurfaceTextures.size(); i++)
    {
-      mSurfaceTextures[i]._setMaterial(mSurfaceTextures[i].getMaterial());
-      //If we already have the material inst and it hasn't changed, skip
-      if (mSurfaceTextures[i].materialInst &&
-         mSurfaceTextures[i].getMaterialAsset()->getMaterialDefinitionName() == mSurfaceTextures[i].materialInst->getMaterial()->getName() &&
-         mSurfaceTextures[i].materialInst->getVertexFormat() == getGFXVertexFormat<VertexType>())
+      if ( !mSurfaceTextures[i].mMaterialAssetRef.notNull() )
          continue;
 
-      SAFE_DELETE(mSurfaceTextures[i].materialInst);
+      Material* surfMat = mSurfaceTextures[i].mMaterialAssetRef.assetPtr->getMaterial();
 
-      Material* material = mSurfaceTextures[i].getMaterialResource();
-
-      if (material == NULL)
+	  //If we already have the material inst and it hasn't changed, skip
+      if ( mSurfaceTextures[i].materialInst &&
+           surfMat &&
+           surfMat->getName() == mSurfaceTextures[i].materialInst->getMaterial()->getName() &&
+           mSurfaceTextures[i].materialInst->getVertexFormat() == getGFXVertexFormat<VertexType>() )
          continue;
 
-      mSurfaceTextures[i].materialInst = material->createMatInstance();
+      SAFE_DELETE( mSurfaceTextures[i].materialInst );
+
+      if ( surfMat == NULL )
+         continue;
+
+      mSurfaceTextures[i].materialInst = surfMat->createMatInstance();
 
       FeatureSet features = MATMGR->getDefaultFeatures();
+      mSurfaceTextures[i].materialInst->init( features, getGFXVertexFormat<VertexType>() );
 
-      mSurfaceTextures[i].materialInst->init(features, getGFXVertexFormat<VertexType>());
-
-      if (!mSurfaceTextures[i].materialInst->isValid())
-      {
-         SAFE_DELETE(mSurfaceTextures[i].materialInst);
-      }
+      if ( !mSurfaceTextures[i].materialInst->isValid() )
+         SAFE_DELETE( mSurfaceTextures[i].materialInst );
    }
 
-   _setMaterial(getMaterial());
+   if ( !mMaterialAssetRef.notNull() )
+   {
+      SAFE_DELETE( mMaterialInst );
+      return;
+   }
+
+   Material* material = mMaterialAssetRef.assetPtr->getMaterial();
+   
    // If the material name matches then don't bother updating it.
-   if (mMaterialInst && getMaterialAsset()->getMaterialDefinitionName() == mMaterialInst->getMaterial()->getName() &&
-      mMaterialInst->getVertexFormat() == getGFXVertexFormat<VertexType>())
+   if ( mMaterialInst && material &&
+        material->getName() == mMaterialInst->getMaterial()->getName() &&
+        mMaterialInst->getVertexFormat() == getGFXVertexFormat<VertexType>() )
       return;
 
    SAFE_DELETE( mMaterialInst );
 
-   Material* material = getMaterialResource();
-
-   if (material == NULL)
+   if ( material == NULL )
       return;
 
    mMaterialInst = material->createMatInstance();
@@ -2112,4 +2109,16 @@ void ConvexShape::Geometry::generate(const Vector< PlaneF > &planes, const Vecto
    }
 }
 
-DEF_ASSET_BINDS(ConvexShape, Material);
+DefineEngineMethod( ConvexShape, getMaterial, String, (), , "Returns the primary material asset id." )
+{
+   return object->getMaterial();
+}
+DefineEngineMethod( ConvexShape, getMaterialAsset, String, (), , "Returns the primary material asset id." )
+{
+   return object->getMaterial();
+}
+DefineEngineMethod( ConvexShape, setMaterial, bool, ( const char* assetName ), , "Sets the primary material asset id." )
+{
+   object->setMaterial( StringTable->insert( assetName ) );
+   return true;
+}

--- a/Engine/source/T3D/convexShape.h
+++ b/Engine/source/T3D/convexShape.h
@@ -137,19 +137,15 @@ public:
    struct surfaceMaterial
    {
       // The name of the Material we will use for rendering
-      DECLARE_MATERIALASSET(surfaceMaterial, Material);
-
-      DECLARE_ASSET_SETGET(surfaceMaterial, Material);
+      AssetRef<MaterialAsset> mMaterialAssetRef;
 
       // The actual Material instance
       BaseMatInstance* materialInst;
 
-      surfaceMaterial()
-      {
-         INIT_ASSET(Material);
+      surfaceMaterial() : materialInst( NULL ) {}
 
-         materialInst = NULL;
-      }
+      StringTableEntry getMaterial() const { return mMaterialAssetRef.getAssetId(); }
+      void setMaterial( const char* assetId ) { mMaterialAssetRef = StringTable->insert( assetId ); }
    };
 
    struct surfaceUV
@@ -248,7 +244,9 @@ public:
 
    /// @}
 
-   String getMaterialName() { return mMaterialName; }
+   StringTableEntry getMaterial() const { return mMaterialAssetRef.getAssetId(); }
+   String getMaterialName() const { return String( mMaterialAssetRef.getAssetId() ); }
+   void setMaterial( StringTableEntry assetId ) { mMaterialAssetRef = assetId; }
 
 protected:
 
@@ -268,8 +266,7 @@ protected:
 
 protected:
 
-   DECLARE_MATERIALASSET(ConvexShape, Material);
-   DECLARE_ASSET_SETGET(ConvexShape, Material);
+   AssetRef<MaterialAsset> mMaterialAssetRef;
 
    // The actual Material instance
    BaseMatInstance* mMaterialInst;

--- a/Engine/source/T3D/decal/decalData.cpp
+++ b/Engine/source/T3D/decal/decalData.cpp
@@ -76,7 +76,6 @@ ConsoleDocClass( DecalData,
 DecalData::DecalData()
 {
    size = 5;
-   INIT_ASSET(Material);
 
    lifeSpan = 5000;
    fadeTime = 1000;
@@ -144,7 +143,7 @@ void DecalData::initPersistFields()
       addFieldV( "size", TypeRangedF32, Offset( size, DecalData ), &CommonValidators::PositiveFloat,
          "Width and height of the decal in meters before scale is applied." );
 
-      INITPERSISTFIELD_MATERIALASSET(Material, DecalData, "Material to use for this decal.");
+      ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, DecalData ) ).doc( "Material asset to use for this decal." );
 
       addFieldV( "lifeSpan", TypeRangedS32, Offset( lifeSpan, DecalData ), &CommonValidators::PositiveInt,
          "Time (in milliseconds) before this decal will be automatically deleted." );
@@ -223,9 +222,9 @@ void DecalData::onStaticModified( const char *slotName, const char *newValue )
       return;
 
    // To allow changing materials live.
-   if ( dStricmp( slotName, "material" ) == 0 )
+   if ( dStricmp( slotName, "materialAsset" ) == 0 )
    {
-      _setMaterial(newValue);
+      mMaterialAssetRef = StringTable->insert( newValue );
       _updateMaterial();
    }
    // To allow changing name live.
@@ -259,7 +258,7 @@ void DecalData::packData( BitStream *stream )
    stream->write( lookupName );
    stream->write( size );
 
-   PACKDATA_ASSET(Material);
+   AssetDatabase.packDataAsset( stream, mMaterialAssetRef.getAssetId() );
 
    stream->write( lifeSpan );
    stream->write( fadeTime );
@@ -288,8 +287,8 @@ void DecalData::unpackData( BitStream *stream )
    assignName(lookupName);
    stream->read( &size );
 
-   UNPACKDATA_ASSET(Material);
-   
+   mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
+
    _updateMaterial();
    stream->read( &lifeSpan );
    stream->read( &fadeTime );
@@ -314,11 +313,9 @@ void DecalData::_initMaterial()
 {
    SAFE_DELETE( matInst );
 
-   _setMaterial(getMaterial());
-
-   if (mMaterialAsset.notNull() && mMaterialAsset->getStatus() == MaterialAsset::Ok)
+   if ( mMaterialAssetRef.notNull() && mMaterialAssetRef.assetPtr->getStatus() == MaterialAsset::Ok )
    {
-      matInst = getMaterialResource()->createMatInstance();
+      matInst = mMaterialAssetRef.assetPtr->getMaterial()->createMatInstance();
    }
    else
       matInst = MATMGR->createMatInstance( "WarningMaterial" );
@@ -329,42 +326,42 @@ void DecalData::_initMaterial()
    matInst->addStateBlockDesc( desc );
 
    matInst->init( MATMGR->getDefaultFeatures(), getGFXVertexFormat<DecalVertex>() );
-   if( !matInst->isValid() )
+   if ( !matInst->isValid() )
    {
-      Con::errorf( "DecalData::_initMaterial - failed to create material instance for '%s'", mMaterialAssetId );
+      Con::errorf( "DecalData::_initMaterial - failed to create material instance for '%s'", mMaterialAssetRef.getAssetId() );
       SAFE_DELETE( matInst );
       matInst = MATMGR->createMatInstance( "WarningMaterial" );
-      matInst->init( MATMGR->getDefaultFeatures(), getGFXVertexFormat< DecalVertex >() );
+      matInst->init( MATMGR->getDefaultFeatures(), getGFXVertexFormat<DecalVertex>() );
    }
 }
 
 void DecalData::_updateMaterial()
 {
-   U32 assetStatus = MaterialAsset::getAssetErrCode(mMaterialAsset);
-   if (assetStatus != AssetBase::Ok && assetStatus != AssetBase::UsingFallback)
-   {
+   U32 assetStatus = MaterialAsset::getAssetErrCode( mMaterialAssetRef.assetPtr );
+   if ( assetStatus != AssetBase::Ok && assetStatus != AssetBase::UsingFallback )
       return;
-   }
+
    // Only update material instance if we have one allocated.
    if ( matInst )
       _initMaterial();
 }
 
-Material* DecalData::getMaterialDefinition()
+Material* DecalData::getMaterial()
 {
-   if ( !getMaterialResource() )
+   if ( !mMaterialAssetRef.notNull() )
    {
       _updateMaterial();
-      if ( !mMaterial )
-         mMaterial = static_cast<Material*>( Sim::findObject("WarningMaterial") );
+      if ( !mMaterialAssetRef.notNull() )
+         return static_cast<Material*>( Sim::findObject( "WarningMaterial" ) );
    }
 
-   return mMaterial;
+   return mMaterialAssetRef.assetPtr->getMaterial();
 }
 
 BaseMatInstance* DecalData::getMaterialInstance()
 {
-   if ( !mMaterial || !matInst || matInst->getMaterial() != mMaterial)
+   Material* matDef = mMaterialAssetRef.notNull() ? mMaterialAssetRef.assetPtr->getMaterial() : nullptr;
+   if ( !matDef || !matInst || matInst->getMaterial() != matDef )
       _initMaterial();
 
    return matInst;

--- a/Engine/source/T3D/decal/decalData.h
+++ b/Engine/source/T3D/decal/decalData.h
@@ -77,9 +77,8 @@ class DecalData : public SimDataBlock
       F32 fadeStartPixelSize;
       F32 fadeEndPixelSize;
 
-      DECLARE_MATERIALASSET(DecalData, Material);
-      DECLARE_ASSET_SETGET(DecalData, Material);
-      
+      AssetRef<MaterialAsset> mMaterialAssetRef;
+
       /// Material instance for decal.
       BaseMatInstance *matInst;
 
@@ -112,7 +111,7 @@ class DecalData : public SimDataBlock
       void packData( BitStream* ) override;
       void unpackData( BitStream* ) override;      
       
-      Material* getMaterialDefinition();
+      Material* getMaterial();
       BaseMatInstance* getMaterialInstance();
 
       static SimSet* getSet();

--- a/Engine/source/T3D/decal/decalDataFile.cpp
+++ b/Engine/source/T3D/decal/decalDataFile.cpp
@@ -206,9 +206,7 @@ bool DecalDataFile::read( Stream &stream )
 				data->lookupName = name;
 				data->registerObject(name);
 				Sim::getRootGroup()->addObject( data );
-				data->mMaterialName = "WarningMaterial";
-				data->mMaterial = dynamic_cast<Material*>(Sim::findObject("WarningMaterial"));
-			
+				
 				Con::errorf( "DecalDataFile::read() - DecalData %s does not exist! Temporarily created %s_missing.", lookupName.c_str(), lookupName.c_str());
 			}
       }

--- a/Engine/source/T3D/decal/decalManager.cpp
+++ b/Engine/source/T3D/decal/decalManager.cpp
@@ -186,7 +186,7 @@ S32 QSORT_CALLBACK cmpDecalRenderOrder( const void *p1, const void *p2 )
 
       if ( (*pd2)->mFlags & SaveDecal )
       {
-         S32 id = ( (*pd1)->mDataBlock->getMaterialDefinition()->getId() - (*pd2)->mDataBlock->getMaterialDefinition()->getId() );
+         S32 id = ( (*pd1)->mDataBlock->getMaterial()->getId() - (*pd2)->mDataBlock->getMaterial()->getId() );
          if ( id != 0 )
             return id;
 
@@ -1181,7 +1181,7 @@ void DecalManager::prepRenderImage( SceneRenderState* state )
    {
       DecalInstance *decal = mDecalQueue[i];      
       DecalData *data = decal->mDataBlock;
-      Material *mat = data->getMaterialDefinition();
+      Material *mat = data->getMaterial();
 
       if ( currentBatch == NULL )
       {

--- a/Engine/source/T3D/examples/renderMeshExample.cpp
+++ b/Engine/source/T3D/examples/renderMeshExample.cpp
@@ -59,7 +59,6 @@ RenderMeshExample::RenderMeshExample()
    // Set it as a "static" object that casts shadows
    mTypeMask |= StaticObjectType | StaticShapeObjectType;
 
-   INIT_ASSET(Material);
    mMaterialInst = NULL;
 }
 
@@ -76,7 +75,9 @@ void RenderMeshExample::initPersistFields()
 {
    docsURL;
    addGroup( "Rendering" );
-   INITPERSISTFIELD_MATERIALASSET(Material, RenderMeshExample, "The material used to render the mesh.");
+   ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, RenderMeshExample ) )
+      .network(UpdateMask)
+      .doc( "Material asset used to render the mesh." );
    endGroup( "Rendering" );
 
    // SceneObject already handles exposing the transform
@@ -145,7 +146,7 @@ U32 RenderMeshExample::packUpdate( NetConnection *conn, U32 mask, BitStream *str
    // Write out any of the updated editable properties
    if (stream->writeFlag(mask & UpdateMask))
    {
-      PACK_ASSET(conn, Material);
+      AssetDatabase.packDataAsset( stream, mMaterialAssetRef.getAssetId() );
    }
 
    return retMask;
@@ -166,7 +167,7 @@ void RenderMeshExample::unpackUpdate(NetConnection *conn, BitStream *stream)
 
    if ( stream->readFlag() )  // UpdateMask
    {
-      UNPACK_ASSET(conn, Material);
+      mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
 
       if ( isProperlyAdded() )
          updateMaterial();
@@ -248,17 +249,17 @@ void RenderMeshExample::createGeometry()
 
 void RenderMeshExample::updateMaterial()
 {
-   if (mMaterialAsset.notNull())
+   if (mMaterialAssetRef.notNull())
    {
-      if (mMaterialInst && String(mMaterialAsset->getMaterialDefinitionName()).equal(mMaterialInst->getMaterial()->getName(), String::NoCase))
+      if (mMaterialInst && String(mMaterialAssetRef.assetPtr->getMaterialName()).equal(mMaterialInst->getMaterial()->getName(), String::NoCase))
          return;
 
       SAFE_DELETE(mMaterialInst);
 
-      mMaterialInst = MATMGR->createMatInstance(mMaterialAsset->getMaterialDefinitionName(), getGFXVertexFormat< VertexType >());
+      mMaterialInst = MATMGR->createMatInstance(mMaterialAssetRef.assetPtr->getMaterialName(), getGFXVertexFormat< VertexType >());
 
       if (!mMaterialInst)
-         Con::errorf("RenderMeshExample::updateMaterial - no Material called '%s'", mMaterialAsset->getMaterialDefinitionName());
+         Con::errorf("RenderMeshExample::updateMaterial - no Material called '%s'", mMaterialAssetRef.assetPtr->getMaterialName());
    }
 }
 

--- a/Engine/source/T3D/examples/renderMeshExample.h
+++ b/Engine/source/T3D/examples/renderMeshExample.h
@@ -73,8 +73,7 @@ class RenderMeshExample : public SceneObject
    //--------------------------------------------------------------------------
    BaseMatInstance* mMaterialInst;
 
-   DECLARE_MATERIALASSET(RenderMeshExample, Material);
-   DECLARE_ASSET_NET_SETGET(RenderMeshExample, Material, UpdateMask);
+   AssetRef<MaterialAsset> mMaterialAssetRef;
 
    // The GFX vertex and primitive buffers
    GFXVertexBufferHandle< VertexType > mVertexBuffer;

--- a/Engine/source/T3D/fx/groundCover.cpp
+++ b/Engine/source/T3D/fx/groundCover.cpp
@@ -460,7 +460,6 @@ GroundCover::GroundCover()
 
    mRandomSeed = 1;
 
-   INIT_ASSET(Material);
    mMaterialInst = NULL;
 
    mMatParams = NULL;
@@ -510,8 +509,6 @@ GroundCover::GroundCover()
       mMinElevation[i] = -99999.0f;
       mMaxElevation[i] = 99999.0f;
 
-      mLayerAsset[i] = NULL;
-      mLayerFile[i] = StringTable->EmptyString();
 
       mInvertLayer[i] = NULL;
 
@@ -545,7 +542,9 @@ void GroundCover::initPersistFields()
    docsURL;
    addGroup( "GroundCover General" );
 
-      INITPERSISTFIELD_MATERIALASSET(Material, GroundCover, "Material used by all GroundCover segments.");
+      ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, GroundCover ) )
+         .network( InitialUpdateMask )
+         .doc( "Material asset used by all GroundCover segments." );
 
       addFieldV( "radius", TypeRangedF32,          Offset( mRadius, GroundCover ), &CommonValidators::PositiveFloat,              "Outer generation radius from the current camera position." );
       addFieldV( "dissolveRadius", TypeRangedF32,          Offset( mFadeRadius, GroundCover ), &CommonValidators::PositiveFloat,          "This is less than or equal to radius and defines when fading of cover elements begins." );
@@ -570,10 +569,10 @@ void GroundCover::initPersistFields()
             .doc("The cover shape. [Optional]")
             .network(-1);
 
-         INITPERSISTFIELD_TERRAINMATERIALASSET_ARRAY(Layer, MAX_COVERTYPES, GroundCover, "Terrain material assetId to limit coverage to, or blank to not limit.");
-
-         //Legacy field
-         addProtectedField("layer", TypeTerrainMaterialAssetPtr, Offset(mLayerAsset, GroundCover), &_setLayerData, &defaultProtectedGetFn, MAX_COVERTYPES, "Terrain material assetId to limit coverage to, or blank to not limit.", AbstractClassRep::FIELD_HideInInspectors); 
+         ADD_FIELD( "layerAsset", TypeTerrainMaterialAssetRef, Offset( mLayerAssetRef, GroundCover ) )
+            .elements( MAX_COVERTYPES )
+            .network( InitialUpdateMask )
+            .doc( "Terrain material asset to limit coverage to, or blank to not limit." );
 
          addField( "invertLayer",   TypeBool,      Offset( mInvertLayer, GroundCover ), MAX_COVERTYPES,     "Indicates that the terrain material index given in 'layer' is an exclusion mask." );
 
@@ -722,7 +721,7 @@ U32 GroundCover::packUpdate( NetConnection *connection, U32 mask, BitStream *str
       // TODO: We could probably optimize a few of these
       // based on reasonable units at some point.
 
-      PACK_ASSET(connection, Material);
+      AssetDatabase.packDataAsset( stream, mMaterialAssetRef.getAssetId() );
 
       stream->write( mRadius );
       stream->write( mZOffset );
@@ -777,7 +776,8 @@ U32 GroundCover::packUpdate( NetConnection *connection, U32 mask, BitStream *str
          AssetDatabase.packUpdateAsset(connection, mask, stream, mShapeAssetRef[i].assetId);
       }
 
-      PACK_ASSET_ARRAY_REFACTOR(connection, Layer, MAX_COVERTYPES)
+      for ( U32 i = 0; i < MAX_COVERTYPES; i++ )
+         AssetDatabase.packUpdateAsset( connection, mask, stream, mLayerAssetRef[i].getAssetId() );
 
       stream->writeFlag( mDebugRenderCells );
       stream->writeFlag( mDebugNoBillboards );
@@ -794,7 +794,7 @@ void GroundCover::unpackUpdate( NetConnection *connection, BitStream *stream )
 
    if (stream->readFlag())
    {
-      UNPACK_ASSET(connection, Material);
+      mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
 
       stream->read( &mRadius );
       stream->read( &mZOffset );
@@ -849,7 +849,8 @@ void GroundCover::unpackUpdate( NetConnection *connection, BitStream *stream )
          mShapeAssetRef[i] = AssetDatabase.unpackUpdateAsset(connection, stream);
       }
 
-      UNPACK_ASSET_ARRAY_REFACTOR(connection, Layer, MAX_COVERTYPES)
+      for ( U32 i = 0; i < MAX_COVERTYPES; i++ )
+         mLayerAssetRef[i] = AssetDatabase.unpackUpdateAsset( connection, stream );
 
       mDebugRenderCells    = stream->readFlag();
       mDebugNoBillboards   = stream->readFlag();
@@ -873,8 +874,8 @@ void GroundCover::_initMaterial()
 {
    SAFE_DELETE(mMaterialInst);
 
-   if (mMaterialAsset.notNull() && mMaterialAsset->getStatus() == MaterialAsset::Ok)
-      mMaterialInst = mMaterial->createMatInstance();
+   if (mMaterialAssetRef.notNull() && mMaterialAssetRef.assetPtr->getStatus() == MaterialAsset::Ok)
+      mMaterialInst = mMaterialAssetRef.assetPtr->getMaterial()->createMatInstance();
    else
       mMaterialInst = MATMGR->createMatInstance("WarningMaterial");
    
@@ -1195,9 +1196,7 @@ GroundCoverCell* GroundCover::_generateCell( const Point2I& index,
       const Box3F typeShapeBounds = typeIsShape ? mShapeInstances[ type ]->getShape()->mBounds : Box3F();
       const F32 typeWindScale = mWindScale[type];
 
-      StringTableEntry typeLayer = StringTable->EmptyString();
-      if (mLayerAsset[type].notNull())
-         typeLayer = mLayerAsset[type]->getAssetId();
+      StringTableEntry typeLayer = mLayerAssetRef[type].getAssetId();
       const bool typeInvertLayer = mInvertLayer[type];
 
       // We can set this once here... all the placements for this are the same.

--- a/Engine/source/T3D/fx/groundCover.h
+++ b/Engine/source/T3D/fx/groundCover.h
@@ -273,8 +273,7 @@ protected:
 
    BaseMatInstance* mMaterialInst;
 
-   DECLARE_MATERIALASSET(GroundCover, Material);
-   DECLARE_ASSET_NET_SETGET(GroundCover, Material, InitialUpdateMask);
+   AssetRef<MaterialAsset> mMaterialAssetRef;
 
    GroundCoverShaderConstData mShaderConstData;
 
@@ -319,7 +318,8 @@ protected:
 
    /// Terrain material assetId to limit coverage to, or
    /// left empty to cover entire terrain.
-   DECLARE_TERRAINMATERIALASSET_NET_ARRAY(GroundCover, Layer, MAX_COVERTYPES, -1)
+   AssetRef<TerrainMaterialAsset> mLayerAssetRef[MAX_COVERTYPES];
+   StringTableEntry getLayerAssetId( U32 index ) const { return mLayerAssetRef[index].getAssetId(); }
    
    /// Inverts the data layer test making the 
    /// layer an exclusion mask.

--- a/Engine/source/T3D/groundPlane.cpp
+++ b/Engine/source/T3D/groundPlane.cpp
@@ -75,7 +75,6 @@ GroundPlane::GroundPlane()
    : mSquareSize( 128.0f ),
      mScaleU( 1.0f ),
      mScaleV( 1.0f ),
-     mMaterial( NULL ),
      mMaterialInst(NULL),
      mPhysicsRep( NULL ),
      mMin( 0.0f, 0.0f ),
@@ -87,13 +86,10 @@ GroundPlane::GroundPlane()
    mConvexList = new Convex;
    mTypeMask |= TerrainLikeObjectType;
 
-   INIT_ASSET(Material);
 }
 
 GroundPlane::~GroundPlane()
 {
-   mMaterial = NULL;
-
    if(mMaterialInst)
       SAFE_DELETE(mMaterialInst);
 
@@ -110,7 +106,9 @@ void GroundPlane::initPersistFields()
       addFieldV( "scaleU", TypeRangedF32,          Offset( mScaleU, GroundPlane ), &CommonValidators::PositiveFloat, "Scale of texture repeat in the U direction." );
       addFieldV( "scaleV", TypeRangedF32,          Offset( mScaleV, GroundPlane ), &CommonValidators::PositiveFloat, "Scale of texture repeat in the V direction." );
 
-      INITPERSISTFIELD_MATERIALASSET(Material, GroundPlane, "The material used to render the ground plane.");
+      ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, GroundPlane ) )
+         .network(-1)
+         .doc( "Material asset used to render the ground plane." );
 
    endGroup( "Plane" );
    
@@ -157,9 +155,9 @@ bool GroundPlane::onAdd()
 
 void GroundPlane::onRemove()
 {
-   U32 assetStatus = MaterialAsset::getAssetErrCode(mMaterialAsset);
+   U32 assetStatus = MaterialAsset::getAssetErrCode(mMaterialAssetRef.assetPtr);
    if (assetStatus == AssetBase::Ok)
-      AssetDatabase.releaseAsset(mMaterialAsset.getAssetId());
+      AssetDatabase.releaseAsset(mMaterialAssetRef.getAssetId());
 
    //SAFE_DELETE(mMaterialInst);
 
@@ -201,7 +199,7 @@ U32 GroundPlane::packUpdate( NetConnection* connection, U32 mask, BitStream* str
    stream->write( mScaleU );
    stream->write( mScaleV );
 
-   PACK_ASSET(connection, Material);
+   AssetDatabase.packDataAsset( stream, mMaterialAssetRef.getAssetId() );
 
    return retMask;
 }
@@ -214,7 +212,7 @@ void GroundPlane::unpackUpdate( NetConnection* connection, BitStream* stream )
    stream->read( &mScaleU );
    stream->read( &mScaleV );
 
-   UNPACK_ASSET(connection, Material);
+   mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
 
    // If we're added then something possibly changed in 
    // the editor... do an update of the material and the
@@ -228,17 +226,17 @@ void GroundPlane::unpackUpdate( NetConnection* connection, BitStream* stream )
 
 void GroundPlane::_updateMaterial()
 {
-   if (mMaterialAsset.notNull())
+   if (mMaterialAssetRef.notNull())
    {
-      if (mMaterialInst && String(mMaterialAsset->getMaterialDefinitionName()).equal(mMaterialInst->getMaterial()->getName(), String::NoCase))
+      if (mMaterialInst && String(mMaterialAssetRef.assetPtr->getMaterialName()).equal(mMaterialInst->getMaterial()->getName(), String::NoCase))
          return;
 
       SAFE_DELETE(mMaterialInst);
 
-      mMaterialInst = MATMGR->createMatInstance(mMaterialAsset->getMaterialDefinitionName(), getGFXVertexFormat< VertexType >());
+      mMaterialInst = MATMGR->createMatInstance(mMaterialAssetRef.assetPtr->getMaterialName(), getGFXVertexFormat< VertexType >());
 
       if (!mMaterialInst)
-         Con::errorf("GroundPlane::_updateMaterial - no Material called '%s'", mMaterialAsset->getMaterialDefinitionName());
+         Con::errorf("GroundPlane::_updateMaterial - no Material called '%s'", mMaterialAssetRef.assetPtr->getMaterialName());
    }
 }
 
@@ -356,7 +354,7 @@ void GroundPlane::prepRenderImage( SceneRenderState* state )
    // TODO: Should we skip rendering the ground plane into
    // the shadows?  Its not like you can ever get under it.
 
-   if ( !mMaterial )
+   if (mMaterialAssetRef.isNull())
       return;
 
    // If we don't have a material instance after the override then 
@@ -592,10 +590,10 @@ void GroundPlane::generateGrid( U32 width, U32 height, F32 squareSize,
 
 void GroundPlane::getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList)
 {
-   U32 assetStatus = MaterialAsset::getAssetErrCode(mMaterialAsset);
+   U32 assetStatus = MaterialAsset::getAssetErrCode(mMaterialAssetRef.assetPtr);
    if (assetStatus == AssetBase::Ok)
    {
-      usedAssetsList->push_back_unique(mMaterialAsset->getAssetId());
+      usedAssetsList->push_back_unique(mMaterialAssetRef.getAssetId());
    }
 
 }

--- a/Engine/source/T3D/groundPlane.h
+++ b/Engine/source/T3D/groundPlane.h
@@ -108,8 +108,7 @@ private:
 
    BaseMatInstance* mMaterialInst;
 
-   DECLARE_MATERIALASSET(GroundPlane, Material);
-   DECLARE_ASSET_NET_SETGET(GroundPlane, Material, -1);
+   AssetRef<MaterialAsset> mMaterialAssetRef;
 
    PhysicsBody *mPhysicsRep;
 

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -679,7 +679,7 @@ void TSStatic::_updateShouldTick()
 
 void TSStatic::prepRenderImage(SceneRenderState* state)
 {
-   if (!mShapeAssetRef.isValid() || !mShapeInstance)
+   if (!mShapeInstance)
       return;
 
    Point3F cameraOffset;
@@ -1582,7 +1582,7 @@ void TSStatic::updateMaterials()
          if (mChangingMaterials[m].slot == i)
          {
             //Fetch the actual material asset
-            pMatList->renameMaterial(i, mChangingMaterials[m].matAsset->getMaterialDefinitionName());
+            pMatList->renameMaterial(i, mChangingMaterials[m].matAsset->getMaterialName());
             found = true;
             break;
          }

--- a/Engine/source/environment/decalRoad.cpp
+++ b/Engine/source/environment/decalRoad.cpp
@@ -288,8 +288,6 @@ DecalRoad::DecalRoad()
    mTypeMask |= StaticObjectType | StaticShapeObjectType;
    mNetFlags.set(Ghostable);
 
-   INIT_ASSET(Material);
-
    mMaterialInst = NULL;
 }
 
@@ -307,7 +305,9 @@ void DecalRoad::initPersistFields()
    docsURL;
    addGroup( "DecalRoad" );
 
-      INITPERSISTFIELD_MATERIALASSET(Material, DecalRoad, "Material used for rendering.");
+      ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, DecalRoad ) )
+         .network( DecalRoadMask )
+         .doc( "Material asset used for rendering." );
 
       addProtectedFieldV("textureLength", TypeRangedF32, Offset(mTextureLength, DecalRoad), &DecalRoad::ptSetTextureLength, &defaultProtectedGetFn, &drTextureLengthV,
          "The length in meters of textures mapped to the DecalRoad" );      
@@ -522,8 +522,7 @@ U32 DecalRoad::packUpdate(NetConnection * con, U32 mask, BitStream * stream)
 
    if ( stream->writeFlag( mask & DecalRoadMask ) )
    {
-      // Write Texture Name.
-      PACK_ASSET(con, Material);
+      AssetDatabase.packDataAsset( stream, mMaterialAssetRef.getAssetId() );
 
       stream->write( mBreakAngle );      
 
@@ -612,7 +611,7 @@ void DecalRoad::unpackUpdate( NetConnection *con, BitStream *stream )
    // DecalRoadMask
    if ( stream->readFlag() )
    {
-      UNPACK_ASSET(con, Material);
+      mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
 
       if (isProperlyAdded())
          _initMaterial();
@@ -1078,29 +1077,21 @@ bool DecalRoad::addNodeFromField( void *object, const char *index, const char *d
 
 void DecalRoad::_initMaterial()
 {
-   _setMaterial(getMaterial());
-
-   if (mMaterialAsset.notNull())
+   if (mMaterialAssetRef.notNull())
    {
-      if (mMaterialInst && String(mMaterialAsset->getMaterialDefinitionName()).equal(mMaterialInst->getMaterial()->getName(), String::NoCase))
+      if (mMaterialInst && String(mMaterialAssetRef.assetPtr->getMaterialName()).equal(mMaterialInst->getMaterial()->getName(), String::NoCase))
          return;
 
       SAFE_DELETE(mMaterialInst);
 
-      Material* tMat = NULL;
-
-      if (!Sim::findObject(mMaterialAsset->getMaterialDefinitionName(), tMat))
-         Con::errorf("DecalRoad::_initMaterial - Material %s was not found.", mMaterialAsset->getMaterialDefinitionName());
-
-      mMaterial = tMat;
-
-      if (mMaterial)
-         mMaterialInst = mMaterial->createMatInstance();
+      Material* tMat = mMaterialAssetRef.assetPtr->getMaterial();
+      if (tMat)
+         mMaterialInst = tMat->createMatInstance();
       else
          mMaterialInst = MATMGR->createMatInstance("WarningMaterial");
 
       if (!mMaterialInst)
-         Con::errorf("DecalRoad::_initMaterial - no Material called '%s'", mMaterialAsset->getMaterialDefinitionName());
+         Con::errorf("DecalRoad::_initMaterial - no Material called '%s'", mMaterialAssetRef.assetPtr->getMaterialName());
    }
 
    if (!mMaterialInst)

--- a/Engine/source/environment/decalRoad.h
+++ b/Engine/source/environment/decalRoad.h
@@ -246,8 +246,8 @@ protected:
 
    BaseMatInstance* mMaterialInst;
 
-   DECLARE_MATERIALASSET(DecalRoad, Material);
-   DECLARE_ASSET_NET_SETGET(DecalRoad, Material, DecalRoadMask);
+   AssetRef<MaterialAsset> mMaterialAssetRef;
+   StringTableEntry getMaterialAssetId() const { return mMaterialAssetRef.getAssetId(); }
 
    S16 mRenderPriority;
 

--- a/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiMeshRoadEditorCtrl.cpp
@@ -97,13 +97,9 @@ GuiMeshRoadEditorCtrl::GuiMeshRoadEditorCtrl()
     mHoverNodeColor( 255,255,255,255 ),
 	 mHasCopied( false )
 {
-   INIT_ASSET(TopMaterial);
-   INIT_ASSET(BottomMaterial);
-   INIT_ASSET(SideMaterial);
-
-   mTopMaterialAssetId = Con::getVariable("$MeshRoadEditor::defaultTopMaterialAsset");
-   mBottomMaterialAssetId = Con::getVariable("$MeshRoadEditor::defaultBottomMaterialAsset");
-   mSideMaterialAssetId = Con::getVariable("$MeshRoadEditor::defaultSideMaterialAsset");
+   mTopMaterialAssetRef    = Con::getVariable( "$MeshRoadEditor::defaultTopMaterialAsset" );
+   mBottomMaterialAssetRef = Con::getVariable( "$MeshRoadEditor::defaultBottomMaterialAsset" );
+   mSideMaterialAssetRef   = Con::getVariable( "$MeshRoadEditor::defaultSideMaterialAsset" );
 }
 
 GuiMeshRoadEditorCtrl::~GuiMeshRoadEditorCtrl()
@@ -222,10 +218,10 @@ void GuiMeshRoadEditorCtrl::initPersistFields()
    addField( "SelectedSplineColor", TypeColorI, Offset( mSelectedSplineColor, GuiMeshRoadEditorCtrl ) );
    addField( "HoverNodeColor",      TypeColorI, Offset( mHoverNodeColor, GuiMeshRoadEditorCtrl ) );
    addField( "isDirty",             TypeBool,   Offset( mIsDirty, GuiMeshRoadEditorCtrl ) );
-
-   INITPERSISTFIELD_MATERIALASSET(TopMaterial, GuiMeshRoadEditorCtrl, "Default Material used by the Mesh Road Editor on upper surface road creation.");
-   INITPERSISTFIELD_MATERIALASSET(BottomMaterial, GuiMeshRoadEditorCtrl, "Default Material used by the Mesh Road Editor on bottom surface road creation.");
-   INITPERSISTFIELD_MATERIALASSET(SideMaterial, GuiMeshRoadEditorCtrl, "Default Material used by the Mesh Road Editor on side surface road creation.");
+   
+   ADD_FIELD( "topMaterialAsset",    TypeMaterialAssetRef, Offset( mTopMaterialAssetRef,    GuiMeshRoadEditorCtrl ) ).doc( "Default material asset used by the Mesh Road Editor on upper surface road creation." );
+   ADD_FIELD( "bottomMaterialAsset", TypeMaterialAssetRef, Offset( mBottomMaterialAssetRef, GuiMeshRoadEditorCtrl ) ).doc( "Default material asset used by the Mesh Road Editor on bottom surface road creation." );
+   ADD_FIELD( "sideMaterialAsset",   TypeMaterialAssetRef, Offset( mSideMaterialAssetRef,   GuiMeshRoadEditorCtrl ) ).doc( "Default material asset used by the Mesh Road Editor on side surface road creation." );
 
    //addField( "MoveNodeCursor", TYPEID< SimObject >(), Offset( mMoveNodeCursor, GuiMeshRoadEditorCtrl) );
    //addField( "AddNodeCursor", TYPEID< SimObject >(), Offset( mAddNodeCursor, GuiMeshRoadEditorCtrl) );
@@ -627,12 +623,12 @@ void GuiMeshRoadEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
 
 		MeshRoad *newRoad = new MeshRoad;  
 
-      if(mTopMaterialAsset.notNull())
-		   newRoad->_setTopMaterial(mTopMaterialAssetId);
-      if (mBottomMaterialAsset.notNull())
-		   newRoad->_setBottomMaterial(mBottomMaterialAssetId);
-      if (mSideMaterialAsset.notNull())
-		   newRoad->_setSideMaterial(mSideMaterialAssetId);
+      if ( mTopMaterialAssetRef.notNull() )
+		   newRoad->mTopMaterialAssetRef = mTopMaterialAssetRef.getAssetId();
+      if ( mBottomMaterialAssetRef.notNull() )
+		   newRoad->mBottomMaterialAssetRef = mBottomMaterialAssetRef.getAssetId();
+      if ( mSideMaterialAssetRef.notNull() )
+		   newRoad->mSideMaterialAssetRef = mSideMaterialAssetRef.getAssetId();
 			
       newRoad->registerObject();
 

--- a/Engine/source/environment/editors/guiMeshRoadEditorCtrl.h
+++ b/Engine/source/environment/editors/guiMeshRoadEditorCtrl.h
@@ -159,14 +159,9 @@ class GuiMeshRoadEditorCtrl : public EditTSCtrl
       bool mHasCopied;
 	public:
 
-      DECLARE_MATERIALASSET(GuiMeshRoadEditorCtrl, TopMaterial);
-      DECLARE_ASSET_SETGET(GuiMeshRoadEditorCtrl, TopMaterial);
-
-      DECLARE_MATERIALASSET(GuiMeshRoadEditorCtrl, BottomMaterial);
-      DECLARE_ASSET_SETGET(GuiMeshRoadEditorCtrl, BottomMaterial);
-
-      DECLARE_MATERIALASSET(GuiMeshRoadEditorCtrl, SideMaterial);
-      DECLARE_ASSET_SETGET(GuiMeshRoadEditorCtrl, SideMaterial);
+      AssetRef<MaterialAsset> mTopMaterialAssetRef;
+      AssetRef<MaterialAsset> mBottomMaterialAssetRef;
+      AssetRef<MaterialAsset> mSideMaterialAssetRef;
 };
 
 class GuiMeshRoadEditorUndoAction : public UndoAction

--- a/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
+++ b/Engine/source/environment/editors/guiRoadEditorCtrl.cpp
@@ -85,7 +85,7 @@ GuiRoadEditorCtrl::GuiRoadEditorCtrl()
    mSavedDrag = false;
    mIsDirty = false;
 
-   mMaterialAssetId = Con::getVariable("$DecalRoadEditor::defaultMaterialAsset");
+   mMaterialAssetRef = Con::getVariable( "$DecalRoadEditor::defaultMaterialAsset" );
 }
 
 GuiRoadEditorCtrl::~GuiRoadEditorCtrl()
@@ -100,7 +100,7 @@ void GuiRoadEditorUndoAction::undo()
       return;
 
    // Temporarily save the roads current data.
-   String materialAssetId = road->mMaterialAssetId;
+   StringTableEntry materialAssetId = road->getMaterialAssetId();
    F32 textureLength = road->mTextureLength;
    F32 breakAngle = road->mBreakAngle;
    F32 segmentsPerBatch = road->mSegmentsPerBatch;
@@ -108,7 +108,7 @@ void GuiRoadEditorUndoAction::undo()
    nodes.merge( road->mNodes );
 
    // Restore the Road properties saved in the UndoAction
-   road->_setMaterial(materialAssetId);
+   road->mMaterialAssetRef = mMaterialAssetId;
    road->mBreakAngle = breakAngle;
    road->mSegmentsPerBatch = segmentsPerBatch;
    road->mTextureLength = textureLength;
@@ -165,7 +165,7 @@ void GuiRoadEditorCtrl::initPersistFields()
    addField( "HoverNodeColor",      TypeColorI, Offset( mHoverNodeColor, GuiRoadEditorCtrl ) );
    addField( "isDirty",             TypeBool,   Offset( mIsDirty, GuiRoadEditorCtrl ) );
 
-   INITPERSISTFIELD_MATERIALASSET(Material, GuiRoadEditorCtrl, "Default Material used by the Road Editor on road creation.");
+   ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, GuiRoadEditorCtrl ) ).doc( "Default material asset used by the Road Editor on road creation." );
 
    //addField( "MoveNodeCursor", TYPEID< SimObject >(), Offset( mMoveNodeCursor, GuiRoadEditorCtrl) );
    //addField( "AddNodeCursor", TYPEID< SimObject >(), Offset( mAddNodeCursor, GuiRoadEditorCtrl) );
@@ -407,8 +407,8 @@ void GuiRoadEditorCtrl::on3DMouseDown(const Gui3DMouseEvent & event)
 
 		DecalRoad *newRoad = new DecalRoad;
 		
-      if (mMaterialAsset.notNull())
-         newRoad->_setMaterial(mMaterialAssetId);
+      if ( mMaterialAssetRef.notNull() )
+         newRoad->mMaterialAssetRef = mMaterialAssetRef.getAssetId();
 
       newRoad->registerObject();
 
@@ -1029,7 +1029,7 @@ void GuiRoadEditorCtrl::submitUndo( const UTF8 *name )
 
    action->mObjId = mSelRoad->getId();
    action->mBreakAngle = mSelRoad->mBreakAngle;
-   action->mMaterialAssetId = mSelRoad->mMaterialAssetId;
+   action->mMaterialAssetId = mSelRoad->getMaterialAssetId();
    action->mSegmentsPerBatch = mSelRoad->mSegmentsPerBatch;   
    action->mTextureLength = mSelRoad->mTextureLength;
    action->mRoadEditor = this;

--- a/Engine/source/environment/editors/guiRoadEditorCtrl.h
+++ b/Engine/source/environment/editors/guiRoadEditorCtrl.h
@@ -103,8 +103,8 @@ class GuiRoadEditorCtrl : public EditTSCtrl
 	
 	public:
 
-      DECLARE_MATERIALASSET(GuiRoadEditorCtrl, Material);
-      DECLARE_ASSET_SETGET(GuiRoadEditorCtrl, Material);
+      AssetRef<MaterialAsset> mMaterialAssetRef;
+      StringTableEntry getMaterialAssetId() const { return mMaterialAssetRef.getAssetId(); }
 
    protected:
 

--- a/Engine/source/environment/meshRoad.cpp
+++ b/Engine/source/environment/meshRoad.cpp
@@ -920,10 +920,6 @@ MeshRoad::MeshRoad()
       mTriangleCount[i] = 0;
    }
 
-   INIT_ASSET(TopMaterial);
-   INIT_ASSET(BottomMaterial);
-   INIT_ASSET(SideMaterial);
-
    mSideProfile.mRoad = this;
 }
 
@@ -939,9 +935,15 @@ void MeshRoad::initPersistFields()
    docsURL;
    addGroup( "MeshRoad" );
 
-      INITPERSISTFIELD_MATERIALASSET(TopMaterial, MeshRoad, "Material for the upper surface of the road.");
-      INITPERSISTFIELD_MATERIALASSET(BottomMaterial, MeshRoad, "Material for the bottom surface of the road.");
-      INITPERSISTFIELD_MATERIALASSET(SideMaterial, MeshRoad, "Material for the side surface of the road.");
+      ADD_FIELD( "topMaterialAsset", TypeMaterialAssetRef, Offset( mTopMaterialAssetRef, MeshRoad ) )
+         .network( MeshRoadMask )
+         .doc( "Material asset for the upper surface of the road." );
+      ADD_FIELD( "bottomMaterialAsset", TypeMaterialAssetRef, Offset( mBottomMaterialAssetRef, MeshRoad ) )
+         .network( MeshRoadMask )
+         .doc( "Material asset for the bottom surface of the road." );
+      ADD_FIELD( "sideMaterialAsset", TypeMaterialAssetRef, Offset( mSideMaterialAssetRef, MeshRoad ) )
+         .network( MeshRoadMask )
+         .doc( "Material asset for the side surface of the road." );
 
       addFieldV( "textureLength", TypeRangedF32, Offset( mTextureLength, MeshRoad ), &mrTextureLengthV,
          "The length in meters of textures mapped to the MeshRoad." );      
@@ -1320,18 +1322,12 @@ void MeshRoad::prepRenderImage( SceneRenderState* state )
 
 void MeshRoad::_initMaterial()
 {
-   if (mTopMaterialAsset.notNull())
+   if (mTopMaterialAssetRef.notNull())
    {
-      if (!mMatInst[Top] || !String(mTopMaterialAsset->getMaterialDefinitionName()).equal(mMatInst[Top]->getMaterial()->getName(), String::NoCase))
+      if (!mMatInst[Top] || !String(mTopMaterialAssetRef.assetPtr->getMaterialName()).equal(mMatInst[Top]->getMaterial()->getName(), String::NoCase))
       {
          SAFE_DELETE(mMatInst[Top]);
-
-         Material* tMat = NULL;
-         if (!Sim::findObject(mTopMaterialAsset->getMaterialDefinitionName(), tMat))
-            Con::errorf("MeshRoad::_initMaterial - Material %s was not found.", mTopMaterialAsset->getMaterialDefinitionName());
-
-         mMaterial[Top] = tMat;
-
+         mMaterial[Top] = mTopMaterialAssetRef.assetPtr->getMaterial();
          if (mMaterial[Top])
             mMatInst[Top] = mMaterial[Top]->createMatInstance();
          else
@@ -1341,19 +1337,12 @@ void MeshRoad::_initMaterial()
       }
    }
 
-   if (mBottomMaterialAsset.notNull())
+   if (mBottomMaterialAssetRef.notNull())
    {
-      if (!mMatInst[Bottom] || !String(mBottomMaterialAsset->getMaterialDefinitionName()).equal(mMatInst[Bottom]->getMaterial()->getName(), String::NoCase))
+      if (!mMatInst[Bottom] || !String(mBottomMaterialAssetRef.assetPtr->getMaterialName()).equal(mMatInst[Bottom]->getMaterial()->getName(), String::NoCase))
       {
-
          SAFE_DELETE(mMatInst[Bottom]);
-
-         Material* tMat = NULL;
-         if (!Sim::findObject(mBottomMaterialAsset->getMaterialDefinitionName(), tMat))
-            Con::errorf("MeshRoad::_initMaterial - Material %s was not found.", mBottomMaterialAsset->getMaterialDefinitionName());
-
-         mMaterial[Bottom] = tMat;
-
+         mMaterial[Bottom] = mBottomMaterialAssetRef.assetPtr->getMaterial();
          if (mMaterial[Bottom])
             mMatInst[Bottom] = mMaterial[Bottom]->createMatInstance();
          else
@@ -1363,18 +1352,12 @@ void MeshRoad::_initMaterial()
       }
    }
 
-   if (mSideMaterialAsset.notNull())
+   if (mSideMaterialAssetRef.notNull())
    {
-      if (!mMatInst[Side] || !String(mSideMaterialAsset->getMaterialDefinitionName()).equal(mMatInst[Side]->getMaterial()->getName(), String::NoCase))
+      if (!mMatInst[Side] || !String(mSideMaterialAssetRef.assetPtr->getMaterialName()).equal(mMatInst[Side]->getMaterial()->getName(), String::NoCase))
       {
          SAFE_DELETE(mMatInst[Side]);
-
-         Material* tMat = NULL;
-         if (!Sim::findObject(mSideMaterialAsset->getMaterialDefinitionName(), tMat))
-            Con::errorf("MeshRoad::_initMaterial - Material %s was not found.", mSideMaterialAsset->getMaterialDefinitionName());
-
-         mMaterial[Side] = tMat;
-
+         mMaterial[Side] = mSideMaterialAssetRef.assetPtr->getMaterial();
          if (mMaterial[Side])
             mMatInst[Side] = mMaterial[Side]->createMatInstance();
          else
@@ -1472,9 +1455,9 @@ U32 MeshRoad::packUpdate(NetConnection * con, U32 mask, BitStream * stream)
       stream->writeAffineTransform( mObjToWorld );
 
       // Write Materials
-      PACK_ASSET(con, TopMaterial);
-      PACK_ASSET(con, BottomMaterial);
-      PACK_ASSET(con, SideMaterial);
+      AssetDatabase.packDataAsset( stream, mTopMaterialAssetRef.getAssetId() );
+      AssetDatabase.packDataAsset( stream, mBottomMaterialAssetRef.getAssetId() );
+      AssetDatabase.packDataAsset( stream, mSideMaterialAssetRef.getAssetId() );
 
       stream->write( mTextureLength );      
       stream->write( mBreakAngle );
@@ -1571,9 +1554,9 @@ void MeshRoad::unpackUpdate(NetConnection * con, BitStream * stream)
       stream->readAffineTransform(&ObjectMatrix);
       Parent::setTransform(ObjectMatrix);
 
-      UNPACK_ASSET(con, TopMaterial);
-      UNPACK_ASSET(con, BottomMaterial);
-      UNPACK_ASSET(con, SideMaterial);
+      mTopMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
+      mBottomMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
+      mSideMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
 
       if ( isProperlyAdded() )
          _initMaterial(); 

--- a/Engine/source/environment/meshRoad.h
+++ b/Engine/source/environment/meshRoad.h
@@ -625,14 +625,9 @@ protected:
    GFXVertexBufferHandle<GFXVertexPNTT> mVB[SurfaceCount];   
    GFXPrimitiveBufferHandle mPB[SurfaceCount];      
 
-   DECLARE_MATERIALASSET(MeshRoad, TopMaterial);
-   DECLARE_ASSET_NET_SETGET(MeshRoad, TopMaterial, MeshRoadMask);
-
-   DECLARE_MATERIALASSET(MeshRoad, BottomMaterial);
-   DECLARE_ASSET_NET_SETGET(MeshRoad, BottomMaterial, MeshRoadMask);
-
-   DECLARE_MATERIALASSET(MeshRoad, SideMaterial);
-   DECLARE_ASSET_NET_SETGET(MeshRoad, SideMaterial, MeshRoadMask);
+   AssetRef<MaterialAsset> mTopMaterialAssetRef;
+   AssetRef<MaterialAsset> mBottomMaterialAssetRef;
+   AssetRef<MaterialAsset> mSideMaterialAssetRef;
 
    //String mMaterialName[SurfaceCount];   
    SimObjectPtr<Material> mMaterial[SurfaceCount];

--- a/Engine/source/environment/scatterSky.cpp
+++ b/Engine/source/environment/scatterSky.cpp
@@ -170,7 +170,6 @@ ScatterSky::ScatterSky()
    mNightCubemapName = StringTable->EmptyString();
    mSunSize = 1.0f;
 
-   INIT_ASSET(MoonMat);
 
    mMoonMatInst = NULL;
 
@@ -413,7 +412,9 @@ void ScatterSky::initPersistFields()
       addField( "moonEnabled", TypeBool, Offset( mMoonEnabled, ScatterSky ),
          "Enable or disable rendering of the moon sprite during night." );
 
-      INITPERSISTFIELD_MATERIALASSET(MoonMat, ScatterSky, "Material for the moon sprite.");
+      ADD_FIELD( "moonMatAsset", TypeMaterialAssetRef, Offset( mMoonMatAssetRef, ScatterSky ) )
+         .network( UpdateMask )
+         .doc( "Material asset for the moon sprite." );
 
       addFieldV( "moonScale", TypeRangedF32, Offset( mMoonScale, ScatterSky ), &CommonValidators::PositiveFloat,
          "Controls size the moon sprite renders, specified as a fractional amount of the screen height." );
@@ -506,7 +507,7 @@ U32 ScatterSky::packUpdate(NetConnection *con, U32 mask, BitStream *stream)
 
       stream->writeFlag( mMoonEnabled );
 
-      PACK_ASSET(con, MoonMat);
+      AssetDatabase.packDataAsset( stream, mMoonMatAssetRef.getAssetId() );
       
       stream->write( mMoonScale );
       stream->write( mMoonTint );
@@ -620,7 +621,7 @@ void ScatterSky::unpackUpdate(NetConnection *con, BitStream *stream)
 
       mMoonEnabled = stream->readFlag();
 
-      UNPACK_ASSET(con, MoonMat);
+      mMoonMatAssetRef = AssetDatabase.unpackDataAsset( stream );
 
       stream->read( &mMoonScale );
       stream->read( &mMoonTint );
@@ -914,14 +915,14 @@ void ScatterSky::_initMoon()
    if ( mMoonMatInst )
       SAFE_DELETE( mMoonMatInst );
 
-   if (mMoonMatAsset.notNull())
+   if (mMoonMatAssetRef.notNull())
    {
       FeatureSet features = MATMGR->getDefaultFeatures();
       features.removeFeature(MFT_RTLighting);
       features.removeFeature(MFT_Visibility);
       features.removeFeature(MFT_ReflectionProbes);      
       features.addFeature(MFT_isBackground);
-      mMoonMatInst = MATMGR->createMatInstance(mMoonMatAsset->getMaterialDefinitionName(), features, getGFXVertexFormat<GFXVertexPCT>());
+      mMoonMatInst = MATMGR->createMatInstance(mMoonMatAssetRef.assetPtr->getMaterialName(), features, getGFXVertexFormat<GFXVertexPCT>());
 
       GFXStateBlockDesc desc;
       desc.setBlend(true);

--- a/Engine/source/environment/scatterSky.h
+++ b/Engine/source/environment/scatterSky.h
@@ -233,8 +233,7 @@ protected:
 
    bool mMoonEnabled;
 
-   DECLARE_MATERIALASSET(ScatterSky, MoonMat);
-   DECLARE_ASSET_NET_SETGET(ScatterSky, MoonMat, UpdateMask);
+   AssetRef<MaterialAsset> mMoonMatAssetRef;
 
    BaseMatInstance *mMoonMatInst;
    F32 mMoonScale;

--- a/Engine/source/environment/skyBox.cpp
+++ b/Engine/source/environment/skyBox.cpp
@@ -56,7 +56,6 @@ SkyBox::SkyBox()
    mTypeMask |= EnvironmentObjectType | StaticObjectType;
    mNetFlags.set(Ghostable | ScopeAlways);
 
-   INIT_ASSET(Material);
    mMatInstance = NULL;
 
    mIsVBDirty = false;
@@ -117,7 +116,9 @@ void SkyBox::initPersistFields()
    docsURL;
    addGroup( "Sky Box" );	
 
-   INITPERSISTFIELD_MATERIALASSET(Material, SkyBox, "The name of a cubemap material for the sky box.");
+   ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, SkyBox ) )
+         .network(-1)
+         .doc( "The material asset for a cubemap material for the sky box." );
 
    addField( "drawBottom", TypeBool, Offset( mDrawBottom, SkyBox ),
       "If false the bottom of the skybox is not rendered." );
@@ -140,7 +141,7 @@ U32 SkyBox::packUpdate( NetConnection *conn, U32 mask, BitStream *stream )
 {
    U32 retMask = Parent::packUpdate( conn, mask, stream );
 
-   PACK_ASSET(conn, Material);
+   AssetDatabase.packDataAsset( stream, mMaterialAssetRef.getAssetId() );
 
    stream->writeFlag( mDrawBottom );
    stream->write( mFogBandHeight );
@@ -152,9 +153,9 @@ void SkyBox::unpackUpdate( NetConnection *conn, BitStream *stream )
 {
    Parent::unpackUpdate( conn, stream );
 
-   StringTableEntry oldMatName = getMaterial();
-   UNPACK_ASSET(conn, Material);
-   if (oldMatName != getMaterial())
+   StringTableEntry oldMatId = mMaterialAssetRef.getAssetId();
+   mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
+   if ( oldMatId != mMaterialAssetRef.getAssetId() )
    {
       _updateMaterial();
    }
@@ -594,8 +595,8 @@ void SkyBox::_initMaterial()
    if ( mMatInstance )
       SAFE_DELETE( mMatInstance );
 
-   if ( mMaterial )
-      mMatInstance = mMaterial->createMatInstance();
+   if (mMaterialAssetRef.notNull())
+      mMatInstance = mMaterialAssetRef.assetPtr->getMaterial()->createMatInstance();
    else
       mMatInstance = MATMGR->createMatInstance( "WarningMaterial" );
 
@@ -621,21 +622,13 @@ void SkyBox::_initMaterial()
 
 void SkyBox::_updateMaterial()
 {
-   if (!getMaterialResource().isValid())
-   {
-      //If our materialDef isn't valid, try setting it
-      _setMaterial(getMaterial());
-   }
-
-   if (getMaterialResource().isValid())
-   {
+   if (mMaterialAssetRef.notNull())
       _initMaterial();
-   }
 }
 
 BaseMatInstance* SkyBox::_getMaterialInstance()
 {
-   if ( !mMaterial || !mMatInstance || mMatInstance->getMaterial() != mMaterial )
+   if (!mMaterialAssetRef.notNull() || !mMatInstance || mMatInstance->getMaterial() != mMaterialAssetRef.assetPtr->getMaterial().getPointer())
       _initMaterial();
 
    if ( !mMatInstance )

--- a/Engine/source/environment/skyBox.h
+++ b/Engine/source/environment/skyBox.h
@@ -102,8 +102,7 @@ public:
 protected:
 
    // Material
-   DECLARE_MATERIALASSET(SkyBox, Material);
-   DECLARE_ASSET_NET_SETGET(SkyBox, Material, -1);
+   AssetRef<MaterialAsset> mMaterialAssetRef;
 
    BaseMatInstance *mMatInstance;
    SkyMatParams mMatParamHandle;

--- a/Engine/source/environment/skySphere.cpp
+++ b/Engine/source/environment/skySphere.cpp
@@ -55,7 +55,6 @@ SkySphere::SkySphere()
    mTypeMask |= EnvironmentObjectType | StaticObjectType;
    mNetFlags.set(Ghostable | ScopeAlways);
 
-   INIT_ASSET(Material);
    mMatInstance = NULL;
 
    mIsVBDirty = false;
@@ -116,7 +115,9 @@ void SkySphere::initPersistFields()
    docsURL;
    addGroup("Sky Sphere");
 
-   INITPERSISTFIELD_MATERIALASSET(Material, SkySphere, "The name of a cubemap material for the sky box.");
+   ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, SkySphere ) )
+      .network(-1)
+      .doc( "The material asset of a cubemap for the sky box." );
 
    addFieldV("fogBandHeight", TypeRangedF32, Offset(mFogBandHeight, SkySphere), &CommonValidators::NormalizedFloat,
       "The height (0-1) of the fog band from the horizon to the top of the SkySphere.");
@@ -136,7 +137,7 @@ U32 SkySphere::packUpdate(NetConnection* conn, U32 mask, BitStream* stream)
 {
    U32 retMask = Parent::packUpdate(conn, mask, stream);
 
-   PACK_ASSET(conn, Material);
+   AssetDatabase.packDataAsset( stream, mMaterialAssetRef.getAssetId() );
 
    stream->write(mFogBandHeight);
 
@@ -147,9 +148,9 @@ void SkySphere::unpackUpdate(NetConnection* conn, BitStream* stream)
 {
    Parent::unpackUpdate(conn, stream);
 
-   StringTableEntry oldMatName = getMaterial();
-   UNPACK_ASSET(conn, Material);
-   if (oldMatName != getMaterial())
+   StringTableEntry oldMatId = mMaterialAssetRef.getAssetId();
+   mMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
+   if ( oldMatId != mMaterialAssetRef.getAssetId() )
    {
       _updateMaterial();
    }
@@ -589,8 +590,8 @@ void SkySphere::_initMaterial()
    if (mMatInstance)
       SAFE_DELETE(mMatInstance);
 
-   if (mMaterial)
-      mMatInstance = mMaterial->createMatInstance();
+   if (mMaterialAssetRef.notNull())
+      mMatInstance = mMaterialAssetRef.assetPtr->getMaterial()->createMatInstance();
    else
       mMatInstance = MATMGR->createMatInstance("WarningMaterial");
 
@@ -615,21 +616,13 @@ void SkySphere::_initMaterial()
 
 void SkySphere::_updateMaterial()
 {
-   if (!getMaterialResource().isValid())
-   {
-      //If our materialDef isn't valid, try setting it
-      _setMaterial(getMaterial());
-   }
-
-   if (getMaterialResource().isValid())
-   {
+   if (mMaterialAssetRef.notNull())
       _initMaterial();
-   }
 }
 
 BaseMatInstance* SkySphere::_getMaterialInstance()
 {
-   if (!mMaterial || !mMatInstance || mMatInstance->getMaterial() != mMaterial)
+   if (!mMaterialAssetRef.notNull() || !mMatInstance || mMatInstance->getMaterial() != mMaterialAssetRef.assetPtr->getMaterial().getPointer())
       _initMaterial();
 
    if (!mMatInstance)

--- a/Engine/source/environment/skySphere.h
+++ b/Engine/source/environment/skySphere.h
@@ -142,8 +142,7 @@ public:
 protected:
 
    // Material
-   DECLARE_MATERIALASSET(SkySphere, Material);
-   DECLARE_ASSET_NET_SETGET(SkySphere, Material, -1);
+   AssetRef<MaterialAsset> mMaterialAssetRef;
 
    BaseMatInstance* mMatInstance;
    SkyMatParams mMatParamHandle;

--- a/Engine/source/environment/sun.cpp
+++ b/Engine/source/environment/sun.cpp
@@ -91,8 +91,6 @@ Sun::Sun()
    mCoronaUseLightColor = true;
    mCoronaMatInst = NULL;
 
-   INIT_ASSET(CoronaMaterial);
-
    mMatrixSet = reinterpret_cast<MatrixSet *>(dMalloc_aligned(sizeof(MatrixSet), 16));
    constructInPlace(mMatrixSet);
 
@@ -181,7 +179,9 @@ void Sun::initPersistFields()
       addField( "coronaEnabled", TypeBool, Offset( mCoronaEnabled, Sun ), 
          "Enable or disable rendering of the corona sprite." );
 
-      INITPERSISTFIELD_MATERIALASSET(CoronaMaterial, Sun, "Material for the corona sprite.");
+      ADD_FIELD( "coronaMaterialAsset", TypeMaterialAssetRef, Offset( mCoronaMaterialAssetRef, Sun ) )
+         .network( UpdateMask )
+         .doc( "Material asset for the corona sprite." );
 
       addFieldV( "coronaScale", TypeRangedF32, Offset( mCoronaScale, Sun ), &CommonValidators::PositiveFloat,
          "Controls size the corona sprite renders, specified as a fractional amount of the screen height." );
@@ -242,7 +242,7 @@ U32 Sun::packUpdate(NetConnection *conn, U32 mask, BitStream *stream )
 
       stream->writeFlag( mCoronaEnabled );
 
-      PACK_ASSET(conn, CoronaMaterial);
+      AssetDatabase.packDataAsset( stream, mCoronaMaterialAssetRef.getAssetId() );
 
       stream->write( mCoronaScale );
       stream->write( mCoronaTint );
@@ -288,7 +288,7 @@ void Sun::unpackUpdate( NetConnection *conn, BitStream *stream )
 
       mCoronaEnabled = stream->readFlag();
 
-      UNPACK_ASSET(conn, CoronaMaterial);
+      mCoronaMaterialAssetRef = AssetDatabase.unpackDataAsset( stream );
 
       stream->read( &mCoronaScale );
       stream->read( &mCoronaTint );
@@ -453,7 +453,7 @@ void Sun::_initCorona()
       
    SAFE_DELETE( mCoronaMatInst );
 
-   if (mCoronaMaterialAsset.notNull())
+   if (mCoronaMaterialAssetRef.notNull())
    {
       FeatureSet features = MATMGR->getDefaultFeatures();
       features.removeFeature(MFT_RTLighting);
@@ -462,7 +462,7 @@ void Sun::_initCorona()
       features.addFeature(MFT_isBackground);
       features.addFeature(MFT_VertLit);
 
-      mCoronaMatInst = MATMGR->createMatInstance(mCoronaMaterialAsset->getMaterialDefinitionName(), features, getGFXVertexFormat<GFXVertexPCT>());
+      mCoronaMatInst = MATMGR->createMatInstance(mCoronaMaterialAssetRef.assetPtr->getMaterialName(), features, getGFXVertexFormat<GFXVertexPCT>());
 
       GFXStateBlockDesc desc;
       desc.setBlend(true);

--- a/Engine/source/environment/sun.h
+++ b/Engine/source/environment/sun.h
@@ -78,8 +78,7 @@ protected:
 
    bool mCoronaEnabled;
 
-   DECLARE_MATERIALASSET(Sun, CoronaMaterial);
-   DECLARE_ASSET_NET_SETGET(Sun, CoronaMaterial, UpdateMask);
+   AssetRef<MaterialAsset> mCoronaMaterialAssetRef;
 
    BaseMatInstance *mCoronaMatInst;
    MatrixSet *mMatrixSet;   

--- a/Engine/source/gui/controls/guiMaterialCtrl.cpp
+++ b/Engine/source/gui/controls/guiMaterialCtrl.cpp
@@ -45,15 +45,13 @@ ConsoleDocClass( GuiMaterialCtrl,
 GuiMaterialCtrl::GuiMaterialCtrl()
    : mMaterialInst( NULL )
 {
-   INIT_ASSET(Material);
 }
 
 void GuiMaterialCtrl::initPersistFields()
 {
    docsURL;
    addGroup( "Material" );
-   INITPERSISTFIELD_MATERIALASSET(Material, GuiMaterialCtrl, "");
-   addProtectedField( "materialName", TypeStringFilename, Offset( mMaterialName, GuiMaterialCtrl ), &GuiMaterialCtrl::_setMaterialData, &defaultProtectedGetFn, "", AbstractClassRep::FIELD_HideInInspectors );
+   ADD_FIELD( "materialAsset", TypeMaterialAssetRef, Offset( mMaterialAssetRef, GuiMaterialCtrl ) ).doc( "Material asset to display in this control." );
    endGroup( "Material" );
 
    Parent::initPersistFields();
@@ -65,7 +63,7 @@ bool GuiMaterialCtrl::onWake()
       return false;
 
    setActive( true );
-   setMaterial( getMaterial() );
+   setMaterial( mMaterialAssetRef.assetId );
 
    return true;
 }
@@ -77,22 +75,26 @@ void GuiMaterialCtrl::onSleep()
    Parent::onSleep();
 }
 
-bool GuiMaterialCtrl::_setMaterial( void *object, const char *index, const char *data )
-{
-   static_cast<GuiMaterialCtrl *>( object )->setMaterial( data );
-
-   // Return false to keep the caller from setting the field.
-   return false;
-}
-
 bool GuiMaterialCtrl::setMaterial( const String &materialName )
 {
    SAFE_DELETE( mMaterialInst );
 
-   _setMaterial(StringTable->insert(materialName.c_str()));
+   StringTableEntry matId = StringTable->insert( materialName.c_str() );
+   if ( matId == StringTable->EmptyString() || AssetDatabase.isDeclaredAsset( matId ))
+   {
+      mMaterialAssetRef = matId;
+   }
+   else
+   {
+      StringTableEntry assetId = MaterialAsset::getAssetIdByMaterialName( matId );
+      if ( assetId != StringTable->EmptyString() )
+         mMaterialAssetRef = assetId;
+   }
 
-   if ( getMaterial() != StringTable->EmptyString() && isAwake() )
-      mMaterialInst = MATMGR->createMatInstance( getMaterial(), getGFXVertexFormat<GFXVertexPCT>() );
+   if ( mMaterialAssetRef.notNull() && isAwake() )
+      mMaterialInst = MATMGR->createMatInstance(
+         mMaterialAssetRef.assetPtr->getMaterialName(),
+         getGFXVertexFormat<GFXVertexPCT>() );
 
    return true;
 }

--- a/Engine/source/gui/controls/guiMaterialCtrl.h
+++ b/Engine/source/gui/controls/guiMaterialCtrl.h
@@ -40,12 +40,8 @@ private:
 
 protected:
 
-   DECLARE_MATERIALASSET(GuiMaterialCtrl, Material);
-   DECLARE_ASSET_SETGET(GuiMaterialCtrl, Material);
-
-   BaseMatInstance *mMaterialInst;
-
-   static bool _setMaterial( void *object, const char *index, const char *data );
+   AssetRef<MaterialAsset> mMaterialAssetRef;
+   BaseMatInstance* mMaterialInst;
 
 public:
 

--- a/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
+++ b/Engine/source/gui/worldEditor/guiConvexShapeEditorCtrl.cpp
@@ -253,13 +253,13 @@ void GuiConvexEditorCtrl::setVisible( bool val )
 
                   //Set the texture to a representatory one so we know what's what
                   if (isTrigger)
-                     proxyShape->_setMaterial(StringTable->insert("ToolsModule:TriggerProxyMaterial"));
+                     proxyShape->setMaterial(StringTable->insert("ToolsModule:TriggerProxyMaterial"));
                   else if (isPortal)
-                     proxyShape->_setMaterial(StringTable->insert("ToolsModule:PortalProxyMaterial"));
+                     proxyShape->setMaterial(StringTable->insert("ToolsModule:PortalProxyMaterial"));
                   else if (isZone)
-                     proxyShape->_setMaterial(StringTable->insert("ToolsModule:ZoneProxyMaterial"));
+                     proxyShape->setMaterial(StringTable->insert("ToolsModule:ZoneProxyMaterial"));
                   else if (isOccluder)
-                     proxyShape->_setMaterial(StringTable->insert("ToolsModule:OccluderProxyMaterial"));
+                     proxyShape->setMaterial(StringTable->insert("ToolsModule:OccluderProxyMaterial"));
 
                   proxyShape->_updateMaterial();
 
@@ -533,7 +533,7 @@ void GuiConvexEditorCtrl::on3DMouseDragged(const Gui3DMouseEvent & event)
          
          setupShape( newShape );
 
-         newShape->_setMaterial(mConvexSEL->getMaterial());
+         newShape->setMaterial(mConvexSEL->getMaterial());
 
          submitUndo( CreateShape, newShape );
 
@@ -1462,7 +1462,7 @@ bool GuiConvexEditorCtrl::isShapeValid( ConvexShape *shape )
 void GuiConvexEditorCtrl::setupShape( ConvexShape *shape )
 {
    shape->registerObject();
-   shape->_setMaterial(mMaterialName);
+   shape->setMaterial(mMaterialName);
    updateShape( shape );
 
    Scene* scene = Scene::getRootScene();
@@ -1992,7 +1992,7 @@ void GuiConvexEditorCtrl::setSelectedFaceMaterial(const char* materialName)
       {
          //add a new one
          ConvexShape::surfaceMaterial newMat;
-         newMat._setMaterial(materialName);
+         newMat.setMaterial(materialName);
 
          mConvexSEL->mSurfaceTextures.push_back(newMat);
 
@@ -2286,7 +2286,7 @@ ConvexEditorTool::EventResult ConvexEditorCreateTool::on3DMouseDown( const Gui3D
 		
       mNewConvex->registerObject();
 
-      mNewConvex->_setMaterial(Parent::mEditor->mMaterialName);
+      mNewConvex->setMaterial(Parent::mEditor->mMaterialName);
 
       mPlaneSizes.set( 0.1f, 0.1f, 0.1f );
       mNewConvex->resizePlanes( mPlaneSizes );
@@ -2510,7 +2510,7 @@ ConvexShape* ConvexEditorCreateTool::extrudeShapeFromFace( ConvexShape *inShape,
    }
 
 	//newShape->setField( "material", Parent::mEditor->mMaterialName );
-   newShape->_setMaterial(inShape->getMaterial());
+   newShape->setMaterial(inShape->getMaterial());
 
    newShape->registerObject();
    mEditor->updateShape( newShape );

--- a/Engine/source/lighting/common/projectedShadow.cpp
+++ b/Engine/source/lighting/common/projectedShadow.cpp
@@ -100,7 +100,6 @@ ProjectedShadow::ProjectedShadow( SceneObject *object )
    Sim::findObject( "BL_ProjectedShadowMaterial", customMat );
    if ( customMat )
    {
-      mDecalData->mMaterial = customMat;
       mDecalData->matInst = customMat->createMatInstance();
    }
    else

--- a/Engine/source/terrain/terrData.cpp
+++ b/Engine/source/terrain/terrData.cpp
@@ -493,7 +493,7 @@ bool TerrainBlock::saveAsset()
          {
             StringTableEntry intMatName = terr->mFile->mMaterials[m]->getInternalName();
 
-            StringTableEntry assetMatDefName = terrMatAsset->getMaterialDefinitionName();
+            StringTableEntry assetMatDefName = terrMatAsset->getMaterialName();
             if (assetMatDefName == intMatName)
             {
                mTerrainAsset->addAssetDependencyField("terrainMaterailAsset", terrMatAsset.getAssetId());
@@ -1005,7 +1005,7 @@ void TerrainBlock::addMaterial( const String &name, U32 insertAt )
          for (U32 i = 0; i < foundCount; i++)
          {
             TerrainMaterialAsset* terrMatAsset = AssetDatabase.acquireAsset<TerrainMaterialAsset>(aq->mAssetList[i]);
-            if (terrMatAsset && terrMatAsset->getMaterialDefinitionName() == terrMatName)
+            if (terrMatAsset && terrMatAsset->getMaterialName() == terrMatName)
             {
                //Do iterative logic to find the next available slot and write to it with our new mat field
                mTerrainAsset->setDataField(StringTable->insert("terrainMaterialAsset"), NULL, aq->mAssetList[i]);

--- a/Engine/source/terrain/terrMaterial.cpp
+++ b/Engine/source/terrain/terrMaterial.cpp
@@ -190,7 +190,7 @@ TerrainMaterial* TerrainMaterial::findOrCreate( const char *nameOrPath )
       TerrainMaterialAsset* terrMatAsset = AssetDatabase.acquireAsset<TerrainMaterialAsset>(assetId);
       if (terrMatAsset)
       {
-         mat = terrMatAsset->getMaterialDefinition();
+         mat = terrMatAsset->getMaterial();
          if (mat)
             return mat;
       }

--- a/Templates/BaseGame/game/core/rendering/Core_Rendering.tscript
+++ b/Templates/BaseGame/game/core/rendering/Core_Rendering.tscript
@@ -39,6 +39,13 @@ function Core_Rendering::onDestroy(%this)
 
 function Core_Rendering::initClient(%this)
 {
+   //Lets init our fallback assets
+   loadImageAssetFallback();
+   loadNamedTargetFallback();
+   loadMaterialAssetFallback();
+   loadTerrainMaterialAssetFallback();
+   loadShapeAssetFallback();
+   
    // Start rendering and stuff.
    initRenderManager();
    initLightingSystems("Advanced Lighting"); 


### PR DESCRIPTION
- Updates the material and terrain material assets to utilize AssetRef and drop the old macros like how Image and ShapeAssets have been updated.
- Updates the various classes using materials to comply to the change.
- Also standardizes some getter names to follow the general convention image and shape used to keep things more consistent across the board to minimize usage friction.
- Shifts handling of fallback asset lookups for the thus-far converted classes to have them be loaded during core initialization rather than being loaded as part of other asset loading as that sometimes lead to nesting execution/stability errors. Explicit call now ensures the fallbacks are loaded before any other asset tries to load, so there's no room for confounding or having no fallback to work with.