### PR TITLE
Misc Fixes for reported issues

### DIFF
--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -229,7 +229,7 @@ GuiControl::GuiControl() : mAddGroup( NULL ),
    mTooltip = StringTable->EmptyString();
    mRenderTooltipDelegate.bind( this, &GuiControl::defaultTooltipRender );
 
-   mCanSaveFieldDictionary = false;
+   mCanSaveFieldDictionary = true;
    mNotifyChildrenResized = true;
    fade_amt = 1.0f;
 }

--- a/Engine/source/gui/editor/guiInspector.cpp
+++ b/Engine/source/gui/editor/guiInspector.cpp
@@ -804,6 +804,10 @@ void GuiInspector::updateVisibility()
 		{
          if (!group) return;
 
+         //We want dynamic fields group ot always display even if there are no fields under it so you can add new ones
+         if (group->getGroupName() == String("Dynamic Fields"))
+            continue;
+
 			const AbstractClassRep::Field* g = target->findField(group->getGroupName().c_str());
 
 			// if group has its own visibility function let it control it.

--- a/Engine/source/gui/game/guiProgressBitmapCtrl.cpp
+++ b/Engine/source/gui/game/guiProgressBitmapCtrl.cpp
@@ -131,43 +131,8 @@ GuiProgressBitmapCtrl::GuiProgressBitmapCtrl()
 void GuiProgressBitmapCtrl::initPersistFields()
 {
    docsURL;
-   ADD_FIELD("bitmapAsset", TypeImageAssetRef, Offset(mBitmapAssetRef, GuiProgressBitmapCtrl))
-      .doc("Bitmap asset to use for rendering the progress bar.\n\n"
-      "If the profile assigned to the control already has a bitmap assigned, this property need not be "
-      "set in which case the bitmap from the profile is used.");
 
    Parent::initPersistFields();
-}
-
-//-----------------------------------------------------------------------------
-
-void GuiProgressBitmapCtrl::_setBitmap(StringTableEntry _in)
-{
-   if (mBitmapAssetRef.assetId == _in)
-      return;
-
-   if (ImageAsset::isNamedTarget(_in))
-   {
-      mBitmapAssetRef.assetId = _in;
-      mBitmapAssetRef.assetPtr = ImageAsset::getNamedTargetAssetPtr(_in);
-      return;
-   }
-
-   mBitmapAssetRef = _in;
-}
-
-void GuiProgressBitmapCtrl::setBitmap( const char* name )
-{
-   bool awake = mAwake;
-   if( awake )
-      onSleep();
-
-   _setBitmap(StringTable->insert(name));
-
-   if( awake )
-      onWake();
-      
-   setUpdate();
 }
 
 //-----------------------------------------------------------------------------
@@ -215,6 +180,9 @@ void GuiProgressBitmapCtrl::onPreRender()
 
 void GuiProgressBitmapCtrl::onRender(Point2I offset, const RectI &updateRect)
 {	
+   if (mNumberOfBitmaps < 1 || mNumberOfBitmaps == 2)
+      return;
+
 	RectI ctrlRect(offset, getExtent());
 	
 	//grab lowest dimension
@@ -262,8 +230,6 @@ void GuiProgressBitmapCtrl::onRender(Point2I offset, const RectI &updateRect)
 			drawUtil->drawBitmapStretchSR(mProfile->getBitmap(), progressRectRight, mProfile->mBitmapArrayRects[2]);
 		}
 	}
-	else
-		Con::warnf("guiProgressBitmapCtrl only processes an array of bitmaps == 1 or >= 3");
 
 	//if there's a border, draw it
    if (mProfile->mBorder)
@@ -285,21 +251,10 @@ bool GuiProgressBitmapCtrl::onWake()
 
 	mNumberOfBitmaps = mProfile->constructBitmapArray();
 
+   if (mNumberOfBitmaps < 1 || mNumberOfBitmaps == 2)
+   {
+      Con::warnf("guiProgressBitmapCtrl only processes an array of bitmaps == 1 or >= 3");
+   }
+
    return true;
