### PR TITLE
make sure connection events stay unique

### DIFF
--- a/Templates/BaseGame/game/core/clientServer/scripts/server/connectionToClient.tscript
+++ b/Templates/BaseGame/game/core/clientServer/scripts/server/connectionToClient.tscript
@@ -101,7 +101,7 @@ function GameConnection::GetEventManager(%this)
 {
    if( !isObject( %this.eventManager ) )
       %this.eventManager = new EventManager() { 
-         queue = "GameConnectionEventManager";
+         queue = "GameConnectionEventManager" @ %this;
       };
       
    return %this.eventManager;


### PR DESCRIPTION
from juicy bruce https://discord.com/channels/358091480004558848/783127087820439582/1541426629769830461

GameConnection::GetEventManager - queue entries were generating crosstalk events. %this ensures each connectin uses it's own keyed value