### PR TITLE
remove redundant text entries

### DIFF
--- a/Templates/BaseGame/game/data/UI/guis/ChooseLevelMenu.gui
+++ b/Templates/BaseGame/game/data/UI/guis/ChooseLevelMenu.gui
@@ -255,7 +255,6 @@ $guiContent = new GuiControl(ChooseLevelMenu) {
                   tooltipProfile = "GuiToolTipProfile";
                };
                new GuiTextEditCtrl(playerNameCTRL) {
-                  text = "Visitor";
                   position = "606 4";
                   extent = "295 22";
                   horizSizing = "left";
@@ -281,7 +280,6 @@ $guiContent = new GuiControl(ChooseLevelMenu) {
                   tooltipProfile = "GuiToolTipProfile";
                };
                new GuiTextEditCtrl(serverNameCTRL) {
-                  text = "Torque 3D Server";
                   position = "606 4";
                   extent = "295 22";
                   horizSizing = "left";
@@ -332,7 +330,6 @@ $guiContent = new GuiControl(ChooseLevelMenu) {
                   tooltipProfile = "GuiToolTipProfile";
                };
                new GuiTextEditCtrl(serverInfoCTRL) {
-                  text = "This is a Torque 3D server.";
                   position = "606 4";
                   extent = "295 22";
                   horizSizing = "left";
@@ -358,7 +355,6 @@ $guiContent = new GuiControl(ChooseLevelMenu) {
                   tooltipProfile = "GuiToolTipProfile";
                };
                new GuiTextEditCtrl(serverMaxPlayersCTRL) {
-                  text = "64";
                   position = "606 4";
                   extent = "295 22";
                   horizSizing = "left";

--- a/Templates/BaseGame/game/data/UI/guis/joinServerMenu.gui
+++ b/Templates/BaseGame/game/data/UI/guis/joinServerMenu.gui
@@ -48,7 +48,6 @@ $guiContent = new GuiControl(JoinServerMenu) {
          tooltipProfile = "GuiToolTipProfile";
       };
       new GuiTextEditCtrl(JoinServerPlayerNameTxt) {
-         text = "Visitor";
          position = "606 7";
          extent = "295 22";
          horizSizing = "left";
@@ -74,7 +73,6 @@ $guiContent = new GuiControl(JoinServerMenu) {
          tooltipProfile = "GuiToolTipProfile";
       };
       new GuiTextEditCtrl(JoinServerPasswordTxt) {
-         text = "Visitor";
          position = "606 7";
          extent = "295 22";
          horizSizing = "left";

--- a/Templates/BaseGame/game/data/defaults.tscript
+++ b/Templates/BaseGame/game/data/defaults.tscript
@@ -211,3 +211,5 @@ $pref::PostFX::EnableHDR = 1;
 $pref::PostFX::EnableSSAO = 1;
 
 $pref::PostFX::EnableHDRBloom = 1;
+
+exec("core/clientServer/scripts/server/defaults");


### PR DESCRIPTION
for GuiTextEditCtrl elements, the text *is* the variable. so filling that entry out overwrites the variable itself. just use obj.variable = $pref::foo; patterns there to ensure lookups. for server config purposes, added an exec("core/clientServer/scripts/server/defaults"); to keep those config values distinctly clustered while ensuring the same order of operations as other prefs.