### PR TITLE
augment setSkinName methods with an add option (off by default)

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -4996,18 +4996,21 @@ DefineEngineMethod( ShapeBase, getShapeName, const char*, (),,
    return object->getShapeName();
 }
 
-DefineEngineMethod( ShapeBase, setSkinName, void, ( const char* name ),,
+DefineEngineMethod( ShapeBase, setSkinName, void, ( const char* name, bool add ), (false),
    "@brief Apply a new skin to this shape.\n\n"
 
    "'Skinning' the shape effectively renames the material targets, allowing "
    "different materials to be used on different instances of the same model.\n\n"
 
-   "@param name name of the skin to apply\n\n"
-
+   "@param name name of the skin to apply\n"
+   "@param add whether to add to the skin replacement string, or replace the existing one\n"
    "@see skin\n"
    "@see getSkinName()\n")
 {
-   object->setSkinName( name );
+   if (add)
+      object->setSkinName(String::ToString("%s;%s", object->getSkinName(), name));
+   else
+      object->setSkinName( name );
 }
 
 DefineEngineMethod( ShapeBase, getSkinName, const char*, (),,

--- a/Engine/source/T3D/tsStatic.cpp
+++ b/Engine/source/T3D/tsStatic.cpp
@@ -1901,16 +1901,30 @@ DefineEngineMethod(TSStatic, getNodeTransform, TransformF, (const char *nodeName
    return xf;
 }
 
-DefineEngineMethod(TSStatic, setSkinName, void, (const char* name), ,
+DefineEngineMethod(TSStatic, setSkinName, void, (const char* name, bool add), (false),
    "@brief Apply a new skin to this shape.\n\n"
 
    "'Skinning' the shape effectively renames the material targets, allowing "
    "different materials to be used on different instances of the same model.\n\n"
 
    "@param name name of the skin to apply\n\n"
-
+   "@param add whether to add to the skin replacement string, or replace the existing one\n"
    "@see skin\n"
    "@see getSkinName()\n")
 {
-   object->setSkinName(name);
+   if (add)
+      object->setSkinName(String::ToString("%s;%s", object->getSkinName(), name));
+   else
+      object->setSkinName(name);
+}
+
+DefineEngineMethod(TSStatic, getSkinName, const char*, (), ,
+   "@brief Get the name of the skin applied to this shape.\n\n"
+
+   "@return the name of the skin\n\n"
+
+   "@see skin\n"
+   "@see setSkinName()\n")
+{
+   return object->getSkinName();
 }

--- a/Engine/source/T3D/tsStatic.h
+++ b/Engine/source/T3D/tsStatic.h
@@ -249,6 +249,7 @@ public:
 
    // Skinning
    void setSkinName(const char* name);
+   const char* getSkinName() const { return mSkinNameHandle.getString(); }
    void reSkin();
 
    // NetObject


### PR DESCRIPTION
setSkinName by default replaces the whole skin string. the add option allows one to run hat method back to back replacing one or more parts at a time. also adds a getSkinName for tsstatics