### PR TITLE
Fixes wrong var used for clearing out subscribers in Event Manager

### DIFF
--- a/Engine/source/util/messaging/eventManager.cpp
+++ b/Engine/source/util/messaging/eventManager.cpp
@@ -95,7 +95,7 @@ bool EventManagerListener::onMessageReceived( StringTableEntry queue, const char
          Con::executef(itter.listener, itter.callback, data);
          itter.callDepth--;
 
-         if (itter.removeFlag && itter.callback == 0)
+         if (itter.removeFlag && itter.callDepth == 0)
          {
             subscribers->erase(i);
             continue;


### PR DESCRIPTION
Changes the var that's checked when we move to clear a subscriber from an event when a message is received.

The old code used callback, but it's a stringTableEntry that's checked against 0/null, but an event should always have a callback anyways, so this check ultimately never did anything.
The problem was that in the event of leaning into event messaging's async handling - like with the spawn setup logic in BaseGame - if you didn't super strictly subscribe->remove, there wasn't any protection of doubling up if the logic went through re-entrancy. 
With the change, we now check the same already-existing removeFlag, but now also check if our callDepth is 0, which means the event being checked isn't dealing with any nesting/holdout calls, so between that and the removeFlag, we contextually know it's safe to clear.
This prevents the above issue by actually cleaning out subscribers that were marked with removeFlag, instead of the erroneous check so they stay forever and can start doubling-up in the script formulation isn't quite correct.