-}
-
-//=============================================================================
-//    Console Methods.
-//=============================================================================
-// MARK: ---- Console Methods ----
-
-//-----------------------------------------------------------------------------
-
-DefineEngineMethod( GuiProgressBitmapCtrl, setBitmap, void, ( const char* filename ),,
-   "Set the bitmap to use for rendering the progress bar.\n\n"
-   "@param filename ~Path to the bitmap file.\n\n"
-   "@note Directly assign to #bitmap rather than using this method.\n\n"
-   "@see GuiProgressBitmapCtrl::setBitmap" )
-{
-   object->setBitmap( filename );
 }

--- a/Engine/source/gui/game/guiProgressBitmapCtrl.h
+++ b/Engine/source/gui/game/guiProgressBitmapCtrl.h
@@ -46,9 +46,6 @@ class GuiProgressBitmapCtrl : public GuiTextCtrl
    protected:
 
       F32 mProgress;
-
-      AssetRef<ImageAsset> mBitmapAssetRef;
-
       bool mUseVariable;
       bool mTile;
       S32 mNumberOfBitmaps;
@@ -57,12 +54,6 @@ class GuiProgressBitmapCtrl : public GuiTextCtrl
    public:
          
       GuiProgressBitmapCtrl();
-
-      void setBitmap( const char* name );
-
-      void _setBitmap(StringTableEntry _in);
-      inline StringTableEntry getBitmapAssetId() const { return mBitmapAssetRef.getAssetId(); }
-      GFXTexHandle getBitmap() { return mBitmapAssetRef.notNull() ? mBitmapAssetRef.assetPtr->getTexture(&GFXDefaultGUIProfile) : NULL; }
       
       //console related methods
       const char *getScriptValue() override;

--- a/Templates/BaseGame/game/core/utility/scripts/helperFunctions.tscript
+++ b/Templates/BaseGame/game/core/utility/scripts/helperFunctions.tscript
@@ -657,16 +657,16 @@ function populateAllFonts()
    for (%i=0;%i<%fontarrayCount;%i++)
    {
       %font = %fontarray.getKey(%i);
-      %hieght =  %fontarray.getValue(%i);
-      schedule(1000*%i,0,"delayedFontsPopulation",%font, %hieght, %i+1);
+      %height =  %fontarray.getValue(%i);
+      schedule(1000*%i,0,"delayedFontsPopulation",%font, %height, %i+1);
    }
    %fontarray.delete();
 }
-function delayedFontsPopulation(%font, %hieght, %fontNum)
+function delayedFontsPopulation(%font, %height, %fontNum)
 {
-    echo("Font ["@ %fontNum @"] Generating "@ %font SPC %hieght);
-    populateFontCacheRange(%font,%hieght,32, 126);
-    populateFontCacheRange(%font,%hieght,160, 65535);
+    echo("Font ["@ %fontNum @"] Generating "@ %font SPC %height);
+    populateFontCacheRange(%font,%height,32, 126);
+    populateFontCacheRange(%font,%height,160, 65535);
 }
 
 //------------------------------------------------------------------------------

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/editAsset.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/editAsset.tscript
@@ -77,17 +77,17 @@ function AssetBrowser::refreshAsset(%this, %assetId)
 //------------------------------------------------------------
 function AssetBrowser::regeneratePreviewImage(%this)
 {
-   %assetDef = AssetDatabase.acquireAsset(AssetBrowser.popupMenu.objectData);
+   %assetDef = AssetDatabase.acquireAsset(%this.popupMenu.objectData);
    %dummyObj = new ScriptObject();
-   %dummyObj.moduleName = AssetDatabase.getAssetModule(AssetBrowser.popupMenu.objectData).moduleId;
-   %dummyObj.assetName = AssetDatabase.getAssetName(AssetBrowser.popupMenu.objectData);
+   %dummyObj.moduleName = %this.getAssetModule(%this.popupMenu.objectData).moduleId;
+   %dummyObj.assetName = %this.getAssetName(%this.popupMenu.objectData);
    
-   %assetType = AssetBrowser.popupMenu.objectType;
+   %assetType = %this.popupMenu.objectType;
    
    AssetBrowser.callAssetTypeFunc(%assetType, "generatePreviewImage", %dummyObj, true);
 
    %dummyObj.delete();
-   AssetDatabase.releaseAsset(AssetBrowser.popupMenu.objectData);
+   AssetDatabase.releaseAsset(%this.popupMenu.objectData);
 }
 
 //------------------------------------------------------------
