### PR TITLE
drop AIObjectType mask down a notch

### DIFF
--- a/Engine/source/T3D/objectTypes.h
+++ b/Engine/source/T3D/objectTypes.h
@@ -173,8 +173,7 @@ enum SceneObjectTypes
    /// A turret object.
    /// @see TurretShape
    TurretObjectType = BIT(29),
-   N_A_31 = BIT(30),
-   AIObjectType = BIT(31),
+   AIObjectType = BIT(30),
 
    /// @}
 };

--- a/Engine/source/console/simObject.cpp
+++ b/Engine/source/console/simObject.cpp
@@ -81,7 +81,6 @@ ImplementBitfieldType(GameTypeMasksType,
 { SceneObjectTypes::N_A_28, "$TypeMasks::N_A_28", "unused 28th bit.\n" },
 { SceneObjectTypes::PathShapeObjectType, "$TypeMasks::PathShapeObjectType", "Path-following Objects.\n" },
 { SceneObjectTypes::TurretObjectType, "$TypeMasks::TurretObjectType", "Turret Objects.\n" },
-{ SceneObjectTypes::N_A_31, "$TypeMasks::N_A_31", "unused 31st bit.\n" },
 { SceneObjectTypes::AIObjectType, "$TypeMasks::AIObjectType", "AIObjectType.\n" },
 
 EndImplementBitfieldType;


### PR DESCRIPTION
given some conceptual concerns about BIT(31), reduced AIObjectType to bit 30, and removed the unused N_A_31 careveout.