### PR TITLE
safety fallbacks for sub-epsilon normal methods.

### DIFF
--- a/Engine/source/math/impl/math_c.cpp
+++ b/Engine/source/math/impl/math_c.cpp
@@ -61,6 +61,10 @@ namespace math_backend::float4::dispatch
             for (int i = 0; i < 4; i++)
                a[i] *= denom;
          }
+         else
+         {
+            a[0] = 1.0f; a[1] = 0.0f; a[2] = 0.0f; a[3] = 0.0f;
+         }
       };
 
       gFloat4.normalize_mag = [](float* a, float f) {
@@ -69,6 +73,10 @@ namespace math_backend::float4::dispatch
          {
             float denom = f / len;
             for (int i = 0; i < 4; i++) a[i] *= denom;
+         }
+         else
+         {
+            a[0] = f; a[1] = 0.0f; a[2] = 0.0f; a[3] = 0.0f;
          }
       };
 
@@ -143,8 +151,12 @@ namespace math_backend::float3::dispatch
          float len = gFloat3.length(a);
          if (len > POINT_EPSILON)
          {
-            float denom = 1.0 / len;
+            float denom = 1.0f / len;
             for (int i = 0; i < 3; i++) a[i] *= denom;
+         }
+         else
+         {
+            a[0] = 1.0f; a[1] = 0.0f; a[2] = 0.0f;
          }
       };
 
@@ -154,6 +166,10 @@ namespace math_backend::float3::dispatch
          {
             float denom = f / len;
             for (int i = 0; i < 3; i++) a[i] *= denom;
+         }
+         else
+         {
+            a[0] = f; a[1] = 0.0f; a[2] = 0.0f;
          }
       };
 
@@ -337,7 +353,7 @@ namespace math_backend::mat44::dispatch
          r[0] = a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3];
          r[1] = a[4] * b[0] + a[5] * b[1] + a[6] * b[2] + a[7] * b[3];
          r[2] = a[8] * b[0] + a[9] * b[1] + a[10] * b[2] + a[11] * b[3];
-         r[2] = a[12] * b[0] + a[13] * b[1] + a[14] * b[2] + a[15] * b[3];
+         r[3] = a[12] * b[0] + a[13] * b[1] + a[14] * b[2] + a[15] * b[3];
       };
 
       gMat44.mul_pos3 = [](const float* a, const float* b, float* r) {


### PR DESCRIPTION
extreemly small or 0,0,0 floats nd quats could end up skipping normalization. in those cases, just return a unit length or scaled unit length default to avoid tripping safeties or heavy processing cacls on hot paths.