### PR TITLE
aiturret collision crashfix

### DIFF
--- a/Engine/source/T3D/turret/aiTurretShape.cpp
+++ b/Engine/source/T3D/turret/aiTurretShape.cpp
@@ -541,7 +541,7 @@ bool AITurretShape::onNewDataBlock(GameBaseData* dptr, bool reload)
 
    // For states
    mStateAnimThread = 0;
-   if (mDataBlock->isAnimated)
+   if (mDataBlock->isAnimated && mShapeInstance)
    {
       mStateAnimThread = mShapeInstance->addThread();
       mShapeInstance->setTimeScale(mStateAnimThread,0);
@@ -614,7 +614,7 @@ void AITurretShape::setTurretState(U32 newState, bool force)
 
    // Reset cyclic sequences back to the first frame to turn it off
    // (the first key frame should be it's off state).
-   if (mStateAnimThread && mStateAnimThread->getSequence()->isCyclic())
+   if (mShapeInstance && mStateAnimThread && mStateAnimThread->getSequence()->isCyclic())
    {
       mShapeInstance->setPos(mStateAnimThread,0);
       mShapeInstance->setTimeScale(mStateAnimThread,0);
@@ -646,7 +646,7 @@ void AITurretShape::setTurretState(U32 newState, bool force)
    mStateDelayTime = stateData.timeoutValue;
 
    // Play animation
-   if (mStateAnimThread && stateData.sequence != -1) 
+   if (mShapeInstance && mStateAnimThread && stateData.sequence != -1) 
    {
       mShapeInstance->setSequence(mStateAnimThread,stateData.sequence, stateData.direction ? 0.0f : 1.0f);
       F32 timeScale = (stateData.scaleAnimation && stateData.timeoutValue) ?
@@ -871,7 +871,7 @@ void AITurretShape::_trackTarget(F32 dt)
    VectorF toTarget;
    MatrixF mat;
    S32 node = mDataBlock->aimNode;
-   if (node != -1)
+   if (node != -1 && mShapeInstance)
    {
       // Get the current position of our node
       MatrixF* nodeTrans = &mShapeInstance->mNodeTransforms[node];
@@ -1150,7 +1150,7 @@ void AITurretShape::advanceTime(F32 dt)
 
    // Update any state thread
    AITurretShapeData::StateData& stateData = *mState;
-   if (mStateAnimThread && stateData.sequence != -1) 
+   if (mShapeInstance && mStateAnimThread && stateData.sequence != -1) 
    {
       mShapeInstance->advanceTime(dt,mStateAnimThread); 
 

--- a/Engine/source/T3D/turret/turretShape.cpp
+++ b/Engine/source/T3D/turret/turretShape.cpp
@@ -357,21 +357,24 @@ bool TurretShape::onNewDataBlock(GameBaseData* dptr, bool reload)
    if (!mDataBlock || !Parent::onNewDataBlock(dptr, reload))
       return false;
 
-   // Mark these nodes for control by code only (will not animate in a sequence)
-   if (mDataBlock->headingNode != -1)
-      mShapeInstance->setNodeAnimationState(mDataBlock->headingNode, TSShapeInstance::MaskNodeHandsOff);
-   if (mDataBlock->pitchNode != -1)
-      mShapeInstance->setNodeAnimationState(mDataBlock->pitchNode, TSShapeInstance::MaskNodeHandsOff);
-   for (U32 i=0; i<TurretShapeData::NumMirrorDirectionNodes; ++i)
+   if (mShapeInstance)
    {
-      if (mDataBlock->pitchNodes[i] != -1)
+      // Mark these nodes for control by code only (will not animate in a sequence)
+      if (mDataBlock->headingNode != -1)
+         mShapeInstance->setNodeAnimationState(mDataBlock->headingNode, TSShapeInstance::MaskNodeHandsOff);
+      if (mDataBlock->pitchNode != -1)
+         mShapeInstance->setNodeAnimationState(mDataBlock->pitchNode, TSShapeInstance::MaskNodeHandsOff);
+      for (U32 i = 0; i < TurretShapeData::NumMirrorDirectionNodes; ++i)
       {
-         mShapeInstance->setNodeAnimationState(mDataBlock->pitchNodes[i], TSShapeInstance::MaskNodeHandsOff);
-      }
+         if (mDataBlock->pitchNodes[i] != -1)
+         {
+            mShapeInstance->setNodeAnimationState(mDataBlock->pitchNodes[i], TSShapeInstance::MaskNodeHandsOff);
+         }
 
-      if (mDataBlock->headingNodes[i] != -1)
-      {
-         mShapeInstance->setNodeAnimationState(mDataBlock->headingNodes[i], TSShapeInstance::MaskNodeHandsOff);
+         if (mDataBlock->headingNodes[i] != -1)
+         {
+            mShapeInstance->setNodeAnimationState(mDataBlock->headingNodes[i], TSShapeInstance::MaskNodeHandsOff);
+         }
       }
    }
 
@@ -418,7 +421,7 @@ bool TurretShape::onNewDataBlock(GameBaseData* dptr, bool reload)
    mRecoilThread = 0;
    if (isGhost())
       for (U32 s = 0; s < TurretShapeData::NumRecoilSequences; s++)
-         if (mDataBlock->recoilSequence[s] != -1) {
+         if (mShapeInstance && mDataBlock->recoilSequence[s] != -1) {
             mRecoilThread = mShapeInstance->addThread();
             mShapeInstance->setSequence(mRecoilThread, mDataBlock->recoilSequence[s], 0);
             mShapeInstance->setTimeScale(mRecoilThread, 0);
@@ -434,17 +437,20 @@ bool TurretShape::onNewDataBlock(GameBaseData* dptr, bool reload)
    mHeadingThread = 0;
    if (isGhost())
    {
-      if (mDataBlock->pitchSequence != -1)
+      if (mShapeInstance)
       {
-         mPitchThread = mShapeInstance->addThread();
-         mShapeInstance->setSequence(mPitchThread, mDataBlock->pitchSequence, 0);
-         mShapeInstance->setTimeScale(mPitchThread, 0);
-      }
-      if (mDataBlock->headingSequence != -1)
-      {
-         mHeadingThread = mShapeInstance->addThread();
-         mShapeInstance->setSequence(mHeadingThread, mDataBlock->headingSequence, 0);
-         mShapeInstance->setTimeScale(mHeadingThread, 0);
+         if (mDataBlock->pitchSequence != -1)
+         {
+            mPitchThread = mShapeInstance->addThread();
+            mShapeInstance->setSequence(mPitchThread, mDataBlock->pitchSequence, 0);
+            mShapeInstance->setTimeScale(mPitchThread, 0);
+         }
+         if (mDataBlock->headingSequence != -1)
+         {
+            mHeadingThread = mShapeInstance->addThread();
+            mShapeInstance->setSequence(mHeadingThread, mDataBlock->headingSequence, 0);
+            mShapeInstance->setTimeScale(mHeadingThread, 0);
+         }
       }
    }
 
@@ -460,6 +466,9 @@ bool TurretShape::onNewDataBlock(GameBaseData* dptr, bool reload)
 
 void TurretShape::updateAnimation(F32 dt)
 {
+   if (!mShapeInstance)
+      return;
+
    if (mRecoilThread)
       mShapeInstance->advanceTime(dt,mRecoilThread);
    if (mImageStateThread)
@@ -537,6 +546,8 @@ void TurretShape::onImageStateAnimation(U32 imageSlot, const char* seqName, bool
 {
    if (isGhost())
    {
+      if (!mShapeInstance)
+         return;
       S32 seqIndex = mShapeInstance->getShape()->findSequence(seqName);
 
       if (seqIndex != -1)
@@ -571,7 +582,7 @@ void TurretShape::updateDamageLevel()
 {
    if (!isGhost())
       setDamageState((mDamage >= mDataBlock->maxDamage)? Destroyed: Enabled);
-   if (mDamageThread)
+   if (mShapeInstance && mDamageThread)
       mShapeInstance->setPos(mDamageThread, mDamage / mDataBlock->destroyedLevel);
 }
 
@@ -772,7 +783,7 @@ void TurretShape::updateMove(const Move* move)
 
 bool TurretShape::getNodeTransform(S32 node, MatrixF& mat)
 {
-   if (node == -1)
+   if (node == -1 || !mShapeInstance)
       return false;
 
    MatrixF nodeTransform = mShapeInstance->mNodeTransforms[node];
@@ -802,13 +813,17 @@ void TurretShape::_setRotation(const Point3F& rot)
 {
    _updateNodes(rot);
 
-   mShapeInstance->animate();
+   if (mShapeInstance)
+      mShapeInstance->animate();
 
    mRot = rot;
 }
 
 void TurretShape::_updateNodes(const Point3F& rot)
 {
+   if (!mShapeInstance)
+      return;
+
    EulerF xRot(rot.x, 0.0f, 0.0f);
    EulerF zRot(0.0f, 0.0f, rot.z);
 
@@ -1148,7 +1163,7 @@ void TurretShape::unpackUpdate(NetConnection *connection, BitStream *stream)
 void TurretShape::getWeaponMountTransform( S32 index, const MatrixF &xfm, MatrixF *outMat )
 {
    // Returns mount point to world space transform
-   if ( index >= 0 && index < ShapeBase::MaxMountedImages) {
+   if (mShapeInstance && index >= 0 && index < ShapeBase::MaxMountedImages) {
       S32 ni = mDataBlock->weaponMountNode[index];
       if (ni != -1) {
          MatrixF mountTransform = mShapeInstance->mNodeTransforms[ni];

--- a/Engine/source/T3D/turret/turretShape.h
+++ b/Engine/source/T3D/turret/turretShape.h
@@ -188,7 +188,7 @@ public:
    virtual bool getAllowManualFire() { return allowManualFire; }
    virtual void setAllowManualFire(bool allow) { setMaskBits(TurretUpdateMask); allowManualFire = allow; }
 
-   virtual void updateMove(const Move* move);
+   void updateMove(const Move* move);
 
    bool getNodeTransform(S32 node, MatrixF& mat);
    bool getWorldNodeTransform(S32 node, MatrixF& mat);


### PR DESCRIPTION
-don't tag a method as virtual if you're not going to have overrides for all subclasses.