### PR TITLE
fix GuiFrameSetCtrl::rebalance truncation errors

### DIFF
--- a/Engine/source/gui/containers/guiFrameCtrl.cpp
+++ b/Engine/source/gui/containers/guiFrameCtrl.cpp
@@ -973,11 +973,11 @@ void GuiFrameSetCtrl::rebalance(const Point2I &newExtent)
    // look at old width offsets
    for (itr = mColumnOffsets.begin() + 1; itr < mColumnOffsets.end(); itr++)
       // multiply each by new_width/old_width
-      *itr = S32(F32(*itr) * widthScale);
+      *itr = mClamp(S32(F32(*itr) * widthScale + 0.5f), 0, newExtent.x);
    // look at old height offsets
    for (itr = mRowOffsets.begin() + 1; itr < mRowOffsets.end(); itr++)
       // multiply each by new_height/new_width
-      *itr = S32(F32(*itr) * heightScale);
+      *itr = mClamp(S32(F32(*itr) * heightScale + 0.5f), 0, newExtent.y);
 
 }
 

--- a/Templates/BaseGame/game/tools/guiEditor/gui/guiEditor.ed.gui
+++ b/Templates/BaseGame/game/tools/guiEditor/gui/guiEditor.ed.gui
@@ -30,7 +30,6 @@ $guiContent = new GuiControl(GuiEditorGui, EditorGuiGroup) {
       hovertime = "1000";
       columns = "0 631";
       rows = "0";
-      borderWidth = "1";
       border = "0";
       borderEnable = "dynamic";
       borderMovable = "dynamic";
@@ -857,7 +856,6 @@ $guiContent = new GuiControl(GuiEditorGui, EditorGuiGroup) {
                new GuiFrameSetCtrl() {
                   columns = "0";
                   rows = "0 338";
-                  borderWidth = "1";
                   borderColor = "207 207 207 207";
                   borderEnable = "dynamic";
                   borderMovable = "dynamic";
@@ -1131,7 +1129,6 @@ $guiContent = new GuiControl(GuiEditorGui, EditorGuiGroup) {
                new GuiFrameSetCtrl() {
                   columns = "0";
                   rows = "0 338";
-                  borderWidth = "1";
                   borderColor = "207 207 207 207";
                   borderEnable = "dynamic";
                   borderMovable = "dynamic";


### PR DESCRIPTION
this was causing horizontal adjustments to shrink vertical slices. for ease of interface usage, remove borderwidth = 1, so it defaults to the 4 for edge grabbing.