### PR TITLE
ActionMap::processAction crashfix

### DIFF
--- a/Engine/source/sim/actionMap.cpp
+++ b/Engine/source/sim/actionMap.cpp
@@ -1482,7 +1482,7 @@ bool ActionMap::processAction(const InputEventInfo* pEvent)
       if(pNode->flags & Node::BindCmd)
       {
          // it's a bind command
-         if (pNode->makeConsoleCommand)
+         if (pNode->makeConsoleCommand && pNode->makeConsoleCommand[0])
          {
             StringTableEntry objectName = getName() != StringTable->EmptyString() ? getName() : getInternalName();
             String context = String::ToString("%s\nObject: %s", Platform::makeRelativePathName(getFilename(), NULL), objectName);


### PR DESCRIPTION
ensure pNode->makeConsoleCommand actually contains data, not just a pointer to where to start reading. reported by steve yorkshire: https://discord.com/channels/358091480004558848/783127087820439582/1524773485308678144