### PR TITLE
User selectable filtering for materials

### DIFF
--- a/Engine/source/materials/materialDefinition.cpp
+++ b/Engine/source/materials/materialDefinition.cpp
@@ -39,6 +39,7 @@
 #include "gui/controls/guiTreeViewCtrl.h"
 #include <console/persistenceManager.h>
 #include "console/typeValidators.h"
+#include "gfx/gfxAPI.h"
 
 IMPLEMENT_CONOBJECT(Material);
 
@@ -234,6 +235,8 @@ Material::Material()
 
    mDirectSoundOcclusion = 1.f;
    mReverbSoundOcclusion = 1.0;
+
+   mFilterType = GFXTextureFilterLinear;
 }
 
 IRangeValidator bmpChanRange(0, 3);
@@ -266,6 +269,14 @@ void Material::initPersistFields()
          .elements(MAX_STAGES)
          .doc("@brief NormalMap.");
    endGroup("Basic Texture Maps");
+
+   addGroup("Material Sampling");
+      ADD_FIELD("filterType", TYPEID< GFXTextureFilterType >(), Offset(mFilterType, Material))
+         .doc("@brief Texture filtering for the material.");
+
+      addField("useAnisotropic", TypeBool, Offset(mUseAnisotropic, Material), MAX_STAGES,
+         "Use anisotropic filtering for the textures of this stage.");
+   endGroup("Material Sampling");
 
    addGroup("Light Influence Maps");
 
@@ -364,8 +375,7 @@ void Material::initPersistFields()
          "Enables parallax mapping and defines the scale factor for the parallax effect.  Typically "
          "this value is less than 0.4 else the effect breaks down.");
 
-      addField("useAnisotropic", TypeBool, Offset(mUseAnisotropic, Material), MAX_STAGES,
-         "Use anisotropic filtering for the textures of this stage.");
+      
 
       addField("vertLit", TypeBool, Offset(mVertLit, Material), MAX_STAGES,
          "If true the vertex color is used for lighting.");

--- a/Engine/source/materials/materialDefinition.h
+++ b/Engine/source/materials/materialDefinition.h
@@ -281,6 +281,10 @@ public:
    void setGlowMap(StringTableEntry assetId, const U32& index) { mGlowMapAssetRef[index] = assetId; }
    GFXTexHandle getGlowMap(const U32& index) { return mGlowMapAssetRef[index].notNull() ? mGlowMapAssetRef[index].assetPtr->getTexture(&GFXStaticTextureProfile) : GFXTexHandle(); }
 
+   /// Explicit filtering override for this material. Defaults to
+   /// GFXTextureFilterLinear (out of range / unset).
+   GFXTextureFilterType mFilterType;
+
    bool     mDiffuseMapSRGB[MAX_STAGES];   // SRGB diffuse
    bool     mIsSRGb[MAX_STAGES];           // SRGB ORM
    U32      mAOChan[MAX_STAGES];
@@ -438,6 +442,8 @@ public:
    bool isLightmapped() const override;
    bool castsShadows() const override { return mCastShadows; }
    const String& getPath() const { return mPath; }
+
+   GFXTextureFilterType getFilterType() { return mFilterType; }
 
    void flush();
 

--- a/Engine/source/materials/processedMaterial.cpp
+++ b/Engine/source/materials/processedMaterial.cpp
@@ -264,17 +264,11 @@ void ProcessedMaterial::_initPassStateBlock( RenderPassData *rpd, GFXStateBlockD
             result.samplers[i].addressModeU = GFXAddressWrap;
             result.samplers[i].addressModeV = GFXAddressWrap;
 
-            if ( maxAnisotropy > 1 )
-            {
-               result.samplers[i].minFilter = GFXTextureFilterAnisotropic;
-               result.samplers[i].magFilter = GFXTextureFilterAnisotropic;
-               result.samplers[i].maxAnisotropy = maxAnisotropy;
-            }
-            else
-            {
-               result.samplers[i].minFilter = GFXTextureFilterLinear;
-               result.samplers[i].magFilter = GFXTextureFilterLinear;
-            }
+            result.samplers[i].minFilter = mMaterial->getFilterType();
+            result.samplers[i].magFilter = mMaterial->getFilterType();
+            result.samplers[i].mipFilter = mMaterial->getFilterType();
+            result.samplers[i].maxAnisotropy = maxAnisotropy;
+
             break;
          }
 


### PR DESCRIPTION
Allows a user to specify the filtering a material will use.

This is sort of a sister PR to the imageasset one, this allows the overall material to have a set-able property for the filtering to be used. Note this is an all or northing type deal, whereas the image asset setup allows more fine grained control