@@ -447,27 +447,21 @@ function AssetBrowser::updateAssetReference(%this, %targetPath, %oldAssetId, %ne
 
 function AssetBrowser::openFileLocation(%this)
 {
-   if(isFunction("systemCommand"))
-   {
-      warnf("AssetBrowser::openFileLocation() - systemCommand function disabled in this build. Unable to launch application to edit file.");
-      return;  
-   }
-   
    %filePath = "";
-   if(%this.popuMenu.assetId !$= "")
+   if(%this.popupMenu.objectData !$= "")
    {
-      if(AssetDatabase.isDeclaredAsset(%this.popuMenu.objectData))
+      if(AssetDatabase.isDeclaredAsset(%this.popupMenu.objectData))
       {
-         %filePath = AssetDatabase.getAssetPath(%this.popuMenu.objectData);
+         %filePath = AssetDatabase.getAssetPath(%this.popupMenu.objectData);
       }
       else
       {
          //probably a file path
-         %pathSplit = strpos(%this.popuMenu.objectData, ":");
+         %pathSplit = strpos(%this.popupMenu.objectData, ":");
          if(%pathSplit != -1)
          {
-            %path = getSubStr(%this.popuMenu.objectData, 0, %pathSplit);
-            %file = getSubStr(%this.popuMenu.objectData, %pathSplit + 1);
+            %path = getSubStr(%this.popupMenu.objectData, 0, %pathSplit);
+            %file = getSubStr(%this.popupMenu.objectData, %pathSplit + 1);
             
             //datablocks pack the originator file in the parent path as-is, so check that
             if(fileExt(%path) !$= "")
@@ -482,22 +476,9 @@ function AssetBrowser::openFileLocation(%this)
       }
    }
    
-   if(isFile(%filePath) || isDirectory(%filePath))
+   if(%filePath !$= "" && (isFile(%filePath) || isDirectory(%filePath)))
    {
-      %fullPath = makeFullPath(%filePath);
-      if(fileExt(%fullPath) $= ".tscript")
-         %fullPath = filePath(%fullPath);
-         
-      if($platform $= "windows")
-      {
-         %cmd = "cd \"" @ %fullPath @ "\" && start .";
-         systemCommand(%cmd);
-      }
-      else
-      {
-         %cmd = "open \"" @ %fullPath @ "\"";
-         systemCommand(%cmd);
-      }
+      gotoWebPage(makeRelativePath(%filePath));
    }
 }
 

--- a/Templates/BaseGame/game/tools/gui/profiles.ed.tscript
+++ b/Templates/BaseGame/game/tools/gui/profiles.ed.tscript
@@ -34,6 +34,7 @@ $Gui::fontTypeBold = "Arial Bold";
 $Gui::fontTypeItalic = "Arial Italic";
 $Gui::fontTypeMono = "Arial";
 
+$GUI::fontSize[9] = 9;
 $GUI::fontSize[12] = 12;
 $GUI::fontSize[14] = 14;
 $GUI::fontSize[16] = 16;
@@ -1556,7 +1557,7 @@ new GuiControlProfile(ToolsGuiConsoleTinyProfile : ToolsGuiConsoleProfile)
 if(!isObject(ToolsGuiConsoleSmallProfile))
 new GuiControlProfile(ToolsGuiConsoleSmallProfile : ToolsGuiConsoleProfile)
 {
-   fontSize = $GUI::fontSize[10];
+   fontSize = $GUI::fontSize[12];
 };
 if(!isObject(ToolsGuiConsoleMediumProfile))
 new GuiControlProfile(ToolsGuiConsoleMediumProfile : ToolsGuiConsoleProfile)


### PR DESCRIPTION
- Makes it so guiControls default to being able to save dynamic fields by default for more consistent behavior with other SimObject types
- Make us not skip over Dynamic Fields inspector group being visible if we don't already have some fields to list
- Moved the bitmap array formatting warning message for GuiProgressBitmapCtrl to onWake instead of spamming in the render function
- Removed never-been-used local bitmap field in GuiProgressBitmapCtrl
- Fixed a spelling error populateAllFonts
- Updated from an explicit AssetBrowser reference to a %this ref in regeneratePreviewImage
- Fixed handling for openFileLocation command in the AssetBrowser to route through goToWebPage console method, which internally gates inside the project directory for safety purposes anyways, and avoids shell command access needs
- Tweaked font sizes in the tools profiles to avoid some console messages for unknown font sizes