### PR TITLE
Another batch of small misc fixes

### DIFF
--- a/Engine/source/gui/editor/guiInspector.cpp
+++ b/Engine/source/gui/editor/guiInspector.cpp
@@ -798,11 +798,13 @@ void GuiInspector::updateVisibility()
 	{
 
 		SimObject* target = getInspectObject(i);
-		if (!target) return;
+		if (!target) 
+		   return;
 
 		for (GuiInspectorGroup* group : mGroups)
 		{
-         if (!group) return;
+         if (!group) 
+            continue;
 
          //We want dynamic fields group ot always display even if there are no fields under it so you can add new ones
          if (group->getGroupName() == String("Dynamic Fields"))
@@ -815,7 +817,7 @@ void GuiInspector::updateVisibility()
 			if (!group_visible)
 			{
 				group->setVisible(group_visible);
-				return;
+            continue;
 			}
 
 			bool anyVisible = false;
@@ -841,7 +843,8 @@ void GuiInspector::updateVisibility()
 					visible = elem.arrayField->visibilityFn(target, String::ToString(elem.elementIndex));
 
 				elem.rollout->setVisible(visible);
-				if (visible) anyVisible = true;
+				if (visible) 
+				   anyVisible = true;
 			}
 
 			group->setVisible(anyVisible);

--- a/Templates/BaseGame/game/core/sfx/Core_SFX.tscript
+++ b/Templates/BaseGame/game/core/sfx/Core_SFX.tscript
@@ -16,8 +16,5 @@ function Core_SFX::onDestroy(%this)
 
 function Core_SFX::initClient(%this)
 {
-   if($pref::SFX::autoDetect)
-   {
-      AutodetectSound();
-   }
+   sfxStartup();
 }

--- a/Templates/BaseGame/game/core/sfx/scripts/audioOptions.tscript
+++ b/Templates/BaseGame/game/core/sfx/scripts/audioOptions.tscript
@@ -132,10 +132,3 @@ function updateAudioOptionsSettings()
                                              SPC $pref::SFX::device 
                                              SPC $pref::SFX::useHardware );
 }
-
-function AutodetectSound()
-{
-   // Nothing to actually do in here? 
-   // function here for convenience.
-   $pref::SFX::autoDetect = false;
-}

--- a/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
+++ b/Templates/BaseGame/game/data/UI/guis/optionsMenu.tscript
@@ -178,6 +178,12 @@ function OptionsMenuList::checkForUnappliedChanges(%this)
                $optionsChangeRequiresRestart = true;
          }
       }
+      else if(%option.class $= "OptionsListSliderEntry")
+      {
+         %tempValue = getVariable(%option.prefVar @ "_tempVar");
+         if(%tempValue !$= "" && getVariable(%option.prefVar) != %tempValue)
+            %unappliedChanges = true;
+      }
    }
 
    return %unappliedChanges;
@@ -477,19 +483,9 @@ function tryCloseOptionsMenu(%val)
 
    %unappliedVideoChanges = VideoSettingsList.checkForUnappliedChanges();
    %unappliedAudioChanges = AudioSettingsList.checkForUnappliedChanges();
+   %unappliedControlChanges = KBMControlsList.checkForUnappliedChanges();
 
-   //validate audio prefs
-   if($pref::SFX::masterVolume_tempVar !$= "" && $pref::SFX::masterVolume_tempVar != $pref::SFX::masterVolume)
-      %unappliedAudioChanges = true;
-
-   for(%i=1; %i < $AudioChannelCount; %i++)
-   {
-      %tempVolume = getVariable("$pref::SFX::channelVolume" @ %i @ "_tempVar");
-      if(%tempVolume !$= "" && $pref::SFX::channelVolume[ %i ] != %tempVolume)
-         %unappliedAudioChanges = true;
-   }
-
-   if(%unappliedVideoChanges || %unappliedAudioChanges)
+   if(%unappliedVideoChanges || %unappliedAudioChanges || %unappliedControlChanges)
    {
       MessageBoxOKCancel("Discard Changes?", "You have unapplied changes to your settings, do you wish to apply or discard them?",
          "OptionsMenu.applyChangedOptions(); BaseUIBackOut(1);", "BaseUIBackOut(1);",
@@ -510,14 +506,17 @@ function tryApplyOptions(%val)
 
    %unappliedVideoChanges = VideoSettingsList.checkForUnappliedChanges();
    %unappliedAudioChanges = AudioSettingsList.checkForUnappliedChanges();
+   %unappliedControlChanges = KBMControlsList.checkForUnappliedChanges();
 
-   if(%unappliedVideoChanges || %unappliedAudioChanges)
+   if(%unappliedVideoChanges || %unappliedAudioChanges || %unappliedControlChanges)
       OptionsMenu.applyChangedOptions();
 }
 
 function OptionsMenu::applyChangedOptions(%this)
 {
    VideoSettingsList.applyChanges();
+   %this.populateVideoSettings(); //Kick a refresh if we happened to change display mode, so resolutions can be selected(or not)
+    
    AudioSettingsList.applyChanges();
    KBMControlsList.applyChanges();  //Saves settings and binds from GamepadControlsList as well
 
@@ -706,6 +705,7 @@ function addOptionSlider(%optionName, %optionDesc, %prefName, %sliderMin, %slide
       vertSizing = "bottom";
       class = "OptionsListSliderEntry";
       canSave = false;
+      prefVar = %prefName;
 
       new GuiButtonCtrl() {
          profile = GuiMenuButtonProfile;


### PR DESCRIPTION
- Fix GuiInspector::updateVisibility to not needlessly early out of the group loop
- Fix for SFX client startup to properly init
- Fix handling of slider options in the options menu to properly apply it's settings and integrate with the unapplied settings checks
- Improve behavior so when swapping between display modes, applying the display mode change refreshes the resolutions list so you can then change the resolution(mode depending) without needing to leave the options menu and going back first