### PR TITLE
static analysis results for core classes

### DIFF
--- a/Engine/source/T3D/gameBase/gameBase.cpp
+++ b/Engine/source/T3D/gameBase/gameBase.cpp
@@ -666,7 +666,8 @@ void GameBase::onMount( SceneObject *obj, S32 node )
 
    if (!isGhost()) {
       setMaskBits(MountedMask);
-      mDataBlock->onMount_callback( this, obj, node );
+      if (mDataBlock)
+         mDataBlock->onMount_callback( this, obj, node );
    }
 }
 
@@ -681,7 +682,8 @@ void GameBase::onUnmount( SceneObject *obj, S32 node )
 
    if (!isGhost()) {
       setMaskBits(MountedMask);
-      mDataBlock->onUnmount_callback( this, obj, node );
+      if (mDataBlock)
+         mDataBlock->onUnmount_callback( this, obj, node );
    }
 }
 

--- a/Engine/source/T3D/gameBase/gameBase.h
+++ b/Engine/source/T3D/gameBase/gameBase.h
@@ -237,8 +237,12 @@ public:
    enum GameBaseMasks {      
       DataBlockMask     = Parent::NextFreeMask << 0,
       ExtendedInfoMask  = Parent::NextFreeMask << 1,
+#ifdef TORQUE_AFX_ENABLED
       ScopeIdMask       = Parent::NextFreeMask << 2,
       NextFreeMask      = Parent::NextFreeMask << 3,
+#else
+      NextFreeMask = Parent::NextFreeMask << 2,
+#endif
    };
 
    // net flags added by game base
@@ -467,8 +471,10 @@ private:
    /// within this callback.
    ///   
    void _onDatablockModified();
+#ifdef TORQUE_AFX_ENABLED
 protected:
    void    onScopeIdChange() override { setMaskBits(ScopeIdMask); }
+#endif
 };
 
 

--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -1220,7 +1220,7 @@ void SceneObject::resolveMountPID()
    if ( mMountPID  )
    {
       SceneObject *obj = dynamic_cast< SceneObject* >( mMountPID->getObject() );
-      if ( obj != mMount.object)
+      if (obj && obj != mMount.object)
          obj->mountObject( this, mMount.node, mMount.xfm );
    }
 }
@@ -1678,15 +1678,7 @@ void SceneObject::PerformUpdatesForChildren(MatrixF mat){
 // parent have moved
 void SceneObject::updateChildTransform(){
 	if (getParent() != NULL){
-		MatrixF one;
-		MatrixF two;
-		MatrixF three;
-		MatrixF four;
 		MatrixF mat;
-		one= getTransform();
-		two = getParent()->getTransform();
-		one.affineInverse();
-		four.mul(two,one);
 		mat.mul(getParent()->mLastXform,getTransform());
 		setTransform(mat);
 	}

--- a/Engine/source/sim/netObject.h
+++ b/Engine/source/sim/netObject.h
@@ -410,12 +410,11 @@ public:
    static T* getClientObject( T *netObj ) { return static_cast<T*>( netObj->getClientObject() ); }
 
    /// @}
-protected:
 #ifdef TORQUE_AFX_ENABLED
+protected:
    U16           mScope_id;
    U16           mScope_refs;
    bool          mScope_registered;
-#endif
    virtual void  onScopeIdChange() { }
 public:
    enum { SCOPE_ID_BITS = 14 };
@@ -424,6 +423,7 @@ public:
    void          removeScopeRef();
    void          setScopeRegistered(bool flag) { mScope_registered = flag; }
    bool          getScopeRegistered() const { return mScope_registered; }
+#endif
 
 protected:
    /// Add a networked field

--- a/Engine/source/sim/netObject.h
+++ b/Engine/source/sim/netObject.h
@@ -411,9 +411,11 @@ public:
 
    /// @}
 protected:
+#ifdef TORQUE_AFX_ENABLED
    U16           mScope_id;
    U16           mScope_refs;
    bool          mScope_registered;
+#endif
    virtual void  onScopeIdChange() { }
 public:
    enum { SCOPE_ID_BITS = 14 };


### PR DESCRIPTION
-netobject had methods only used by afx, but not removed when it was shut off. -SceneObject::resolveMountPID() wasn't checking obj prior to obj->mountobject -SceneObject::updateChildTransform() had a bunch of redundant matrix calcs -GameBase::onMount and onUnMount were't making sure mDatablock existed before the ->callbacks