### PR TITLE
gui cleanups

### DIFF
--- a/Engine/source/gui/controls/guiTextEditSliderCtrl.cpp
+++ b/Engine/source/gui/controls/guiTextEditSliderCtrl.cpp
@@ -222,6 +222,27 @@ void GuiTextEditSliderCtrl::onMouseDragged(const GuiEvent &event)
    }
 }
 
+bool GuiTextEditSliderCtrl::cursorInArea()
+{
+   GuiCanvas* root = getRoot();
+   if (!root) return false;
+
+   Point2I pt = root->getCursorPos();
+   pt = root->getPlatformWindow() ? root->getPlatformWindow()->screenToClient(pt) : pt;
+   Point2I extent = getExtent();
+   Point2I offset = localToGlobalCoord(Point2I(0, 0));
+   U32 pad = extent.y;
+   if (pt.x >= offset.x - pad && pt.y >= offset.y - pad &&
+      pt.x < offset.x + extent.x + pad && pt.y < offset.y + extent.y + pad)
+   {
+      return true;
+   }
+   else
+   {
+      return false;
+   }
+}
+
 void GuiTextEditSliderCtrl::onMouseUp(const GuiEvent &event)
 {
    // If we're not active then skip out.
@@ -237,14 +258,18 @@ void GuiTextEditSliderCtrl::onMouseUp(const GuiEvent &event)
    if ( mTextAreaHit != None )
       selectAllText();
 
-  //if we released the mouse within this control, then the parent will call
-  //the mConsoleCommand other wise we have to call it.
-   Parent::onMouseUp(event);
-
-   //if we didn't release the mouse within this control, then perform the action
-   // if (!cursorInControl())
-   execConsoleCallback();   
-   execAltConsoleCallback();
+   if (cursorInArea())
+   {
+      //if we released the mouse within this control, then the parent will call
+      //the mConsoleCommand other wise we have to call it.
+      Parent::onMouseUp(event);
+   }
+   else
+   {
+      //if we didn't release the mouse within this control, then perform the action
+      execConsoleCallback();
+      execAltConsoleCallback();
+   }
 
    //Set the cursor position to where the user clicked
    mCursorPos = calculateCursorPos( event.mousePoint );

--- a/Engine/source/gui/controls/guiTextEditSliderCtrl.h
+++ b/Engine/source/gui/controls/guiTextEditSliderCtrl.h
@@ -63,6 +63,7 @@ public:
    void checkRange();
    void checkIncValue();
    void timeInc(U32 elapseTime);
+   bool cursorInArea();
 
    bool onKeyDown(const GuiEvent &event) override;
    void onMouseDown(const GuiEvent &event) override;

--- a/Engine/source/gui/core/guiTypes.cpp
+++ b/Engine/source/gui/core/guiTypes.cpp
@@ -462,6 +462,9 @@ void GuiControlProfile::initPersistFields()
    );
 
    Parent::initPersistFields();
+
+   removeField("hidden");
+   removeField("locked");
 }
 
 bool GuiControlProfile::onAdd()


### PR DESCRIPTION
A) from Abisnail: variables https://discord.com/channels/358091480004558848/783127087820439582/1531249379682291712 remove the hidden and locked variable binds from guiControlProfiles B) from Steve Yorkshire: https://discord.com/channels/358091480004558848/783127087820439582/1531312956409909278 add a new GuiTextEditSliderCtrl::cursorInArea() that is defined as the usual cursorInControl() check with extra hieght based padding around the gui element that is then used as a filter to allow just clicking in the gui element to enable text editing, rather than instantly re-applying the variable if the gui has a comand entry.